### PR TITLE
chore(workspace) run lint in CI; de-lint

### DIFF
--- a/.github/workflows/_lint.yaml
+++ b/.github/workflows/_lint.yaml
@@ -1,0 +1,32 @@
+name: Lint
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: Lint Code
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run lint
+        run: pnpm lint

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,8 +5,12 @@ on:
     branches:
       - main # continuous deployment on merge to main
 jobs:
+  lint:
+    uses: ./.github/workflows/_lint.yaml
+
   deploy:
     name: Deploy www
+    needs: lint
     runs-on: ubuntu-latest
     concurrency: deploy-group # optional: ensure only one action runs at a time
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,32 @@
+name: Pull Request
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint Code
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run lint
+        run: pnpm lint

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,28 +5,4 @@ on:
 
 jobs:
   lint:
-    name: Lint Code
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-          cache: 'pnpm'
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Run lint
-        run: pnpm lint
+    uses: ./.github/workflows/_lint.yaml

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,12 +1,12 @@
-import globals from "globals";
-import pluginJs from "@eslint/js";
-import tseslint from "typescript-eslint";
-
+import globals from 'globals'
+import pluginJs from '@eslint/js'
+import tseslint from 'typescript-eslint'
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
+  { files: ['**/*.{js,mjs,cjs,ts}'] },
+  { ignores: ['apps/www/{.astro,dist}/**/*'] },
+  { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
-];
+]

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "type": "git",
     "url": "git+https://github.com/jamesarosen/pickmyfruit.git"
   },
+  "engines": {
+    "node": "22.12.0"
+  },
   "packageManager": "pnpm@9.12.0",
   "scripts": {
     "dev": "NODE_ENV=development pnpm --filter www dev",


### PR DESCRIPTION
1. don't lint Astro-generated files
2. add `engines` to `package.json` with Node version
3. add `pull-request` GitHub Actions workflow that installs dependencies and runs `lint`
4. Extract the `lint` job from the `pull-request` workflow into a new reusable `_lint` workflow
5. Rename the `fly` workflow to `main`
6. Call the `_lint` workflow from the `pull-request` and `main` workflows
7. Block `deploy` job on `lint`