### PR TITLE
feat(inquiries): add gleaner inquiry system with email notifications

### DIFF
--- a/apps/www/.env.example
+++ b/apps/www/.env.example
@@ -2,6 +2,7 @@
 # Required: A secret key for signing sessions and tokens (min 32 characters)
 # Generate with: openssl rand -base64 32
 BETTER_AUTH_SECRET=your-secret-key-here-min-32-chars
+HMAC_SECRET=cr9o174ycv/DZQJOy/EnET48XNQJ4NByeUTvMSo+oVE=
 
 # Optional: Base URL for the app (auto-detected in development)
 # BETTER_AUTH_URL=http://localhost:3000

--- a/apps/www/drizzle/0004_add_inquiries.sql
+++ b/apps/www/drizzle/0004_add_inquiries.sql
@@ -1,0 +1,20 @@
+UPDATE listings SET status = 'unavailable' WHERE status IN ('claimed', 'harvested');
+--> statement-breakpoint
+-- Add soft delete column with index for efficient filtering
+ALTER TABLE listings ADD COLUMN deleted_at integer;
+--> statement-breakpoint
+CREATE INDEX listings_deleted_at_idx ON listings(deleted_at);
+--> statement-breakpoint
+-- Create inquiries table
+CREATE TABLE inquiries (
+	id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	created_at integer DEFAULT (unixepoch()) NOT NULL,
+	listing_id integer NOT NULL REFERENCES listings(id),
+	gleaner_id text NOT NULL REFERENCES user(id),
+	note text,
+	email_sent_at integer
+);
+--> statement-breakpoint
+CREATE INDEX inquiry_listing_id_idx ON inquiries(listing_id);
+--> statement-breakpoint
+CREATE INDEX inquiry_gleaner_id_idx ON inquiries(gleaner_id);

--- a/apps/www/drizzle/meta/_journal.json
+++ b/apps/www/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1739379200000,
 			"tag": "0003_remove_owners",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "6",
+			"when": 1739465600000,
+			"tag": "0004_add_inquiries",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/www/src/api/inquiries.ts
+++ b/apps/www/src/api/inquiries.ts
@@ -1,0 +1,89 @@
+import { createServerFn } from '@tanstack/solid-start'
+import { inquiryFormSchema, ListingStatus } from '@/lib/validation'
+import { errorMiddleware, UserError } from '@/lib/server-error-middleware'
+
+export const submitInquiry = createServerFn({ method: 'POST' })
+	.middleware([errorMiddleware])
+	.inputValidator((data: { listingId: number; note?: string }) =>
+		inquiryFormSchema.parse(data)
+	)
+	.handler(async ({ data: { listingId, note } }) => {
+		const { getRequestHeaders } = await import('@tanstack/solid-start/server')
+		const headers = getRequestHeaders()
+		const { auth } = await import('@/lib/auth')
+		const session = await auth.api.getSession({ headers })
+
+		if (!session?.user) {
+			throw new UserError('AUTH_REQUIRED', 'Authentication required')
+		}
+
+		const {
+			createInquiry,
+			hasRecentInquiry,
+			getListingWithOwner,
+			getUserById,
+			markInquiryEmailSent,
+		} = await import('@/data/queries')
+
+		const result = await getListingWithOwner(listingId)
+		if (!result) {
+			throw new UserError('NOT_FOUND', 'Listing not found')
+		}
+
+		const { listing, owner } = result
+
+		if (
+			listing.status !== ListingStatus.available &&
+			listing.status !== ListingStatus.private
+		) {
+			throw new UserError('NOT_ALLOWED', 'This listing is not accepting inquiries')
+		}
+
+		if (listing.userId === session.user.id) {
+			throw new UserError(
+				'NOT_ALLOWED',
+				'You cannot inquire about your own listing'
+			)
+		}
+
+		const hasRecent = await hasRecentInquiry(session.user.id, listingId)
+		if (hasRecent) {
+			throw new UserError(
+				'RATE_LIMITED',
+				'You have already contacted this owner recently. Please wait 24 hours before trying again.'
+			)
+		}
+
+		const gleaner = await getUserById(session.user.id)
+		if (!gleaner) {
+			throw new UserError('NOT_FOUND', 'User not found')
+		}
+
+		const inquiry = await createInquiry({
+			listingId,
+			gleanerId: session.user.id,
+			note: note || null,
+		})
+
+		const { getRequestBaseUrl } = await import('@/lib/request-url')
+		const baseUrl = getRequestBaseUrl(headers)
+		const { sendInquiryEmail } = await import('@/lib/email-templates')
+		const emailSent = await sendInquiryEmail({
+			ownerName: owner.name,
+			ownerEmail: owner.email,
+			gleanerName: gleaner.name,
+			gleanerEmail: gleaner.email,
+			gleanerNote: note,
+			produceType: listing.type,
+			quantity: listing.quantity,
+			listingNotes: listing.notes,
+			plantId: listing.id,
+			baseUrl,
+		})
+
+		if (emailSent) {
+			await markInquiryEmailSent(inquiry.id)
+		}
+
+		return { inquiryId: inquiry.id, emailSent }
+	})

--- a/apps/www/src/components/InquiryForm.css
+++ b/apps/www/src/components/InquiryForm.css
@@ -1,0 +1,148 @@
+@layer components {
+	.inquiry-form-container {
+		margin-top: 32px;
+		padding-top: 24px;
+		border-top: 1px solid oklch(from var(--color-quiet) l calc(c * 0.2) h);
+	}
+
+	.inquiry-form h3 {
+		font-size: 20px;
+		font-weight: 600;
+		color: var(--color-foreground);
+		margin: 0 0 20px 0;
+	}
+
+	.inquiry-form .form-field {
+		margin-bottom: 16px;
+	}
+
+	.inquiry-form label {
+		display: block;
+		font-size: 14px;
+		font-weight: 500;
+		color: var(--color-foreground);
+		margin-bottom: 6px;
+	}
+
+	.inquiry-form .optional {
+		font-weight: 400;
+		color: var(--color-quiet);
+	}
+
+	.inquiry-form input,
+	.inquiry-form textarea {
+		width: 100%;
+		padding: 12px;
+		border: 1px solid oklch(from var(--color-quiet) l calc(c * 0.3) h);
+		border-radius: 8px;
+		font-size: 16px;
+		font-family: inherit;
+		color: var(--color-foreground);
+		background: var(--color-background);
+		transition: border-color 0.2s;
+	}
+
+	.inquiry-form input:focus,
+	.inquiry-form textarea:focus {
+		outline: none;
+		border-color: var(--color-primary);
+	}
+
+	.inquiry-form input:disabled,
+	.inquiry-form textarea:disabled {
+		background: oklch(from var(--color-quiet) l calc(c * 0.1) h);
+		cursor: not-allowed;
+	}
+
+	.inquiry-form textarea {
+		resize: vertical;
+		min-height: 80px;
+	}
+
+	.inquiry-form .char-count {
+		display: block;
+		text-align: right;
+		font-size: 12px;
+		color: var(--color-quiet);
+		margin-top: 4px;
+	}
+
+	.inquiry-submit {
+		width: 100%;
+		padding: 14px 28px;
+		background: var(--color-primary);
+		color: var(--color-background);
+		border: none;
+		border-radius: 8px;
+		font-size: 16px;
+		font-weight: 600;
+		cursor: pointer;
+		transition: background-color 0.2s;
+	}
+
+	.inquiry-submit:hover:not(:disabled) {
+		background: oklch(from var(--color-primary) calc(l - 0.08) c h);
+	}
+
+	.inquiry-submit:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.inquiry-error {
+		padding: 12px;
+		background: oklch(from var(--color-primary) l c h / 0.1);
+		color: var(--color-primary);
+		border-radius: 8px;
+		font-size: 14px;
+		margin-bottom: 16px;
+	}
+
+	.inquiry-success,
+	.inquiry-rate-limited {
+		padding: 24px;
+		border-radius: 12px;
+		text-align: center;
+	}
+
+	.inquiry-success {
+		background: oklch(from var(--color-secondary) l c h / 0.1);
+	}
+
+	.inquiry-success h3 {
+		color: var(--color-secondary);
+		font-size: 20px;
+		font-weight: 600;
+		margin: 0 0 8px 0;
+	}
+
+	.inquiry-success p {
+		color: var(--color-foreground);
+		margin: 0;
+	}
+
+	.inquiry-success .email-warning {
+		margin-top: 16px;
+		padding: 12px;
+		background: oklch(from var(--color-accent) l c h / 0.1);
+		color: var(--color-accent);
+		border-radius: 8px;
+		font-size: 14px;
+	}
+
+	.inquiry-rate-limited {
+		background: oklch(from var(--color-accent) l c h / 0.1);
+	}
+
+	.inquiry-rate-limited h3 {
+		color: var(--color-accent);
+		font-size: 20px;
+		font-weight: 600;
+		margin: 0 0 8px 0;
+	}
+
+	.inquiry-rate-limited p {
+		color: var(--color-foreground);
+		margin: 0;
+	}
+}

