### PR TITLE
refactor(tooling): extract quality-gate.sh for /deliver skill

### DIFF
--- a/bin/quality-gate.sh
+++ b/bin/quality-gate.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Quality gate: runs typecheck, lint, tests, and format check.
+# Used by /deliver before commit and by code-quality.sh (Stop hook).
+# Exits with status 2 if any check fails.
+
+set -o pipefail
+
+cd "$(dirname "$0")/.." || exit 2
+
+echo "[quality-gate] Running typecheck..."
+errors=$(pnpm typecheck 2>&1)
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+	echo "[quality-gate] typecheck failed" >&2
+	echo "$errors" >&2
+	echo "" >&2
+	echo "Review and fix these errors before proceeding." >&2
+	exit 2
+fi
+
+echo "[quality-gate] Running lint..."
+errors=$(pnpm lint 2>&1)
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+	echo "[quality-gate] lint failed" >&2
+	echo "$errors" >&2
+	echo "" >&2
+	echo "Review and fix these errors before proceeding." >&2
+	exit 2
+fi
+
+echo "[quality-gate] Running tests..."
+errors=$(pnpm test:run 2>&1)
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+	echo "[quality-gate] tests failed" >&2
+	echo "$errors" >&2
+	echo "" >&2
+	echo "Review and fix these errors before proceeding." >&2
+	exit 2
+fi
+
+echo "[quality-gate] Checking formatting..."
+errors=$(pnpm format:check 2>&1)
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+	echo "[quality-gate] formatting check failed" >&2
+	echo "$errors" >&2
+	echo "" >&2
+	echo "Run 'pnpm format:write' to fix." >&2
+	exit 2
+fi
+
+echo "All quality checks passed"


### PR DESCRIPTION
## Summary

- Extract check-only quality gate (typecheck, lint, test, format:check) into `bin/quality-gate.sh` so the `/deliver` skill finds and runs it at the Quality Gate step
- Simplify `bin/code-quality.sh` (Stop hook) to wrap the gate with auto-fix retry for formatting issues
- No change in behavior: same checks run in the same order

## Test Plan

- [x] Run `bin/quality-gate.sh` directly — passes all four checks
- [x] Run `bin/code-quality.sh` directly — delegates to quality-gate.sh, auto-fixes formatting if needed
- [x] Use `/deliver` on a small change — verify it invokes `bin/quality-gate.sh` at the Quality Gate step

🤖 Generated with [Claude Code](https://claude.com/claude-code)