### PR TITLE
docs(agents): add createServerFn rule for route loaders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ We use a monorepo structure
 - Do not mix: a DB created with `push` can't switch to `migrate` (and vice versa)
 - Use Solid JS for reactive UI components
 - Routes are defined using TanStack Router's file-based routing
+- Route loaders that fetch data must use `createServerFn` (not `createIsomorphicFn` with `.client(() => undefined)`) so client-side navigation triggers an RPC call
 
 ### Authentication
 


### PR DESCRIPTION
## Summary

- Add rule to AGENTS.md: route loaders must use `createServerFn`, not `createIsomorphicFn` with `.client(() => undefined)`
- Matches existing rule in CLAUDE.md

## Test Plan

- [x] N/A — documentation only

## Review Notes

Extracted from `inquiries` branch to narrow that diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)