--- a/apps/www/src/components/InquiryForm.tsx
+++ b/apps/www/src/components/InquiryForm.tsx
@@ -1,0 +1,219 @@
+import { createEffect, createSignal, on, Show } from 'solid-js'
+import { authClient, useSession } from '@/lib/auth-client'
+import { submitInquiry as submitInquiryFn } from '@/api/inquiries'
+import MagicLinkWaiting from '@/components/MagicLinkWaiting'
+import '@/components/InquiryForm.css'
+
+interface InquiryFormProps {
+	listingId: number
+	callbackURL: string
+}
+
+type FormState =
+	| 'initial'
+	| 'awaiting-magic-link'
+	| 'submitting'
+	| 'success'
+	| 'rate-limited'
+	| 'error'
+
+const PENDING_INQUIRY_KEY = 'pendingInquiry'
+
+export default function InquiryForm(props: InquiryFormProps) {
+	const session = useSession()
+	const [formState, setFormState] = createSignal<FormState>('initial')
+	const [email, setEmail] = createSignal('')
+	const [note, setNote] = createSignal('')
+	const [error, setError] = createSignal<string | null>(null)
+	const [emailSent, setEmailSent] = createSignal(true)
+
+	const isAuthenticated = () => Boolean(session().data?.user)
+
+	async function submitInquiry() {
+		setFormState('submitting')
+		setError(null)
+
+		try {
+			const result = await submitInquiryFn({
+				data: {
+					listingId: props.listingId,
+					note: note() || undefined,
+				},
+			})
+
+			setEmailSent(result.emailSent)
+			setFormState('success')
+			sessionStorage.removeItem(PENDING_INQUIRY_KEY)
+		} catch (err) {
+			const message =
+				err instanceof Error ? err.message : 'Failed to submit inquiry'
+			if (message.includes('already contacted') || message.includes('24 hours')) {
+				setFormState('rate-limited')
+				return
+			}
+			setError(message)
+			setFormState('error')
+		}
+	}
+
+	async function handleSubmit(e: SubmitEvent) {
+		e.preventDefault()
+
+		if (isAuthenticated()) {
+			await submitInquiry()
+		} else {
+			// Store pending inquiry data
+			sessionStorage.setItem(
+				PENDING_INQUIRY_KEY,
+				JSON.stringify({
+					listingId: props.listingId,
+					note: note(),
+				})
+			)
+
+			// Trigger magic link flow
+			const emailValue = email().trim()
+			if (!emailValue) {
+				setError('Email is required')
+				return
+			}
+
+			setFormState('awaiting-magic-link')
+			await authClient.signIn.magicLink({
+				email: emailValue,
+				callbackURL: `${props.callbackURL}?inquiry_complete=true`,
+			})
+		}
+	}
+
+	function handleMagicLinkCancel() {
+		setFormState('initial')
+		sessionStorage.removeItem(PENDING_INQUIRY_KEY)
+	}
+
+	async function handleMagicLinkVerified() {
+		// Auto-submit the stored inquiry
+		await submitInquiry()
+	}
+
+	// Auto-submit pending inquiry when returning from magic link authentication
+	let hasAutoSubmitted = false
+	createEffect(
+		on(
+			() => session().data?.user,
+			(user) => {
+				if (!user || hasAutoSubmitted || typeof window === 'undefined') return
+
+				const urlParams = new URLSearchParams(window.location.search)
+				if (urlParams.get('inquiry_complete') !== 'true') return
+
+				const pending = sessionStorage.getItem(PENDING_INQUIRY_KEY)
+				if (!pending) return
+
+				let storedNote: string
+				try {
+					const parsed = JSON.parse(pending)
+					storedNote = parsed.note || ''
+				} catch {
+					sessionStorage.removeItem(PENDING_INQUIRY_KEY)
+					return
+				}
+
+				hasAutoSubmitted = true
+				setNote(storedNote)
+				submitInquiry()
+			}
+		)
+	)
+
+	return (
+		<div class="inquiry-form-container">
+			<Show when={formState() === 'awaiting-magic-link'}>
+				<MagicLinkWaiting
+					email={email()}
+					callbackURL={`${props.callbackURL}?inquiry_complete=true`}
+					onCancel={handleMagicLinkCancel}
+					onVerified={handleMagicLinkVerified}
+				/>
+			</Show>
+
+			<Show when={formState() === 'success'}>
+				<div class="inquiry-success">
+					<h3>Request sent!</h3>
+					<p>The owner has been notified and will reach out to you soon.</p>
+					<Show when={!emailSent()}>
+						<p class="email-warning">
+							Note: There was an issue sending the email, but your request was
+							recorded. The owner will see it when they check their listings.
+						</p>
+					</Show>
+				</div>
+			</Show>
+
+			<Show when={formState() === 'rate-limited'}>
+				<div class="inquiry-rate-limited">
+					<h3>Already contacted</h3>
+					<p>
+						You've already reached out to this owner recently. Please wait 24 hours
+						before trying again.
+					</p>
+				</div>
+			</Show>
+
+			<Show
+				when={
+					formState() === 'initial' ||
+					formState() === 'submitting' ||
+					formState() === 'error'
+				}
+			>
+				<form class="inquiry-form" onSubmit={handleSubmit}>
+					<h3>Interested in this fruit?</h3>
+
+					<Show when={!isAuthenticated()}>
+						<div class="form-field">
+							<label for="inquiry-email">Your email</label>
+							<input
+								type="email"
+								id="inquiry-email"
+								value={email()}
+								onInput={(e) => setEmail(e.currentTarget.value)}
+								placeholder="you@example.com"
+								required
+								disabled={formState() === 'submitting'}
+							/>
+						</div>
+					</Show>
+
+					<div class="form-field">
+						<label for="inquiry-note">
+							Message to owner <span class="optional">(optional)</span>
+						</label>
+						<textarea
+							id="inquiry-note"
+							value={note()}
+							onInput={(e) => setNote(e.currentTarget.value)}
+							placeholder="Hi! I'd love to pick some of your fruit..."
+							maxLength={500}
+							rows={3}
+							disabled={formState() === 'submitting'}
+						/>
+						<span class="char-count">{note().length}/500</span>
+					</div>
+
+					<Show when={error()}>
+						<div class="inquiry-error">{error()}</div>
+					</Show>
+
+					<button
+						type="submit"
+						class="inquiry-submit"
+						disabled={formState() === 'submitting'}
+					>
+						{formState() === 'submitting' ? 'Sending...' : 'Put me in touch'}
+					</button>
+				</form>
+			</Show>
+		</div>
+	)
+}

--- a/apps/www/src/components/ListingForm.css
+++ b/apps/www/src/components/ListingForm.css
@@ -164,42 +164,6 @@
 		border: 1px solid oklch(from var(--color-secondary) l c h / 0.3);
 	}
 
