### PR TITLE
feat(www): add color palette

### DIFF
--- a/apps/www/src/components/Layout.astro
+++ b/apps/www/src/components/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import '@/styles/base.css'
+import '@/styles/colors.css'
 
 export interface Props {
 	title: string

--- a/apps/www/src/pages/css-test.astro
+++ b/apps/www/src/pages/css-test.astro
@@ -2,9 +2,9 @@
 import Layout from '@/components/Layout.astro'
 ---
 
-<Layout title="CSS Reset Test">
+<Layout title="CSS Demo">
 	<main>
-		<h1>Pick My Fruit CSS Reset Test Document</h1>
+		<h1>Pick My Fruit CSS Test Document</h1>
 
 		<p>
 			This document exists to test the Pick My Fruit CSS. Eventually, this should
@@ -194,6 +194,14 @@ import Layout from '@/components/Layout.astro'
 		</dialog>
 
 		<button id="open-dialog">Open Dialog (Test backdrop)</button>
+
+		<section>
+			This section uses the default theme. The
+			<code class="text-primary">.text-primary</code>,
+			<code class="text-secondary">.text-secondary</code>, and
+			<code class="text-accent">.text-accent</code> utility classes change text color.
+			It also supports dark mode.
+		</section>
 	</main>
 </Layout>
 <style>
@@ -204,6 +212,12 @@ import Layout from '@/components/Layout.astro'
 		margin: auto;
 		max-inline-size: 90ch;
 		padding: 2rem;
+	}
+
+	.card {
+		border: 1px solid var(--color-border);
+		border-radius: 0.5rem;
+		padding: 1rem;
 	}
 </style>
 <script>

--- a/apps/www/src/styles/base.css
+++ b/apps/www/src/styles/base.css
@@ -34,6 +34,9 @@
 		-webkit-text-size-adjust: none;
 		text-size-adjust: none;
 
+		background-color: var(--color-background);
+		border-color: var(--color-border);
+		color: var(--color-foreground);
 		color-scheme: light dark;
 		font-family: system-ui, sans-serif;
 		font-size: clamp(1rem, 1rem + 0.5vw, 2rem);
@@ -153,9 +156,8 @@
 	/* Ensure consistent anchor styling. Keep the link the same color as the
 	 * surrounding text and use a contrasting color for the underline. */
 	a {
-		--color-highlight: oklch(from currentColor l c h + 120);
-		color: currentColor;
-		text-decoration-color: var(--color-highlight);
+		color: var(--color-secondary);
+		text-decoration-color: currentColor;
 		text-decoration-skip-ink: auto;
 	}
 
@@ -187,7 +189,7 @@
 
 	/* Improve focus visibility for keyboard navigation */
 	:focus-visible {
-		outline: 2px solid currentColor;
+		outline: 2px solid var(--color-accent);
 		outline-offset: 2px;
 	}
 

--- a/apps/www/src/styles/colors.css
+++ b/apps/www/src/styles/colors.css
@@ -1,0 +1,54 @@
+@layer base {
+	:root {
+		/**
+		 * Named colors
+		 */
+		--color-sunset-coral: #ff6b5a;
+		--color-fresh-green: #10b981;
+		--color-golden-light: #d38f0f;
+		--color-morning-cream: #fffcf5;
+		--color-warm-charcoal: #2d2d2a;
+		--color-medium-slate: #6b7280;
+
+		/**
+		 * Semantic colors, base theme
+		 */
+		--color-primary: light-dark(
+			var(--color-sunset-coral),
+			oklch(from var(--color-sunset-coral) 0.65 c h)
+		);
+		--color-secondary: light-dark(
+			var(--color-fresh-green),
+			oklch(from var(--color-fresh-green) calc(l + 0.02) c h)
+		);
+		--color-accent: light-dark(
+			var(--color-golden-light),
+			oklch(from var(--color-golden-light) 0.83 c h)
+		);
+		--color-background: light-dark(
+			var(--color-morning-cream),
+			oklch(from var(--color-warm-charcoal) 0.19 c h)
+		);
+		--color-foreground: light-dark(
+			var(--color-warm-charcoal),
+			var(--color-morning-cream)
+		);
+		--color-quiet: light-dark(
+			var(--color-medium-slate),
+			oklch(from var(--color-medium-slate) 0.75 c h)
+		);
+		--color-border: currentColor;
+	}
+}
+
+@layer utilities {
+	.text-primary {
+		color: var(--color-primary);
+	}
+	.text-secondary {
+		color: var(--color-secondary);
+	}
+	.text-accent {
+		color: var(--color-accent);
+	}
+}


### PR DESCRIPTION
- add named colors: sunset coral, fresh green, golden light, morning cream, warm charcoal, medium slate
- add semantic colors based on the named colors: primary action, secondary action, accent, background, foreground
- add light/dark mode variants for semantic colors
- add utility classes for `.text-primary`, `.text-secondary`, and `.text-accent`
- update css-test.astro to demonstrate the new colors and utility classes