### PR TITLE
feat(www): move visibility editing to detail page

### DIFF
--- a/apps/www/src/lib/listing-status.ts
+++ b/apps/www/src/lib/listing-status.ts
@@ -1,5 +1,31 @@
 import { ListingStatus, type ListingStatusValue } from '@/lib/validation'
 
+/** The three visibility states a listing can be in, with user-facing labels. */
+export const VISIBILITY_OPTIONS = [
+	{
+		value: ListingStatus.available,
+		label: 'Available',
+		description: 'Listed publicly, accepts inquiries',
+	},
+	{
+		value: ListingStatus.unavailable,
+		label: 'Unavailable',
+		description: 'Listed publicly, but no inquiries, e.g. out of season',
+	},
+	{
+		value: ListingStatus.private,
+		label: 'Private',
+		description: 'Invisible, but accepts inquiries via direct link',
+	},
+] as const
+
+/** Maps each listing status to a semantic CSS color variable. */
+export const statusSemanticColor: Record<ListingStatusValue, string> = {
+	[ListingStatus.available]: 'var(--color-secondary)',
+	[ListingStatus.unavailable]: 'var(--color-quiet)',
+	[ListingStatus.private]: 'var(--color-accent)',
+}
+
 const statusClassMap: Record<ListingStatusValue, string> = {
 	[ListingStatus.available]: 'status-available',
 	[ListingStatus.unavailable]: 'status-unavailable',

--- a/apps/www/src/lib/validation.ts
+++ b/apps/www/src/lib/validation.ts
@@ -95,8 +95,7 @@ const listingStatusValues = Object.values(ListingStatus) as [
 	...ListingStatusValue[],
 ]
 
-// Accepts all statuses including 'private' for future API use; the UI only
-// exposes the available ↔ unavailable toggle.
+// Accepts all three statuses; the UI exposes them as a radio group.
 export const updateListingStatusSchema = z.object({
 	status: z.enum(listingStatusValues, { message: 'Invalid status' }),
 })

--- a/apps/www/src/routes/listings.css
+++ b/apps/www/src/routes/listings.css
@@ -172,6 +172,68 @@
 		margin: 0 0 24px 0;
 	}
 
