### PR TITLE
fix env build in docker

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -1,0 +1,32 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm docker:build

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,3 +6,7 @@ on:
 jobs:
   lint:
     uses: ./.github/workflows/_lint.yaml
+
+  build:
+    uses: ./.github/workflows/_build.yaml
+    needs: lint

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -7,7 +7,9 @@
     "valibot": "1.0.0-beta.9"
   },
   "devDependencies": {
-    "tsx": "^4.19.2"
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "*"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,15 @@ importers:
         specifier: 1.0.0-beta.9
         version: 1.0.0-beta.9(typescript@5.7.2)
     devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.10.2
       tsx:
         specifier: ^4.19.2
         version: 4.19.2
+      typescript:
+        specifier: '*'
+        version: 5.7.2
 
 packages:
 


### PR DESCRIPTION
 * env: add `typescript` as a dev dependency to run `tsc`
 * env: add `@types/node` as a dev dependency to define `process.env`
 * CICD: run `docker:build` job in the pull request workflow to ensure Docker containers build properly before merging