### PR TITLE
chore(www) add continuous deployment

### DIFF
--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -1,0 +1,17 @@
+# See https://fly.io/docs/launch/continuous-deployment-with-github-actions/
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main # continuous deployment on merge to main
+jobs:
+  deploy:
+    name: Deploy www
+    runs-on: ubuntu-latest
+    concurrency: deploy-group # optional: ensure only one action runs at a time
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only --config apps/www/fly.toml --dockerfile apps/www/Dockerfile
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Add `.github/workflows/fly.yaml` for continuous deployment with GitHub Actions. Deploy to Fly.io automatically on push to `main` branch.

See https://fly.io/docs/launch/continuous-deployment-with-github-actions/