+	.visibility-fieldset {
+		border: none;
+		padding: 0;
+		margin: 0;
+	}
+
+	.visibility-fieldset[aria-busy='true'] {
+		opacity: 0.6;
+		cursor: wait;
+	}
+
+	.visibility-legend {
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--color-quiet);
+		margin-bottom: 8px;
+	}
+
+	.visibility-option {
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+		cursor: pointer;
+		padding: 4px 0;
+	}
+
+	.visibility-option input[type='radio'] {
+		margin: 3px 0 0;
+		cursor: pointer;
+		accent-color: var(--visibility-color);
+	}
+
+	.visibility-option-text {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.visibility-option-label {
+		font-size: 14px;
+		font-weight: 500;
+	}
+
+	.visibility-option-description {
+		font-size: 12px;
+		color: var(--color-quiet);
+	}
+
+	.visibility-option--selected .visibility-option-label {
+		color: var(--visibility-color);
+	}
+
+	.visibility-error {
+		font-size: 13px;
+		color: var(--color-primary);
+		margin: 8px 0 0;
+		padding: 8px 12px;
+		background: oklch(from var(--color-primary) l c h / 0.1);
+		border-radius: 6px;
+	}
+
 	@media (max-width: 600px) {
 		.listing-detail {
 			padding: 24px;

--- a/apps/www/src/routes/listings/mine.css
+++ b/apps/www/src/routes/listings/mine.css
@@ -10,53 +10,36 @@
 		background: var(--color-background);
 		border: 1px solid oklch(from var(--color-quiet) l calc(c * 0.2) h);
 		border-radius: 12px;
-		padding: 20px;
 		transition: box-shadow 0.2s;
 	}
 
-	.listing-card:hover {
+	.listing-card:has(.listing-card-link:hover, .listing-card-link:focus-visible) {
 		box-shadow: 0 4px 12px oklch(from var(--color-foreground) l c h / 0.1);
 	}
 
-	.listing-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: flex-start;
-		margin-bottom: 12px;
+	.listing-card-link {
+		display: block;
+		padding: 20px;
+		color: inherit;
+		text-decoration: none;
+		border-radius: 12px;
+		cursor: pointer;
 	}
 
-	.listing-header h3 {
+	.listing-card-link:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: -2px;
+	}
+
+	.listing-card-link h3 {
 		font-size: 18px;
 		font-weight: 600;
 		color: var(--color-foreground);
-		margin: 0;
-	}
-
-	.status-badge {
-		font-size: 12px;
-		font-weight: 600;
-		padding: 4px 10px;
-		border-radius: 12px;
-		text-transform: capitalize;
-	}
-
-	.status-badge.status-available {
-		background: oklch(from var(--color-secondary) l c h / 0.15);
-		color: var(--color-secondary);
-	}
-
-	.status-badge.status-unavailable {
-		background: oklch(from var(--color-quiet) l c h / 0.15);
-		color: var(--color-quiet);
-	}
-
-	.status-badge.status-private {
-		background: oklch(from var(--color-accent) l c h / 0.15);
-		color: var(--color-accent);
+		margin: 0 0 6px;
 	}
 
 	.listing-details {
-		margin-bottom: 16px;
+		margin-bottom: 0;
 	}
 
 	.listing-details p {
@@ -69,89 +52,24 @@
 		font-weight: 500;
 	}
 
-	.listing-error {
-		font-size: 13px;
-		color: var(--color-primary);
-		margin: 0 0 12px 0;
-		padding: 8px 12px;
-		background: oklch(from var(--color-primary) l c h / 0.1);
-		border-radius: 6px;
+	.status-label {
+		display: inline-block;
+		font-size: 12px;
+		font-weight: 600;
+		text-transform: capitalize;
+		margin-bottom: 8px;
 	}
 
-	.listing-actions {
-		display: flex;
-		gap: 12px;
+	.status-label.status-available {
+		color: var(--color-secondary);
 	}
 
-	.listing-actions .status-toggle-button {
-		font-size: 14px;
-		color: var(--color-background);
-		background: var(--color-secondary);
-		border: none;
-		padding: 8px 14px;
-		border-radius: 6px;
-		cursor: pointer;
-		font-weight: 500;
-		transition: background-color 0.2s;
-	}
-
-	.listing-actions .status-toggle-button:hover:not(:disabled) {
-		background: oklch(from var(--color-secondary) calc(l - 0.08) c h);
-	}
-
-	.listing-actions .status-toggle-button:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	.listing-actions .edit-button {
-		font-size: 14px;
-		color: var(--color-accent);
-		text-decoration: none;
-		font-weight: 500;
-		background: none;
-		border: none;
-		padding: 0;
-		cursor: pointer;
-	}
-
-	.listing-actions .edit-button:hover:not(:disabled) {
-		text-decoration: underline;
-	}
-
-	.listing-actions .edit-button:disabled {
+	.status-label.status-unavailable {
 		color: var(--color-quiet);
-		cursor: not-allowed;
 	}
 
-	.listing-actions .status-toggle-button {
-		font-size: 14px;
-		color: var(--color-background);
-		background: var(--color-secondary);
-		border: none;
-		padding: 8px 14px;
-		border-radius: 6px;
-		cursor: pointer;
-		font-weight: 500;
-		transition: background-color 0.2s;
-	}
-
-	.listing-actions .status-toggle-button:hover:not(:disabled) {
-		background: oklch(from var(--color-secondary) calc(l - 0.08) c h);
-	}
-
-	.listing-actions .status-toggle-button:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	.listing-error {
-		font-size: 13px;
-		color: var(--color-primary);
-		margin: 0 0 12px 0;
-		padding: 8px 12px;
-		background: oklch(from var(--color-primary) l c h / 0.1);
-		border-radius: 6px;
+	.status-label.status-private {
+		color: var(--color-accent);
 	}
 
 	.success-message {

--- a/apps/www/src/routes/listings/mine.tsx
+++ b/apps/www/src/routes/listings/mine.tsx
@@ -4,8 +4,6 @@ import Layout from '@/components/Layout'
 import { useSession } from '@/lib/auth-client'
 import { authMiddleware } from '@/middleware/auth'
 import { getStatusClass } from '@/lib/listing-status'
-import { ListingStatus } from '@/lib/validation'
-import { Sentry } from '@/lib/sentry'
 import type { Listing } from '@/data/schema'
 import { getMyListings } from '@/api/listings'
 import '@/routes/listings/mine.css'
@@ -25,91 +23,27 @@ export const Route = createFileRoute('/listings/mine')({
 	},
 })
 
-function getToggleButtonText(isToggling: boolean, status: string): string {
-	if (isToggling) {
-		return 'Updating...'
-	}
-	if (status === ListingStatus.available) {
-		return 'Mark Unavailable'
-	}
-	return 'Mark Available'
-}
-
 function ListingCard(props: { listing: Listing }) {
-	const [isToggling, setIsToggling] = createSignal(false)
-	const [currentStatus, setCurrentStatus] = createSignal(props.listing.status)
-	const [error, setError] = createSignal<string | null>(null)
-
-	const statusClass = () => getStatusClass(currentStatus())
-	const isToggleable = () => currentStatus() !== ListingStatus.private
-
-	async function toggleStatus() {
-		const newStatus =
-			currentStatus() === ListingStatus.available
-				? ListingStatus.unavailable
-				: ListingStatus.available
-		setIsToggling(true)
-		setError(null)
-
-		try {
-			const response = await fetch(`/api/listings/${props.listing.id}`, {
-				method: 'PATCH',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ status: newStatus }),
-			})
-
-			if (!response.ok) {
-				let message = 'Failed to update status'
-				try {
-					const data = await response.json()
-					message = typeof data.error === 'string' ? data.error : message
-				} catch {
-					// Response wasn't JSON
-				}
-				throw new Error(message)
-			}
-
-			setCurrentStatus(newStatus)
-		} catch (err) {
-			Sentry.captureException(err)
-			setError(err instanceof Error ? err.message : 'Failed to update')
-		} finally {
-			setIsToggling(false)
-		}
-	}
-
 	return (
 		<article class="listing-card">
-			<div class="listing-header">
+			<Link
+				to="/listings/$id"
+				params={{ id: String(props.listing.id) }}
+				class="listing-card-link"
+			>
 				<h3>{props.listing.name}</h3>
-				<span class={`status-badge ${statusClass()}`}>{currentStatus()}</span>
-			</div>
-			<div class="listing-details">
-				<p class="listing-location">
-					{props.listing.city}, {props.listing.state}
-				</p>
-				<Show when={props.listing.harvestWindow}>
-					<p class="listing-harvest">Harvest: {props.listing.harvestWindow}</p>
-				</Show>
-			</div>
-			<Show when={error()}>
-				<p class="listing-error">{error()}</p>
-			</Show>
-			<div class="listing-actions">
-				<Show when={isToggleable()}>
-					<button
-						type="button"
-						class="status-toggle-button"
-						onClick={toggleStatus}
-						disabled={isToggling()}
-					>
-						{getToggleButtonText(isToggling(), currentStatus())}
-					</button>
-				</Show>
-				<button type="button" class="edit-button" disabled>
-					Edit
-				</button>
-			</div>
+				<span class={`status-label ${getStatusClass(props.listing.status)}`}>
+					{props.listing.status}
+				</span>
+				<div class="listing-details">
+					<p class="listing-location">
+						{props.listing.city}, {props.listing.state}
+					</p>
+					<Show when={props.listing.harvestWindow}>
+						<p class="listing-harvest">Harvest: {props.listing.harvestWindow}</p>
+					</Show>
+				</div>
+			</Link>
 		</article>
 	)
 }

--- a/apps/www/tests/e2e/listing-detail.test.ts
+++ b/apps/www/tests/e2e/listing-detail.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './helpers/fixtures'
 import { createTestListing } from './helpers/test-db'
+import { loginViaUI } from './helpers/login'
 
 test.describe('Listing Detail Page', () => {
 	// Run serially to avoid SQLite lock conflicts from parallel DB writes
@@ -67,5 +68,19 @@ test.describe('Listing Detail Page', () => {
 		await expect(homeLink).toBeVisible()
 		await homeLink.click()
 		await expect(page).toHaveURL('/')
+	})
+
+	test('owner can see their own private listing', async ({ page, testUser }) => {
+		const privateListing = await createTestListing(testUser.id, {
+			status: 'private',
+		})
+
+		await loginViaUI(page, testUser)
+		await page.goto(`/listings/${privateListing.id}`)
+
+		await expect(page.getByRole('heading', { level: 1 })).toHaveText(
+			privateListing.type
+		)
+		await expect(page.getByRole('radio', { name: /^Private / })).toBeChecked()
 	})
 })


### PR DESCRIPTION
## Summary
- Add session-aware `getListingForViewer` server function so owners always see their own listings (including private ones)
- Move the visibility editing from a toggle button on the my-garden overview to a radio group on the `/listings/$id` detail page (owner-only)
- Simplify My Garden cards to read-only links with a status label
- Update E2E tests to exercise radio controls on the detail page and verify owners can view their own private listings

## Test plan
- [x] `/listings/mine` cards are read-only links with status label, no radio or edit button
- [x] `/listings/$id` as owner shows radio group; changes persist
- [x] `/listings/$id` as non-owner shows static badge, no radios
- [x] Owner sets listing to Private on detail page → still sees it
- [x] Non-owner visits private listing URL → "Not Found"
- [x] `bin/quality-gate.sh` passes (typecheck, lint, tests, formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)