### PR TITLE
fix(seed): use ListingStatus constants instead of invalid 'claimed' string

### DIFF
--- a/apps/www/src/data/seed.ts
+++ b/apps/www/src/data/seed.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker'
 import { latLngToCell } from 'h3-js'
 import { db } from './db'
 import { listings, user, type NewListing, type NewUser } from './schema'
+import { ListingStatus } from '@/lib/validation'
 
 // Napa Valley approximate bounds
 const NAPA_BOUNDS = {
@@ -46,7 +47,12 @@ const FRUIT_TYPES = [
 ]
 
 const QUANTITIES = ['abundant', 'moderate', 'few']
-const STATUSES = ['available', 'available', 'available', 'claimed'] // More weight to available
+const STATUSES = [
+	ListingStatus.available,
+	ListingStatus.available,
+	ListingStatus.available,
+	ListingStatus.unavailable,
+] // More weight to available
 
 function generateUser(): NewUser {
 	return {


### PR DESCRIPTION
## Summary

- Replace hardcoded `'claimed'` string (not a valid status) with `ListingStatus.unavailable`
- Import `ListingStatus` from validation module for type safety

## Test Plan

- [x] Run `pnpm db:seed` and verify listings have valid statuses

## Review Notes

Extracted from `inquiries` branch to narrow that diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)