### PR TITLE
fix: resolve flaky e2e auth test (attempt 2)

### DIFF
--- a/apps/www/tests/e2e/auth.test.ts
+++ b/apps/www/tests/e2e/auth.test.ts
@@ -8,41 +8,26 @@ test.describe('Authentication', () => {
 	test('magic link sign-in flow', async ({ page, testUser }) => {
 		await page.goto('/login')
 
-		// Wait for login page to fully load
 		await expect(
 			page.getByRole('heading', { name: 'Sign in to Pick My Fruit' })
 		).toBeVisible()
 
-		// Wait for form to be ready
 		const emailInput = page.locator('input#email')
 		await expect(emailInput).toBeVisible()
-
-		// Type email using pressSequentially which properly triggers input events
 		await emailInput.pressSequentially(testUser.email, { delay: 30 })
-
-		// Verify the email was entered correctly
 		await expect(emailInput).toHaveValue(testUser.email)
 
-		// Submit the form and wait for network response
 		const submitButton = page.locator('button.submit-button')
-		const responsePromise = page.waitForResponse((resp) =>
-			resp.url().includes('/api/auth/sign-in/magic-link')
-		)
 		await submitButton.click()
-		await responsePromise
-
-		// Wait for "Check your email" view
 		await expect(
 			page.getByRole('heading', { name: 'Check your email' })
-		).toBeVisible({ timeout: 10000 })
+		).toBeVisible({ timeout: 15000 })
 
-		// Get token from database and verify
 		const token = await getMagicLinkToken(testUser.email)
 		const tokenInput = page.locator('input#magic-link-token')
 		await tokenInput.pressSequentially(token, { delay: 20 })
 		await page.getByRole('button', { name: 'Verify' }).click()
 
-		// Should redirect to garden
 		await expect(page).toHaveURL('/garden/mine')
 	})
 
@@ -54,44 +39,25 @@ test.describe('Authentication', () => {
 	test('invalid token shows error', async ({ page, testUser }) => {
 		await page.goto('/login')
 
-		// Wait for login page to fully load (same as first test)
 		await expect(
 			page.getByRole('heading', { name: 'Sign in to Pick My Fruit' })
 		).toBeVisible()
 
-		// Wait for form to be ready (same as first test)
 		const emailInput = page.locator('input#email')
 		await expect(emailInput).toBeVisible()
-
-		// Type email using pressSequentially (same as first test)
 		await emailInput.pressSequentially(testUser.email, { delay: 30 })
 		await expect(emailInput).toHaveValue(testUser.email)
 
-		// Submit the form (same as first test)
 		const submitButton = page.locator('button.submit-button')
-		const responsePromise = page.waitForResponse((resp) =>
-			resp.url().includes('/api/auth/sign-in/magic-link')
-		)
 		await submitButton.click()
-		await responsePromise
-
-		// Wait for "Check your email" view (same as first test)
 		await expect(
 			page.getByRole('heading', { name: 'Check your email' })
-		).toBeVisible({ timeout: 10000 })
+		).toBeVisible({ timeout: 15000 })
 
-		// Enter invalid token
 		const tokenInput = page.locator('input#magic-link-token')
 		await tokenInput.pressSequentially('invalid-token-12345', { delay: 20 })
 
-		// Click verify and wait for response
-		const verifyResponsePromise = page.waitForResponse((resp) =>
-			resp.url().includes('/api/auth/magic-link/verify')
-		)
 		await page.getByRole('button', { name: 'Verify' }).click()
-		await verifyResponsePromise
-
-		// Should show error
-		await expect(page.locator('.token-error')).toBeVisible({ timeout: 10000 })
+		await expect(page.locator('.token-error')).toBeVisible({ timeout: 15000 })
 	})
 })


### PR DESCRIPTION
Wait for UI state changes instead of intercepting network requests. This is more reliable because it doesn't depend on knowing the exact API URL (which may change) and tests what users actually see.