### PR TITLE
chore(css): polish listing card hover and focus styles

### DIFF
--- a/apps/www/src/routes/index.css
+++ b/apps/www/src/routes/index.css
@@ -255,19 +255,25 @@
 
 	.listing-card {
 		display: block;
+		text-decoration: none;
+		color: inherit;
 		border-radius: 12px;
 		padding: 24px;
 		box-shadow: 0 2px 8px oklch(from var(--color-foreground) l c h / 0.1);
-		text-decoration: none;
-		color: inherit;
 		transition:
-			transform 0.2s,
-			box-shadow 0.2s;
+			transform 0.15s ease,
+			box-shadow 0.15s ease;
+		cursor: pointer;
 	}
 
 	.listing-card:hover {
-		transform: translateY(-4px);
-		box-shadow: 0 4px 12px oklch(from var(--color-foreground) l c h / 0.15);
+		transform: translateY(-2px);
+		box-shadow: 0 4px 12px oklch(from var(--color-quiet) l c h / 0.15);
+	}
+
+	.listing-card:focus {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
 	}
 
 	.listing-card h3 {


### PR DESCRIPTION
## Summary

- Soften hover effect (2px lift instead of 4px, 0.15s ease timing)
- Add `:focus` outline for keyboard navigation accessibility
- Use `--color-quiet` for hover shadow instead of `--color-foreground`

## Test Plan

- [x] Verify listing cards on homepage have subtle hover lift
- [x] Tab to a listing card and confirm visible focus outline

## Review Notes

Extracted from `inquiries` branch to narrow that diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)