### PR TITLE
fix(workspace) use a consistent node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,6 @@
 # require pnpm to use the same node version as the project (match this version in CI/CD config for consistent publishing)
-use-node-version=20.14.0
+# @see https://pnpm.io/npmrc#use-node-version
+use-node-version=22.12.0
 
 # only resolve local deps to local files with symlinks when `workspace:` protocol is used to improve predictability
 link-workspace-packages=false

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/jamesarosen/pickmyfruit.git"
   },
   "engines": {
-    "node": "22.12.0"
+    "node": "^22.12.0"
   },
   "packageManager": "pnpm@9.12.0",
   "scripts": {
@@ -26,6 +26,7 @@
     "ci:test": "CI=true NODE_ENV=test pnpm --recursive run test",
     "ci:build": "NODE_ENV=production pnpm --recursive --stream run build",
     "docker:build": "pnpm -r --if-present --parallel docker:build",
+    "install:node": "pnpm env use --global ^22.12.0",
     "setup": "pnpm run reset && pnpm install",
     "reset": "pnpm dlx rimraf --glob ./**/node_modules",
     "build": "NODE_ENV=production pnpm run --recursive --stream build",
@@ -49,8 +50,7 @@
     "kill:vscode-server": "ps uxa | grep .vscode-server | awk '{print $2}' | xargs kill",
     "kill:vscode-server:force": "ps uxa | grep .vscode-server | awk '{print $2}' | xargs kill -9",
     "clear:node_modules": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
-    "clear:dist": "find . -name 'dist' -type d -prune -exec rm -rf '{}' +",
-    "pnpm:env:node:lts": "pnpm env use --global lts"
+    "clear:dist": "find . -name 'dist' -type d -prune -exec rm -rf '{}' +"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.4",


### PR DESCRIPTION
- change `.npmrc` to instruct pnpm to use node@22.12.0
- remove `pnpm:env:node:compat` script in favor of `install:node`, which installs a version that's compatible with the `engines.node` field in `package.json`

There is still a fair bit of duplication here. There doesn't seem to be a single source of truth for the node version within the JavaScript ecosystem.

See https://pnpm.io/npmrc#use-node-version