-	.success-content {
-		text-align: center;
-		padding: 40px 20px;
-	}
-
-	.success-content h2 {
-		font-size: 28px;
-		font-weight: 700;
-		color: var(--color-secondary);
-		margin: 0 0 16px 0;
-	}
-
-	.success-content p {
-		font-size: 16px;
-		color: var(--color-quiet);
-		margin: 0 0 24px 0;
-	}
-
-	.success-content .back-button {
-		display: inline-block;
-		background: var(--color-secondary);
-		color: var(--color-background);
-		padding: 14px 28px;
-		border-radius: 8px;
-		border: none;
-		font-weight: 600;
-		font-size: 16px;
-		text-decoration: none;
-		cursor: pointer;
-		transition: background-color 0.2s;
-	}
-
-	.success-content .back-button:hover {
-		background: oklch(from var(--color-secondary) calc(l - 0.08) c h);
-	}
-
 	/* Readonly input styling */
 	.form-group input[readonly] {
 		background: oklch(from var(--color-quiet) l c h / 0.1);

--- a/apps/www/src/data/queries.ts
+++ b/apps/www/src/data/queries.ts
@@ -1,6 +1,14 @@
 import { db } from './db'
-import { listings, type Listing, type NewListing } from './schema'
-import { eq, desc, and, ne } from 'drizzle-orm'
+import {
+	listings,
+	inquiries,
+	user,
+	type Listing,
+	type NewListing,
+	type Inquiry,
+	type NewInquiry,
+} from './schema'
+import { eq, desc, and, ne, isNull, gt } from 'drizzle-orm'
 import { ListingStatus, type ListingStatusValue } from '@/lib/validation'
 
 export async function getAvailableListings(
@@ -23,7 +31,7 @@ export async function getUserListings(userId: string): Promise<Listing[]> {
 	return await db
 		.select()
 		.from(listings)
-		.where(eq(listings.userId, userId))
+		.where(and(eq(listings.userId, userId), isNull(listings.deletedAt)))
 		.orderBy(desc(listings.createdAt))
 }
 
@@ -37,7 +45,10 @@ export async function getListingById(id: number): Promise<Listing | undefined> {
 }
 
 /** Public listing fields safe to expose to any visitor. */
-export type PublicListing = Omit<Listing, 'address' | 'accessInstructions'>
+export type PublicListing = Omit<
+	Listing,
+	'address' | 'accessInstructions' | 'deletedAt'
+>
 
 /** Fetches a listing by ID, returning only public-safe fields. Excludes private listings. */
 export async function getPublicListingById(
@@ -81,6 +92,82 @@ export async function deleteListingById(
 	return result.length > 0
 }
 
+// ============================================================================
+// Inquiry Functions
+// ============================================================================
+
+export async function createInquiry(data: NewInquiry): Promise<Inquiry> {
+	const result = await db.insert(inquiries).values(data).returning()
+	return result[0]
+}
+
+export async function markInquiryEmailSent(id: number): Promise<void> {
+	await db
+		.update(inquiries)
+		.set({ emailSentAt: new Date() })
+		.where(eq(inquiries.id, id))
+}
+
+export async function hasRecentInquiry(
+	gleanerId: string,
+	listingId: number
+): Promise<boolean> {
+	const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
+	const result = await db
+		.select({ id: inquiries.id })
+		.from(inquiries)
+		.where(
+			and(
+				eq(inquiries.gleanerId, gleanerId),
+				eq(inquiries.listingId, listingId),
+				gt(inquiries.createdAt, twentyFourHoursAgo)
+			)
+		)
+		.limit(1)
+	return result.length > 0
+}
+
+export async function getListingWithOwner(id: number): Promise<
+	| {
+			listing: Listing
+			owner: { id: string; name: string; email: string }
+	  }
+	| undefined
+> {
+	const result = await db
+		.select({
+			listing: listings,
+			owner: {
+				id: user.id,
+				name: user.name,
+				email: user.email,
+			},
+		})
+		.from(listings)
+		.innerJoin(user, eq(listings.userId, user.id))
+		.where(and(eq(listings.id, id), isNull(listings.deletedAt)))
+		.limit(1)
+
+	return result[0]
+}
+
+export async function getListingForInquiry(
+	id: number
+): Promise<Listing | undefined> {
+	const result = await db
+		.select()
+		.from(listings)
+		.where(
+			and(
+				eq(listings.id, id),
+				isNull(listings.deletedAt)
+				// Status validation (available or private) done at API layer
+			)
+		)
+		.limit(1)
+	return result[0]
+}
+
 /** Updates a listing's status, scoped to the owning user. */
 export async function updateListingStatus(
 	id: number,
@@ -91,6 +178,27 @@ export async function updateListingStatus(
 		.update(listings)
 		.set({ status, updatedAt: new Date() })
 		.where(and(eq(listings.id, id), eq(listings.userId, userId)))
+		.returning({ id: listings.id })
+	return result.length > 0
+}
+
+export async function getUserById(
+	id: string
+): Promise<{ name: string; email: string } | undefined> {
+	const result = await db
+		.select({ name: user.name, email: user.email })
+		.from(user)
+		.where(eq(user.id, id))
+		.limit(1)
+	return result[0]
+}
+
+/** Mark a listing as unavailable (used by HMAC-signed one-click URL). */
+export async function markListingUnavailable(id: number): Promise<boolean> {
+	const result = await db
+		.update(listings)
+		.set({ status: ListingStatus.unavailable, updatedAt: new Date() })
+		.where(and(eq(listings.id, id), isNull(listings.deletedAt)))
 		.returning({ id: listings.id })
 	return result.length > 0
 }

--- a/apps/www/src/data/schema.ts
+++ b/apps/www/src/data/schema.ts
@@ -131,6 +131,7 @@ export const listings = sqliteTable(
 		// Metadata
 		notes: text('notes'),
 		accessInstructions: text('access_instructions'), // e.g., 'Ring doorbell', 'Gate code 1234'
+		deletedAt: integer('deleted_at', { mode: 'timestamp' }), // soft delete
 		createdAt: integer('created_at', { mode: 'timestamp' })
 			.notNull()
 			.default(sql`(unixepoch())`),
@@ -143,3 +144,32 @@ export const listings = sqliteTable(
 
 export type Listing = typeof listings.$inferSelect
 export type NewListing = typeof listings.$inferInsert
+
+// ============================================================================
+// Inquiries Table
+// ============================================================================
+
+export const inquiries = sqliteTable(
+	'inquiries',
+	{
+		id: integer('id').primaryKey({ autoIncrement: true }),
+		createdAt: integer('created_at', { mode: 'timestamp' })
+			.notNull()
+			.default(sql`(unixepoch())`),
+		listingId: integer('listing_id')
+			.notNull()
+			.references(() => listings.id),
+		gleanerId: text('gleaner_id')
+			.notNull()
+			.references(() => user.id),
+		note: text('note'), // max 500 chars, validated at API layer
+		emailSentAt: integer('email_sent_at', { mode: 'timestamp' }),
+	},
+	(table) => [
+		index('inquiry_listing_id_idx').on(table.listingId),
+		index('inquiry_gleaner_id_idx').on(table.gleanerId),
+	]
+)
+
+export type Inquiry = typeof inquiries.$inferSelect
+export type NewInquiry = typeof inquiries.$inferInsert

--- a/apps/www/src/lib/email-templates.ts
+++ b/apps/www/src/lib/email-templates.ts
@@ -1,0 +1,120 @@
+import { buildUnavailableUrl } from './hmac'
+
+interface InquiryEmailData {
+	ownerName: string
+	ownerEmail: string
+	gleanerName: string
+	gleanerEmail: string
+	gleanerNote?: string | null
+	produceType: string
+	quantity?: string | null
+	listingNotes?: string | null
+	plantId: number
+	baseUrl: string
+}
+
+export function buildInquiryEmailSubject(data: InquiryEmailData): string {
+	return `${data.gleanerName} wants your ${data.produceType}`
+}
+
+export function buildInquiryEmailHtml(data: InquiryEmailData): string {
+	const unavailableUrl = buildUnavailableUrl(data.baseUrl, data.plantId)
+
+	const quantitySection = data.quantity
+		? `<p style="margin: 0 0 8px 0;"><strong>Quantity:</strong> ${escapeHtml(data.quantity)}</p>`
+		: ''
+
+	const notesSection = data.listingNotes
+		? `<p style="margin: 0;"><strong>Your notes:</strong> ${escapeHtml(data.listingNotes)}</p>`
+		: ''
+
+	const gleanerNoteSection = data.gleanerNote
+		? `
+  <div style="background: #fef3c7; border-radius: 8px; padding: 16px; margin: 24px 0;">
+    <h3 style="margin: 0 0 8px 0; color: #92400e;">Message from ${escapeHtml(data.gleanerName)}</h3>
+    <p style="margin: 0;">${escapeHtml(data.gleanerNote)}</p>
+  </div>
+  `
+		: ''
+
+	return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h1 style="color: #2d5016; margin-bottom: 24px;">Someone wants your ${escapeHtml(data.produceType)}!</h1>
+
+  <p>Hi ${escapeHtml(data.ownerName)},</p>
+
+  <p><strong>${escapeHtml(data.gleanerName)}</strong> is interested in your ${escapeHtml(data.produceType)}.</p>
+
+  <div style="background: #f9fafb; border-radius: 8px; padding: 16px; margin: 24px 0;">
+    <h3 style="margin: 0 0 12px 0; color: #2d5016;">Listing Details</h3>
+    <p style="margin: 0 0 8px 0;"><strong>Type:</strong> ${escapeHtml(data.produceType)}</p>
+    ${quantitySection}
+    ${notesSection}
+  </div>
+
+  ${gleanerNoteSection}
+
+  <p>Simply <strong>reply to this email</strong> to get in touch with ${escapeHtml(data.gleanerName)}.</p>
+
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 32px 0;">
+
+  <p style="color: #666; font-size: 14px;">
+    All done with this listing?
+    <a href="${unavailableUrl}" style="color: #4a7c23;">Mark as unavailable</a>
+  </p>
+</body>
+</html>`
+}
+
+function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#039;')
+}
+
+export async function sendInquiryEmail(
+	data: InquiryEmailData
+): Promise<boolean> {
+	const resendApiKey = process.env.RESEND_API_KEY
+
+	if (!resendApiKey) {
+		// Development mode: log to console
+		console.log('\n========================================')
+		console.log('INQUIRY EMAIL (dev mode - no RESEND_API_KEY)')
+		console.log('========================================')
+		console.log(`To: ${data.ownerEmail}`)
+		console.log(`Reply-To: ${data.gleanerEmail}`)
+		console.log(`Subject: ${buildInquiryEmailSubject(data)}`)
+		console.log('----------------------------------------')
+		console.log(buildInquiryEmailHtml(data))
+		console.log('========================================\n')
+		return true
+	}
+
+	try {
+		const { Resend } = await import('resend')
+		const resend = new Resend(resendApiKey)
+
+		await resend.emails.send({
+			from:
+				process.env.EMAIL_FROM || 'Pick My Fruit <notifications@pickmyfruit.com>',
+			to: data.ownerEmail,
+			replyTo: data.gleanerEmail,
+			subject: buildInquiryEmailSubject(data),
+			html: buildInquiryEmailHtml(data),
+		})
+
+		return true
+	} catch (error) {
+		console.error('Failed to send inquiry email:', error)
+		return false
+	}
+}

--- a/apps/www/src/lib/hmac.ts
+++ b/apps/www/src/lib/hmac.ts
@@ -1,0 +1,34 @@
+import { createHmac, timingSafeEqual, randomUUID } from 'crypto'
+
+const HMAC_SECRET = process.env.HMAC_SECRET || 'dev-secret-change-in-prod'
+
+export function signUrl(listingId: number): { nonce: string; sig: string } {
+	const nonce = randomUUID()
+	const message = `${listingId}:${nonce}`
+	const sig = createHmac('sha256', HMAC_SECRET).update(message).digest('hex')
+	return { nonce, sig }
+}
+
+export function verifySignature(
+	listingId: number,
+	nonce: string,
+	sig: string
+): boolean {
+	const message = `${listingId}:${nonce}`
+	const expected = createHmac('sha256', HMAC_SECRET)
+		.update(message)
+		.digest('hex')
+	// Timing-safe comparison
+	if (sig.length !== expected.length) {
+		return false
+	}
+	return timingSafeEqual(Buffer.from(sig), Buffer.from(expected))
+}
+
+export function buildUnavailableUrl(
+	baseUrl: string,
+	listingId: number
+): string {
+	const { nonce, sig } = signUrl(listingId)
+	return `${baseUrl}/api/listings/${listingId}/unavailable?nonce=${nonce}&sig=${sig}`
+}

--- a/apps/www/src/lib/request-url.ts
+++ b/apps/www/src/lib/request-url.ts
@@ -1,0 +1,10 @@
+/**
+ * Derive the base URL (scheme + host) from request headers.
+ * Works behind reverse proxies (Fly.io) that set X-Forwarded-* headers.
+ */
+export function getRequestBaseUrl(headers: Headers): string {
+	const proto = headers.get('x-forwarded-proto') || 'http'
+	const host =
+		headers.get('x-forwarded-host') || headers.get('host') || 'localhost'
+	return `${proto}://${host}`
+}

--- a/apps/www/src/lib/validation.ts
+++ b/apps/www/src/lib/validation.ts
@@ -67,6 +67,20 @@ export const createListingSchema = listingFormSchema.extend({
 
 export type CreateListingData = z.infer<typeof createListingSchema>
 
+// ============================================================================
+// Inquiry Schemas
+// ============================================================================
+
+export const inquiryFormSchema = z.object({
+	listingId: z.number().int().positive('Invalid listing'),
+	note: z.preprocess(
+		(val) => (val === '' || val === null ? undefined : val),
+		z.string().max(500, 'Note must be 500 characters or less').optional()
+	),
+})
+
+export type InquiryFormData = z.infer<typeof inquiryFormSchema>
+
 export const ListingStatus = {
 	available: 'available',
 	unavailable: 'unavailable',

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -16,9 +16,11 @@ import { Route as ListingsNewRouteImport } from './routes/listings/new'
 import { Route as ListingsMineRouteImport } from './routes/listings/mine'
 import { Route as ListingsIdRouteImport } from './routes/listings.$id'
 import { Route as ApiListingsRouteImport } from './routes/api/listings'
+import { Route as ApiInquiriesRouteImport } from './routes/api/inquiries'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
 import { Route as ApiListingsIdRouteImport } from './routes/api/listings.$id'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
+import { Route as ApiListingsIdUnavailableRouteImport } from './routes/api/listings.$id.unavailable'
 
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
@@ -55,6 +57,11 @@ const ApiListingsRoute = ApiListingsRouteImport.update({
   path: '/api/listings',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiInquiriesRoute = ApiInquiriesRouteImport.update({
+  id: '/api/inquiries',
+  path: '/api/inquiries',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiHealthRoute = ApiHealthRouteImport.update({
   id: '/api/health',
   path: '/api/health',
@@ -70,30 +77,40 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   path: '/api/auth/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiListingsIdUnavailableRoute =
+  ApiListingsIdUnavailableRouteImport.update({
+    id: '/unavailable',
+    path: '/unavailable',
+    getParentRoute: () => ApiListingsIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/css-test': typeof CssTestRoute
   '/login': typeof LoginRoute
   '/api/health': typeof ApiHealthRoute
+  '/api/inquiries': typeof ApiInquiriesRoute
   '/api/listings': typeof ApiListingsRouteWithChildren
   '/listings/$id': typeof ListingsIdRoute
   '/listings/mine': typeof ListingsMineRoute
   '/listings/new': typeof ListingsNewRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
-  '/api/listings/$id': typeof ApiListingsIdRoute
+  '/api/listings/$id': typeof ApiListingsIdRouteWithChildren
+  '/api/listings/$id/unavailable': typeof ApiListingsIdUnavailableRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/css-test': typeof CssTestRoute
   '/login': typeof LoginRoute
   '/api/health': typeof ApiHealthRoute
+  '/api/inquiries': typeof ApiInquiriesRoute
   '/api/listings': typeof ApiListingsRouteWithChildren
   '/listings/$id': typeof ListingsIdRoute
   '/listings/mine': typeof ListingsMineRoute
   '/listings/new': typeof ListingsNewRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
-  '/api/listings/$id': typeof ApiListingsIdRoute
+  '/api/listings/$id': typeof ApiListingsIdRouteWithChildren
+  '/api/listings/$id/unavailable': typeof ApiListingsIdUnavailableRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -101,12 +118,14 @@ export interface FileRoutesById {
   '/css-test': typeof CssTestRoute
   '/login': typeof LoginRoute
   '/api/health': typeof ApiHealthRoute
+  '/api/inquiries': typeof ApiInquiriesRoute
   '/api/listings': typeof ApiListingsRouteWithChildren
   '/listings/$id': typeof ListingsIdRoute
   '/listings/mine': typeof ListingsMineRoute
   '/listings/new': typeof ListingsNewRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
-  '/api/listings/$id': typeof ApiListingsIdRoute
+  '/api/listings/$id': typeof ApiListingsIdRouteWithChildren
+  '/api/listings/$id/unavailable': typeof ApiListingsIdUnavailableRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -115,36 +134,42 @@ export interface FileRouteTypes {
     | '/css-test'
     | '/login'
     | '/api/health'
+    | '/api/inquiries'
     | '/api/listings'
     | '/listings/$id'
     | '/listings/mine'
     | '/listings/new'
     | '/api/auth/$'
     | '/api/listings/$id'
+    | '/api/listings/$id/unavailable'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/css-test'
     | '/login'
     | '/api/health'
+    | '/api/inquiries'
     | '/api/listings'
     | '/listings/$id'
     | '/listings/mine'
     | '/listings/new'
     | '/api/auth/$'
     | '/api/listings/$id'
+    | '/api/listings/$id/unavailable'
   id:
     | '__root__'
     | '/'
     | '/css-test'
     | '/login'
     | '/api/health'
+    | '/api/inquiries'
     | '/api/listings'
     | '/listings/$id'
     | '/listings/mine'
     | '/listings/new'
     | '/api/auth/$'
     | '/api/listings/$id'
+    | '/api/listings/$id/unavailable'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -152,6 +177,7 @@ export interface RootRouteChildren {
   CssTestRoute: typeof CssTestRoute
   LoginRoute: typeof LoginRoute
   ApiHealthRoute: typeof ApiHealthRoute
+  ApiInquiriesRoute: typeof ApiInquiriesRoute
   ApiListingsRoute: typeof ApiListingsRouteWithChildren
   ListingsIdRoute: typeof ListingsIdRoute
   ListingsMineRoute: typeof ListingsMineRoute
@@ -210,6 +236,13 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof ApiListingsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/inquiries': {
+      id: '/api/inquiries'
+      path: '/api/inquiries'
+      fullPath: '/api/inquiries'
+      preLoaderRoute: typeof ApiInquiriesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/health': {
       id: '/api/health'
       path: '/api/health'
@@ -231,15 +264,34 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof ApiAuthSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/listings/$id/unavailable': {
+      id: '/api/listings/$id/unavailable'
+      path: '/unavailable'
+      fullPath: '/api/listings/$id/unavailable'
+      preLoaderRoute: typeof ApiListingsIdUnavailableRouteImport
+      parentRoute: typeof ApiListingsIdRoute
+    }
   }
 }
 
+interface ApiListingsIdRouteChildren {
+  ApiListingsIdUnavailableRoute: typeof ApiListingsIdUnavailableRoute
+}
+
+const ApiListingsIdRouteChildren: ApiListingsIdRouteChildren = {
+  ApiListingsIdUnavailableRoute: ApiListingsIdUnavailableRoute,
+}
+
+const ApiListingsIdRouteWithChildren = ApiListingsIdRoute._addFileChildren(
+  ApiListingsIdRouteChildren,
+)
+
 interface ApiListingsRouteChildren {
-  ApiListingsIdRoute: typeof ApiListingsIdRoute
+  ApiListingsIdRoute: typeof ApiListingsIdRouteWithChildren
 }
 
 const ApiListingsRouteChildren: ApiListingsRouteChildren = {
-  ApiListingsIdRoute: ApiListingsIdRoute,
+  ApiListingsIdRoute: ApiListingsIdRouteWithChildren,
 }
 
 const ApiListingsRouteWithChildren = ApiListingsRoute._addFileChildren(
@@ -251,6 +303,7 @@ const rootRouteChildren: RootRouteChildren = {
   CssTestRoute: CssTestRoute,
   LoginRoute: LoginRoute,
   ApiHealthRoute: ApiHealthRoute,
+  ApiInquiriesRoute: ApiInquiriesRoute,
   ApiListingsRoute: ApiListingsRouteWithChildren,
   ListingsIdRoute: ListingsIdRoute,
   ListingsMineRoute: ListingsMineRoute,

--- a/apps/www/src/routes/api/inquiries.ts
+++ b/apps/www/src/routes/api/inquiries.ts
@@ -1,0 +1,126 @@
+import { createFileRoute } from '@tanstack/solid-router'
+import { inquiryFormSchema, ListingStatus } from '@/lib/validation'
+
+export const Route = createFileRoute('/api/inquiries')({
+	server: {
+		handlers: {
+			async POST({ request }) {
+				// Dynamic imports to avoid bundling server-only code for browser
+				const { auth } = await import('@/lib/auth')
+				const {
+					createInquiry,
+					hasRecentInquiry,
+					getListingWithOwner,
+					getUserById,
+					markInquiryEmailSent,
+				} = await import('@/data/queries')
+				const { sendInquiryEmail } = await import('@/lib/email-templates')
+
+				// Require authentication
+				const session = await auth.api.getSession({
+					headers: request.headers,
+				})
+
+				if (!session?.user) {
+					return Response.json({ error: 'Authentication required' }, { status: 401 })
+				}
+
+				let body: unknown
+				try {
+					body = await request.json()
+				} catch {
+					return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+				}
+
+				// Validate form data
+				const parsed = inquiryFormSchema.safeParse(body)
+				if (!parsed.success) {
+					return Response.json({ error: parsed.error.flatten() }, { status: 400 })
+				}
+
+				const { listingId, note } = parsed.data
+
+				// Get listing with owner info
+				const result = await getListingWithOwner(listingId)
+				if (!result) {
+					return Response.json({ error: 'Listing not found' }, { status: 404 })
+				}
+
+				const { listing, owner } = result
+
+				// Check listing status allows inquiries
+				if (
+					listing.status !== ListingStatus.available &&
+					listing.status !== ListingStatus.private
+				) {
+					return Response.json(
+						{ error: 'This listing is not accepting inquiries' },
+						{ status: 404 }
+					)
+				}
+
+				// Cannot inquire on own listing
+				if (listing.userId === session.user.id) {
+					return Response.json(
+						{ error: 'You cannot inquire about your own listing' },
+						{ status: 400 }
+					)
+				}
+
+				// Check rate limit
+				const hasRecent = await hasRecentInquiry(session.user.id, listingId)
+				if (hasRecent) {
+					return Response.json(
+						{
+							error:
+								'You have already contacted this owner recently. Please wait 24 hours before trying again.',
+						},
+						{ status: 400 }
+					)
+				}
+
+				// Get gleaner info
+				const gleaner = await getUserById(session.user.id)
+				if (!gleaner) {
+					return Response.json({ error: 'User not found' }, { status: 400 })
+				}
+
+				// Create inquiry record
+				const inquiry = await createInquiry({
+					listingId,
+					gleanerId: session.user.id,
+					note: note || null,
+				})
+
+				// Attempt to send email
+				const baseUrl = new URL(request.url).origin
+				const emailSent = await sendInquiryEmail({
+					ownerName: owner.name,
+					ownerEmail: owner.email,
+					gleanerName: gleaner.name,
+					gleanerEmail: gleaner.email,
+					gleanerNote: note,
+					produceType: listing.type,
+					quantity: listing.quantity,
+					listingNotes: listing.notes,
+					plantId: listing.id,
+					baseUrl,
+				})
+
+				// Update emailSentAt if successful
+				if (emailSent) {
+					await markInquiryEmailSent(inquiry.id)
+				}
+
+				return Response.json(
+					{
+						success: true,
+						inquiryId: inquiry.id,
+						emailSent,
+					},
+					{ status: 201 }
+				)
+			},
+		},
+	},
+})

--- a/apps/www/src/routes/api/listings.$id.unavailable.ts
+++ b/apps/www/src/routes/api/listings.$id.unavailable.ts
@@ -1,0 +1,63 @@
+import { createFileRoute, redirect } from '@tanstack/solid-router'
+import { z } from 'zod'
+
+const paramsSchema = z.object({
+	id: z.coerce.number().int().positive(),
+})
+
+const querySchema = z.object({
+	nonce: z.string().min(1),
+	sig: z.string().min(1),
+})
+
+export const Route = createFileRoute('/api/listings/$id/unavailable')({
+	server: {
+		handlers: {
+			async GET({ request, params }) {
+				// Dynamic imports to avoid bundling server-only code for browser
+				const { verifySignature } = await import('@/lib/hmac')
+				const { markListingUnavailable } = await import('@/data/queries')
+
+				// Validate params
+				const parsedParams = paramsSchema.safeParse(params)
+				if (!parsedParams.success) {
+					return Response.json({ error: 'Invalid listing ID' }, { status: 400 })
+				}
+
+				// Parse query params
+				const url = new URL(request.url)
+				const parsedQuery = querySchema.safeParse({
+					nonce: url.searchParams.get('nonce'),
+					sig: url.searchParams.get('sig'),
+				})
+
+				if (!parsedQuery.success) {
+					return Response.json(
+						{ error: 'Missing nonce or sig parameter' },
+						{ status: 400 }
+					)
+				}
+
+				const { id } = parsedParams.data
+				const { nonce, sig } = parsedQuery.data
+
+				// Verify HMAC signature
+				if (!verifySignature(id, nonce, sig)) {
+					return Response.json({ error: 'Invalid signature' }, { status: 403 })
+				}
+
+				// Mark listing as unavailable
+				const updated = await markListingUnavailable(id)
+				if (!updated) {
+					return Response.json({ error: 'Listing not found' }, { status: 404 })
+				}
+
+				// Redirect to my listings page with success message
+				throw redirect({
+					to: '/listings/mine',
+					search: { marked: 'unavailable' },
+				})
+			},
+		},
+	},
+})

--- a/apps/www/src/routes/listings.$id.tsx
+++ b/apps/www/src/routes/listings.$id.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/solid-router'
 import { Show } from 'solid-js'
 import Layout from '@/components/Layout'
+import InquiryForm from '@/components/InquiryForm'
 import { useSession } from '@/lib/auth-client'
 import { getStatusClass } from '@/lib/listing-status'
 import { ListingStatus } from '@/lib/validation'
@@ -16,9 +17,14 @@ export const Route = createFileRoute('/listings/$id')({
 function ListingDetailPage() {
 	const data = Route.useLoaderData()
 	const session = useSession()
+	const params = Route.useParams()
 
 	const listing = () => data() as PublicListing | undefined
 	const isOwner = () => session().data?.user?.id === listing()?.userId
+	const canInquire = () => {
+		const l = listing()
+		return l && l.status === ListingStatus.available && !isOwner()
+	}
 
 	return (
 		<Show
@@ -110,6 +116,13 @@ function ListingDetailPage() {
 										Manage My Listings
 									</Link>
 								</div>
+							</Show>
+
+							<Show when={canInquire()}>
+								<InquiryForm
+									listingId={l().id}
+									callbackURL={`/listings/${params().id}`}
+								/>
 							</Show>
 						</article>
 					</main>

--- a/apps/www/src/routes/listings/mine.css
+++ b/apps/www/src/routes/listings/mine.css
@@ -124,6 +124,63 @@
 		cursor: not-allowed;
 	}
 
+	.listing-actions .status-toggle-button {
+		font-size: 14px;
+		color: var(--color-background);
+		background: var(--color-secondary);
+		border: none;
+		padding: 8px 14px;
+		border-radius: 6px;
+		cursor: pointer;
+		font-weight: 500;
+		transition: background-color 0.2s;
+	}
+
+	.listing-actions .status-toggle-button:hover:not(:disabled) {
+		background: oklch(from var(--color-secondary) calc(l - 0.08) c h);
+	}
+
+	.listing-actions .status-toggle-button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.listing-error {
+		font-size: 13px;
+		color: var(--color-primary);
+		margin: 0 0 12px 0;
+		padding: 8px 12px;
+		background: oklch(from var(--color-primary) l c h / 0.1);
+		border-radius: 6px;
+	}
+
+	.success-message {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+		padding: 16px 20px;
+		background: oklch(from var(--color-secondary) l c h / 0.1);
+		color: var(--color-secondary);
+		border-radius: 8px;
+		margin-bottom: 24px;
+		font-size: 14px;
+	}
+
+	.success-message .dismiss-button {
+		background: none;
+		border: none;
+		color: var(--color-secondary);
+		text-decoration: underline;
+		cursor: pointer;
+		font-size: 14px;
+		padding: 0;
+	}
+
+	.success-message .dismiss-button:hover {
+		text-decoration: none;
+	}
+
 	.empty-state {
 		text-align: center;
 		padding: 60px 20px;

--- a/apps/www/src/routes/listings/mine.tsx
+++ b/apps/www/src/routes/listings/mine.tsx
@@ -129,6 +129,10 @@ function EmptyState() {
 function MyGardenPage() {
 	const listings = Route.useLoaderData()
 	const session = useSession()
+	const search = Route.useSearch()
+	const [showMarkedMessage, setShowMarkedMessage] = createSignal(
+		() => (search as () => { marked?: string })()?.marked === 'unavailable'
+	)
 
 	return (
 		<Layout title="My Garden - Pick My Fruit">
@@ -139,6 +143,20 @@ function MyGardenPage() {
 						<p>Welcome back, {session().data?.user?.name || 'friend'}!</p>
 					</Show>
 				</header>
+
+				<Show when={showMarkedMessage()()}>
+					<div class="success-message">
+						Listing marked as unavailable. Gleaners won't be able to contact you about
+						this listing.
+						<button
+							type="button"
+							class="dismiss-button"
+							onClick={() => setShowMarkedMessage(() => () => false)}
+						>
+							Dismiss
+						</button>
+					</div>
+				</Show>
 
 				<Show when={(listings() ?? []).length > 0} fallback={<EmptyState />}>
 					<div class="listings-grid">

--- a/docs/0002-inquiry-system.md
+++ b/docs/0002-inquiry-system.md
@@ -1,0 +1,601 @@
+# PR #7: Inquiry System
+
+## Summary
+
+Add a system that lets gleaners express interest in fruit listings. When a gleaner clicks "Put me in touch," PMF emails the owner with the gleaner's contact info. Owners can mark listings as unavailable (visible but contact disabled) or private (hidden but shareable via URL).
+
+**Note**: The database table is `plants` but URLs use `/listings/` for user-friendly semantics.
+
+---
+
+## Data Model Changes
+
+### 1. Update `plants` table (`src/data/schema.ts`)
+
+**Status field**: Change from `'available' | 'claimed' | 'harvested'` to `'active' | 'unavailable' | 'private'`
+
+**Add fields**:
+- `deletedAt: integer('deleted_at', { mode: 'timestamp' })` - soft delete
+
+### 2. Add `inquiries` table (`src/data/schema.ts`)
+
+```typescript
+export const inquiries = sqliteTable('inquiries', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+  listingId: integer('listing_id').notNull().references(() => plants.id),
+  gleanerId: text('gleaner_id').notNull().references(() => user.id),
+  note: text('note'), // max 500 chars, validated at API layer
+  emailSentAt: integer('email_sent_at', { mode: 'timestamp' }),
+}, (table) => [
+  index('inquiry_listing_id_idx').on(table.listingId),
+  index('inquiry_gleaner_id_idx').on(table.gleanerId),
+])
+
+export type Inquiry = typeof inquiries.$inferSelect
+export type NewInquiry = typeof inquiries.$inferInsert
+```
+
+### 3. Migration (`drizzle/0003_add_inquiries.sql`)
+
+```sql
+-- Update existing status values (must happen before query code changes)
+UPDATE plants SET status = 'active' WHERE status = 'available';
+UPDATE plants SET status = 'unavailable' WHERE status IN ('claimed', 'harvested');
+
+-- Add soft delete column with index for efficient filtering
+ALTER TABLE plants ADD COLUMN deleted_at integer;
+CREATE INDEX plants_deleted_at_idx ON plants(deleted_at);
+
+-- Create inquiries table
+CREATE TABLE inquiries (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  created_at integer DEFAULT (unixepoch()) NOT NULL,
+  listing_id integer NOT NULL REFERENCES plants(id),
+  gleaner_id text NOT NULL REFERENCES user(id),
+  note text,
+  email_sent_at integer
+);
+CREATE INDEX inquiry_listing_id_idx ON inquiries(listing_id);
+CREATE INDEX inquiry_gleaner_id_idx ON inquiries(gleaner_id);
+```
+
+**Critical**: Run migration before deploying code changes. The migration updates status values so existing data works with new query filters.
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `src/lib/email-templates.ts` | Inquiry email HTML builder |
+| `src/lib/hmac.ts` | HMAC utilities for signed URLs |
+| `src/routes/api/inquiries.ts` | POST /api/inquiries endpoint |
+| `src/routes/api/listings.$id.ts` | PATCH /api/listings/:id |
+| `src/routes/api/plants.$id.unavailable.ts` | GET one-click mark unavailable (with HMAC) |
+| `src/routes/listings.$id.tsx` | Listing detail page |
+| `src/routes/listings.css` | Listing detail styles |
+| `src/components/InquiryForm.tsx` | "Put me in touch" form |
+| `src/components/InquiryForm.css` | Form styles |
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/data/schema.ts` | Add `inquiries` table, add `deletedAt` to plants, export types |
+| `src/data/queries.ts` | Add inquiry queries, update status filter to `active`, add soft delete check |
+| `src/lib/validation.ts` | Add `inquiryFormSchema`, `updateListingStatusSchema` |
+| `src/routes/garden/mine.tsx` | Add status toggle button, update status badge classes |
+| `src/routes/garden/mine.css` | Add styles for new status values and toggle button |
+| `src/routes/index.tsx` | Make plant cards clickable links to `/listings/:id` |
+| `src/routes/index.css` | Add hover/focus states for clickable cards |
+
+---
+
+## Query Functions (`src/data/queries.ts`)
+
+### New Functions
+
+```typescript
+// Create an inquiry
+export async function createInquiry(data: NewInquiry): Promise<Inquiry>
+
+// Update emailSentAt after successful send
+export async function markInquiryEmailSent(id: number): Promise<void>
+
+// Check rate limit: has gleaner inquired on this listing in last 24h?
+export async function hasRecentInquiry(gleanerId: string, listingId: number): Promise<boolean>
+
+// Get listing with owner info for email
+export async function getListingWithOwner(id: number): Promise<{
+  listing: Plant
+  owner: { id: string; name: string; email: string }
+} | undefined>
+
+// Get listing for inquiry validation (active or private, not deleted)
+export async function getListingForInquiry(id: number): Promise<Plant | undefined>
+
+// Update listing status (owner only)
+export async function updateListingStatus(
+  id: number,
+  userId: string,
+  status: 'active' | 'unavailable' | 'private'
+): Promise<boolean>
+
+// Get user by ID (for gleaner info in email)
+export async function getUserById(id: string): Promise<{ name: string; email: string } | undefined>
+```
+
+### Modified Functions
+
+```typescript
+// Update to filter by 'active' status and exclude deleted
+export async function getAvailablePlants(limit: number = 10): Promise<Plant[]> {
+  return await db
+    .select()
+    .from(plants)
+    .where(and(
+      eq(plants.status, 'active'),
+      isNull(plants.deletedAt)
+    ))
+    .orderBy(desc(plants.createdAt))
+    .limit(limit)
+}
+
+// Update to exclude deleted listings
+export async function getUserListings(userId: string): Promise<Plant[]> {
+  return await db
+    .select()
+    .from(plants)
+    .where(and(
+      eq(plants.userId, userId),
+      isNull(plants.deletedAt)
+    ))
+    .orderBy(desc(plants.createdAt))
+}
+```
+
+---
+
+## API Endpoints
+
+### POST /api/inquiries
+
+**Auth**: Required (gleaner must be logged in)
+
+**Request Body**:
+```typescript
+interface InquiryRequest {
+  listingId: number
+  note?: string // max 500 chars
+}
+```
+
+**Validation**:
+1. Listing exists, is not deleted, and status is `active` or `private`
+2. Gleaner is not the listing owner
+3. Note is max 500 characters
+4. **Rate limit**: No inquiry from this gleaner on this listing in last 24 hours
+
+**Response** (201):
+```typescript
+interface InquiryResponse {
+  success: true
+  inquiryId: number
+  emailSent: boolean // false if email failed but inquiry was recorded
+}
+```
+
+**Error Responses**:
+- 400: Invalid input, own listing, rate limit exceeded
+- 401: Not authenticated
+- 404: Listing not found or unavailable
+
+**Email Handling**:
+1. Create inquiry record with `emailSentAt: null`
+2. Attempt to send email
+3. On success: update `emailSentAt` to current timestamp
+4. On failure: log error, return `emailSent: false` (inquiry still recorded)
+
+---
+
+### PATCH /api/listings/:id
+
+**Auth**: Required (must be listing owner)
+
+**Request Body**:
+```typescript
+interface ListingUpdateRequest {
+  status: 'active' | 'unavailable' | 'private'
+}
+```
+
+**Response** (200):
+```typescript
+interface ListingUpdateResponse {
+  success: true
+}
+```
+
+**Error Responses**:
+- 400: Invalid status
+- 401: Not authenticated
+- 404: Listing not found or not authorized
+
+---
+
+### GET /api/plants/:id/unavailable
+
+**Auth**: HMAC signature verification
+
+**URL Format**:
+```
+/api/plants/:id/unavailable?nonce=abc123&sig=def456
+```
+
+**HMAC Signature**:
+```typescript
+// Generate (in email template)
+const nonce = crypto.randomUUID()
+const message = `${plantId}:${nonce}`
+const sig = hmac(message, process.env.HMAC_SECRET)
+const url = `/api/plants/${plantId}/unavailable?nonce=${nonce}&sig=${sig}`
+
+// Verify (in endpoint)
+const expectedSig = hmac(`${plantId}:${nonce}`, process.env.HMAC_SECRET)
+if (sig !== expectedSig) return 403
+```
+
+**Action**: Mark listing unavailable, redirect to `/garden/mine?marked=unavailable`
+
+**Error Responses**:
+- 400: Missing nonce or sig
+- 403: Invalid signature
+- 404: Listing not found
+
+---
+
+## HMAC Utilities (`src/lib/hmac.ts`)
+
+```typescript
+import { createHmac } from 'crypto'
+
+const HMAC_SECRET = process.env.HMAC_SECRET || 'dev-secret-change-in-prod'
+
+export function signUrl(plantId: number): { nonce: string; sig: string } {
+  const nonce = crypto.randomUUID()
+  const message = `${plantId}:${nonce}`
+  const sig = createHmac('sha256', HMAC_SECRET).update(message).digest('hex')
+  return { nonce, sig }
+}
+
+export function verifySignature(plantId: number, nonce: string, sig: string): boolean {
+  const message = `${plantId}:${nonce}`
+  const expected = createHmac('sha256', HMAC_SECRET).update(message).digest('hex')
+  // Timing-safe comparison
+  return sig.length === expected.length &&
+    crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))
+}
+
+export function buildUnavailableUrl(baseUrl: string, plantId: number): string {
+  const { nonce, sig } = signUrl(plantId)
+  return `${baseUrl}/api/plants/${plantId}/unavailable?nonce=${nonce}&sig=${sig}`
+}
+```
+
+---
+
+## Validation Schemas (`src/lib/validation.ts`)
+
+```typescript
+export const inquiryFormSchema = z.object({
+  listingId: z.number().int().positive('Invalid listing'),
+  note: z.preprocess(
+    (val) => (val === '' || val === null ? undefined : val),
+    z.string().max(500, 'Note must be 500 characters or less').optional()
+  ),
+})
+
+export type InquiryFormData = z.infer<typeof inquiryFormSchema>
+
+export const listingStatuses = ['active', 'unavailable', 'private'] as const
+export type ListingStatus = (typeof listingStatuses)[number]
+
+export const updateListingStatusSchema = z.object({
+  status: z.enum(listingStatuses, { message: 'Invalid status' }),
+})
+```
+
+---
+
+## Inquiry Email Template
+
+**Subject**: `{GleanerName} wants your {ProduceType}`
+
+**From**: `Pick My Fruit <notifications@pickmyfruit.com>`
+
+**Reply-To**: Gleaner's email address
+
+**HTML Body** (matches magic link email styling from `src/lib/auth.ts`):
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h1 style="color: #2d5016; margin-bottom: 24px;">Someone wants your {produceType}!</h1>
+
+  <p>Hi {ownerName},</p>
+
+  <p><strong>{gleanerName}</strong> is interested in your {produceType}.</p>
+
+  <div style="background: #f9fafb; border-radius: 8px; padding: 16px; margin: 24px 0;">
+    <h3 style="margin: 0 0 12px 0; color: #2d5016;">Listing Details</h3>
+    <p style="margin: 0 0 8px 0;"><strong>Type:</strong> {produceType}</p>
+    {quantity && <p style="margin: 0 0 8px 0;"><strong>Quantity:</strong> {quantity}</p>}
+    {notes && <p style="margin: 0;"><strong>Your notes:</strong> {notes}</p>}
+  </div>
+
+  {gleanerNote &&
+  <div style="background: #fef3c7; border-radius: 8px; padding: 16px; margin: 24px 0;">
+    <h3 style="margin: 0 0 8px 0; color: #92400e;">Message from {gleanerName}</h3>
+    <p style="margin: 0;">{gleanerNote}</p>
+  </div>
+  }
+
+  <p>Simply <strong>reply to this email</strong> to get in touch with {gleanerName}.</p>
+
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 32px 0;">
+
+  <p style="color: #666; font-size: 14px;">
+    All done with this listing?
+    <a href="{unavailableUrl}" style="color: #4a7c23;">Mark as unavailable</a>
+  </p>
+</body>
+</html>
+```
+
+---
+
+## UI Flows
+
+### Listing Detail Page (`/listings/:id`)
+
+**Route**: `src/routes/listings.$id.tsx`
+
+The `$id` parameter is accessed via `params.id` in the route loader.
+
+**Display**:
+- Produce type (h1)
+- Status badge (active/unavailable/private)
+- Variety (if provided)
+- Quantity (if provided)
+- Harvest window (if provided)
+- Location: city, state only (privacy: no street address)
+- Owner's notes (if provided)
+
+**Conditional Content**:
+- If status is `active` or `private`: show InquiryForm
+- If status is `unavailable`: show "Check back later" message, no form
+- If listing not found or deleted: show 404 message
+
+---
+
+### InquiryForm Component
+
+**States**:
+1. **Initial (authenticated)**: Note textarea + "Put me in touch" button
+2. **Initial (unauthenticated)**: Email field + Note textarea + button
+3. **Awaiting magic link**: MagicLinkWaiting component (reuse existing)
+4. **Submitting**: Disabled button with "Sending..." text
+5. **Success**: Confirmation message
+6. **Rate limited**: "You've already contacted this owner recently" message
+
+**Flow (authenticated user)**:
+1. User enters optional note
+2. Clicks "Put me in touch"
+3. POST /api/inquiries
+4. If rate limited (400): show rate limit message
+5. If success: show confirmation (note if email failed)
+
+**Flow (unauthenticated user)**:
+1. User enters email and optional note
+2. Clicks "Put me in touch"
+3. Store `{ listingId, note }` in sessionStorage (key: `pendingInquiry`)
+4. Trigger magic link flow with callback to `/listings/:id?inquiry_complete=true`
+5. After verification, auto-submit stored inquiry
+6. Show success message
+
+**SessionStorage Limitation**: If user opens magic link in different browser/tab, pending inquiry is lost. This is acceptable for MVP (documented in ROADMAP future enhancements).
+
+---
+
+### My Listings Page Updates (`/garden/mine`)
+
+**Status Badge Classes**:
+```css
+.status-badge.status-active {
+  background: oklch(from var(--color-secondary) l c h / 0.15);
+  color: var(--color-secondary);
+}
+
+.status-badge.status-unavailable {
+  background: oklch(from var(--color-quiet) l c h / 0.15);
+  color: var(--color-quiet);
+}
+
+.status-badge.status-private {
+  background: oklch(from var(--color-accent) l c h / 0.15);
+  color: var(--color-accent);
+}
+```
+
+**Status Toggle Button**:
+- If active: "Mark Unavailable" button
+- If unavailable: "Mark Active" button
+- Shows loading state during PATCH request
+- On error: revert to previous state, show error message
+
+**Note**: Private status toggle not in MVP UI - owners can only toggle active/unavailable.
+
+---
+
+### Home Page Updates (`/index.tsx`)
+
+Make plant cards clickable:
+
+```tsx
+<Link to={`/listings/${plant.id}`} class="plant-card surface-subtle">
+  {/* existing card content */}
+</Link>
+```
+
+**Add hover/focus states** (`src/routes/index.css`):
+
+```css
+.plant-card {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.plant-card:hover,
+.plant-card:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px oklch(from var(--color-quiet) l c h / 0.15);
+}
+
+.plant-card:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+```
+
+---
+
+## Implementation Order
+
+### Phase 1: Database Layer (atomic - deploy together)
+1. Update `src/data/schema.ts` - add inquiries table, add deletedAt to plants
+2. Create migration `drizzle/0003_add_inquiries.sql`
+3. Update `src/data/queries.ts` - all query changes (status filter, soft delete, new functions)
+4. Run migration, then deploy code
+
+### Phase 2: Utilities
+5. Create `src/lib/hmac.ts` - HMAC utilities
+6. Update `src/lib/validation.ts` - add inquiry schemas
+7. Create `src/lib/email-templates.ts` - inquiry email builder
+
+### Phase 3: API Endpoints
+8. Create `src/routes/api/inquiries.ts`
+9. Create `src/routes/api/listings.$id.ts`
+10. Create `src/routes/api/plants.$id.unavailable.ts`
+
+### Phase 4: UI Components
+11. Create `src/components/InquiryForm.tsx` + CSS
+12. Create `src/routes/listings.$id.tsx` + CSS
+
+### Phase 5: Updates to Existing Pages
+13. Update `src/routes/garden/mine.tsx` - add status toggle with loading state
+14. Update `src/routes/garden/mine.css` - new status classes, toggle button
+15. Update `src/routes/index.tsx` - make cards clickable links
+16. Update `src/routes/index.css` - hover/focus states
+
+---
+
+## Environment Variables
+
+Add to `.env`:
+```
+HMAC_SECRET=generate-a-secure-random-string
+```
+
+For production (Fly.io):
+```bash
+fly secrets set HMAC_SECRET=$(openssl rand -hex 32)
+```
+
+---
+
+## Verification Checklist
+
+### Setup
+- [ ] Add `HMAC_SECRET` to `.env`
+- [ ] Run migration: `pnpm db:migrate`
+- [ ] Seed data: `pnpm db:seed`
+- [ ] Start dev server: `pnpm dev`
+
+### Listing Detail Page
+- [ ] Navigate to `/listings/1` - see listing details
+- [ ] Verify location shows city/state only, not full address
+- [ ] Verify status badge displays correctly
+
+### Inquiry Flow (Authenticated)
+- [ ] Log in as User A, create a listing
+- [ ] Log in as User B
+- [ ] Navigate to User A's listing
+- [ ] Submit inquiry with note
+- [ ] Verify success message appears
+- [ ] Check console for email log (dev mode)
+- [ ] Verify inquiry record in database with `emailSentAt` set
+- [ ] Try submitting again - should see rate limit message
+
+### Inquiry Flow (Unauthenticated)
+- [ ] Log out
+- [ ] Navigate to a listing
+- [ ] Enter email and note, submit
+- [ ] Verify magic link email sent
+- [ ] Click magic link (same browser)
+- [ ] Verify inquiry auto-submits after verification
+- [ ] Verify success message appears
+
+### Status Toggle
+- [ ] Navigate to `/garden/mine`
+- [ ] Click "Mark Unavailable" on a listing
+- [ ] Verify button shows loading state during request
+- [ ] Verify badge changes to "unavailable"
+- [ ] Navigate to that listing's detail page
+- [ ] Verify "Check back later" shows, no inquiry form
+- [ ] Go back to `/garden/mine`
+- [ ] Click "Mark Active"
+- [ ] Verify inquiry form returns on detail page
+
+### One-Click Unavailable (HMAC)
+- [ ] Check console for email log with unavailable URL
+- [ ] Copy the full URL (including nonce and sig params)
+- [ ] Visit the URL
+- [ ] Verify redirect to `/garden/mine?marked=unavailable`
+- [ ] Verify listing status is now "unavailable"
+- [ ] Try visiting URL again - should still work (idempotent)
+- [ ] Modify the sig parameter - should get 403 error
+
+### Home Page Cards
+- [ ] Verify cards are clickable (cursor: pointer)
+- [ ] Verify hover state (slight lift, shadow)
+- [ ] Verify focus state (outline visible)
+- [ ] Click card - navigates to detail page
+
+### Edge Cases
+- [ ] Try to inquire on own listing - should get error
+- [ ] Try to submit inquiry with >500 char note - should get error
+- [ ] Navigate to non-existent listing - should see 404 message
+- [ ] Navigate to unavailable listing - should see "check back later"
+
+---
+
+## Out of Scope (Future Enhancements)
+
+- In-app notifications (badge on "My Listings")
+- Inquiry history view for owners
+- Server-side pending inquiry storage (cross-browser magic link)
+- Reminder email cadence (10 days, 30 days, season end)
+- `reminderSentAt` field on plants table
+- Gleaner profiles
+- Inquiry outcome tracking ("How did it go?")
+- Private status toggle in UI (schema supports it, UI deferred)


### PR DESCRIPTION
## Summary
- Add inquiry system: gleaners express interest in a listing, the owner receives an email with the gleaner's contact info (reply-to gleaner's email), and the inquiry is logged in the database
- Add listing detail page (`/listings/$id`) with inquiry form, status badges, and conditional content based on listing state and user role
- Simplify listing statuses from `available/claimed/harvested` to `available/unavailable/private`, with owner-facing status toggle on My Garden page
- Add HMAC-signed one-click "mark unavailable" link in inquiry emails so owners can delist without logging in
- Add soft delete (`deleted_at`) column on listings; update all queries to filter deleted rows
- 24-hour per-gleaner-per-listing rate limit on inquiries
- Unauthenticated users enter magic-link flow then auto-submit the stored inquiry on return

## Test plan
- [x] Run migration (`pnpm db:migrate`) and seed (`pnpm db:seed`), verify app starts
- [x] As an authenticated non-owner, submit inquiry on a listing; verify success message and console email log
- [x] Re-submit inquiry on same listing within 24h; verify rate-limit message
- [x] As unauthenticated user, submit inquiry; verify magic-link flow auto-submits after verification
- [x] Toggle listing status (available/unavailable) on My Garden page; verify detail page updates accordingly
- [x] Copy HMAC-signed unavailable URL from console email, visit it, verify redirect to `/listings/mine?marked=unavailable`
- [x] Verify home page listing cards are clickable and navigate to detail pages
- [x] Verify client-side navigation to `/listings/mine` after creating a listing shows fresh data

## Review notes
- Migration `0004_add_inquiries.sql` migrates existing status values and creates the inquiries table
- Listing detail page uses `<Show>` with render callback for proper Solid reactivity (no early returns)
- Magic link auto-submit uses `createEffect(on(...))` with a double-submission guard
- Email sending degrades gracefully: inquiry is recorded even if email fails (`emailSent: false` in response)
- Private status is supported in schema/API but toggle UI is deferred
- `sessionStorage` is used for pending inquiry data during magic-link flow
- Hardening items tracked in `docs/_now-next-later.md` under "Inquiry System Hardening"

🤖 Generated with [Claude Code](https://claude.com/claude-code)