### PR TITLE
refactor: use faker-generated users for e2e test isolation

### DIFF
--- a/apps/www/tests/e2e/global-setup.ts
+++ b/apps/www/tests/e2e/global-setup.ts
@@ -1,7 +1,6 @@
 import { execSync } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { seedTestUser } from './helpers/test-db'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const wwwRoot = resolve(__dirname, '../..')
@@ -14,5 +13,5 @@ export default async function globalSetup() {
 		env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
 		stdio: 'inherit',
 	})
-	await seedTestUser()
+	// Test users are now created per-test in beforeEach hooks
 }

--- a/apps/www/tests/e2e/helpers/fixtures.ts
+++ b/apps/www/tests/e2e/helpers/fixtures.ts
@@ -1,0 +1,22 @@
+import { test as base } from '@playwright/test'
+import { type TestUser, createTestUser, cleanupTestUser } from './test-db'
+
+type TestFixtures = {
+	testUser: TestUser
+}
+
+export const test = base.extend<TestFixtures>({
+	// Auto-fixture: clears cookies before every test
+	context: async ({ context }, playwrightUse) => {
+		await context.clearCookies()
+		await playwrightUse(context)
+	},
+
+	testUser: async ({ browserName: _ }, playwrightUse) => {
+		const user = await createTestUser()
+		await playwrightUse(user)
+		await cleanupTestUser(user)
+	},
+})
+
+export { expect } from '@playwright/test'


### PR DESCRIPTION
Each e2e test now gets its own unique user, eliminating flakiness from parallel test interactions sharing a static TEST_USER.

Changes:
- Add Playwright fixtures (helpers/fixtures.ts) for automatic lifecycle:
  - context fixture: clears cookies before every test
  - testUser fixture: creates user before, cleans up after (on-demand)
- Replace static TEST_USER with faker-generated users (uuid-based email)
- Add cleanupTestUser() to delete user and related records (verification tokens, listings) that aren't cascade-deleted
- Remove global seedTestUser() from global-setup.ts