### PR TITLE
feat(nav): add shared SiteHeader with breadcrumbs and auth nav

### DIFF
--- a/apps/www/src/components/SiteHeader.css
+++ b/apps/www/src/components/SiteHeader.css
@@ -1,0 +1,62 @@
+@layer components {
+	.site-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 16px 20px;
+	}
+
+	.site-header .breadcrumb ol {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		font-size: 14px;
+		color: var(--color-quiet);
+	}
+
+	.site-header .breadcrumb li + li::before {
+		content: '/';
+		margin-right: 8px;
+		color: oklch(from var(--color-quiet) l calc(c * 0.5) h);
+	}
+
+	.site-header .breadcrumb a {
+		color: var(--color-primary);
+		text-decoration: none;
+	}
+
+	.site-header .breadcrumb a:hover {
+		text-decoration: underline;
+	}
+
+	.site-header .header-nav {
+		display: flex;
+		align-items: center;
+		gap: 20px;
+	}
+
+	.site-header .nav-link {
+		font-size: 14px;
+		font-weight: 500;
+		color: var(--color-quiet);
+		text-decoration: none;
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		transition: color 0.2s;
+	}
+
+	.site-header .nav-link:hover {
+		color: var(--color-foreground);
+	}
+
+	.site-header .nav-link.sign-out {
+		color: var(--color-primary);
+	}
+}

--- a/apps/www/src/components/SiteHeader.tsx
+++ b/apps/www/src/components/SiteHeader.tsx
@@ -1,0 +1,52 @@
+import { Link } from '@tanstack/solid-router'
+import { For, Show } from 'solid-js'
+import { useSession, signOut } from '@/lib/auth-client'
+import './SiteHeader.css'
+
+export type Breadcrumb = { label: string; to?: string }
+
+/** Shared page header with breadcrumbs and auth navigation. */
+export default function SiteHeader(props: { breadcrumbs?: Breadcrumb[] }) {
+	const session = useSession()
+
+	return (
+		<header class="site-header">
+			<nav class="breadcrumb" aria-label="Breadcrumb">
+				<ol>
+					<li>
+						<Link to="/">Home</Link>
+					</li>
+					<For each={props.breadcrumbs}>
+						{(crumb) => (
+							<li>
+								<Show
+									when={crumb.to}
+									fallback={<span aria-current="page">{crumb.label}</span>}
+								>
+									{(to) => <Link to={to()}>{crumb.label}</Link>}
+								</Show>
+							</li>
+						)}
+					</For>
+				</ol>
+			</nav>
+			<nav class="header-nav" aria-label="Account">
+				<Show
+					when={session().data?.user}
+					fallback={
+						<Link to="/login" class="nav-link">
+							Sign In
+						</Link>
+					}
+				>
+					<Link to="/listings/mine" class="nav-link">
+						My Garden
+					</Link>
+					<button type="button" class="nav-link sign-out" onClick={() => signOut()}>
+						Sign Out
+					</button>
+				</Show>
+			</nav>
+		</header>
+	)
+}

--- a/apps/www/src/routes/listings.$id.tsx
+++ b/apps/www/src/routes/listings.$id.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/solid-router'
 import { createSignal, For, onCleanup, Show } from 'solid-js'
 import Layout from '@/components/Layout'
+import SiteHeader from '@/components/SiteHeader'
 import InquiryForm from '@/components/InquiryForm'
 import { useSession } from '@/lib/auth-client'
 import {
@@ -131,6 +132,7 @@ function ListingDetailPage() {
 			when={listing()}
 			fallback={
 				<Layout title="Listing Not Found - Pick My Fruit">
+					<SiteHeader breadcrumbs={[{ label: 'Listing' }]} />
 					<main class="listing-page">
 						<div class="listing-not-found">
 							<h1>Listing Not Found</h1>
@@ -145,15 +147,8 @@ function ListingDetailPage() {
 		>
 			{(l) => (
 				<Layout title={`${l().name} - Pick My Fruit`}>
+					<SiteHeader breadcrumbs={[{ label: l().name }]} />
 					<main class="listing-page">
-						<nav class="breadcrumb" aria-label="Breadcrumb">
-							<Link to="/">Home</Link>
-							<span class="separator" aria-hidden="true">
-								/
-							</span>
-							<span aria-current="page">Listing</span>
-						</nav>
-
 						<article class="listing-detail">
 							<header class="listing-detail-header">
 								<h1>{l().type}</h1>

--- a/apps/www/src/routes/listings.css
+++ b/apps/www/src/routes/listings.css
@@ -5,28 +5,6 @@
 		padding: 40px 20px;
 	}
 
-	.breadcrumb {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		font-size: 14px;
-		color: var(--color-quiet);
-		margin-bottom: 24px;
-	}
-
-	.breadcrumb a {
-		color: var(--color-primary);
-		text-decoration: none;
-	}
-
-	.breadcrumb a:hover {
-		text-decoration: underline;
-	}
-
-	.breadcrumb .separator {
-		color: oklch(from var(--color-quiet) l calc(c * 0.5) h);
-	}
-
 	.listing-detail {
 		background: var(--color-background);
 		border: 1px solid oklch(from var(--color-quiet) l calc(c * 0.2) h);

--- a/apps/www/src/routes/listings/mine.tsx
+++ b/apps/www/src/routes/listings/mine.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/solid-router'
 import { createSignal, For, Show } from 'solid-js'
 import Layout from '@/components/Layout'
+import SiteHeader from '@/components/SiteHeader'
 import { useSession } from '@/lib/auth-client'
 import { authMiddleware } from '@/middleware/auth'
 import { getStatusClass } from '@/lib/listing-status'
@@ -12,6 +13,7 @@ export const Route = createFileRoute('/listings/mine')({
 	loader: () => getMyListings(),
 	pendingComponent: () => (
 		<Layout title="My Garden - Pick My Fruit">
+			<SiteHeader breadcrumbs={[{ label: 'My Garden' }]} />
 			<main class="page-container">
 				<p>Loading…</p>
 			</main>
@@ -70,6 +72,7 @@ function MyGardenPage() {
 
 	return (
 		<Layout title="My Garden - Pick My Fruit">
+			<SiteHeader breadcrumbs={[{ label: 'My Garden' }]} />
 			<main class="page-container">
 				<header class="page-header">
 					<h1>My Garden</h1>

--- a/apps/www/src/routes/listings/new.tsx
+++ b/apps/www/src/routes/listings/new.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/solid-router'
 import Layout from '@/components/Layout'
+import SiteHeader from '@/components/SiteHeader'
 import ListingForm from '@/components/ListingForm'
 import { authMiddleware } from '@/middleware/auth'
 import '@/routes/listings/new.css'
@@ -14,6 +15,12 @@ export const Route = createFileRoute('/listings/new')({
 function NewListingPage() {
 	return (
 		<Layout title="List My Fruit Tree - Pick My Fruit">
+			<SiteHeader
+				breadcrumbs={[
+					{ label: 'My Garden', to: '/listings/mine' },
+					{ label: 'New Listing' },
+				]}
+			/>
 			<main class="page-container">
 				<header class="page-header">
 					<h1>List Your Fruit Tree</h1>

--- a/apps/www/src/routes/login.css
+++ b/apps/www/src/routes/login.css
@@ -1,6 +1,6 @@
 @layer page {
 	.login-page {
-		min-height: 100vh;
+		flex: 1;
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -11,25 +11,6 @@
 	.login-container {
 		width: 100%;
 		max-width: 400px;
-	}
-
-	.login-header {
-		text-align: center;
-		margin-bottom: 40px;
-	}
-
-	.login-header .logo {
-		display: inline-flex;
-		align-items: center;
-		gap: 8px;
-		font-size: 20px;
-		font-weight: 600;
-		color: var(--color-foreground);
-		text-decoration: none;
-	}
-
-	.login-header .logo-icon {
-		font-size: 28px;
 	}
 
 	.login-content {

--- a/apps/www/src/routes/login.tsx
+++ b/apps/www/src/routes/login.tsx
@@ -1,6 +1,5 @@
 import {
 	createFileRoute,
-	Link,
 	redirect,
 	useNavigate,
 	useSearch,
@@ -8,6 +7,7 @@ import {
 import { createSignal, Show } from 'solid-js'
 import { z } from 'zod'
 import Layout from '@/components/Layout'
+import SiteHeader from '@/components/SiteHeader'
 import MagicLinkWaiting from '@/components/MagicLinkWaiting'
 import { authClient } from '@/lib/auth-client'
 import './login.css'
@@ -66,15 +66,9 @@ function LoginPage() {
 
 	return (
 		<Layout title="Sign In - Pick My Fruit">
+			<SiteHeader breadcrumbs={[{ label: 'Sign In' }]} />
 			<main class="login-page">
 				<div class="login-container">
-					<header class="login-header">
-						<Link to="/" class="logo">
-							<span class="logo-icon">🍑</span>
-							<span class="logo-text">Pick My Fruit</span>
-						</Link>
-					</header>
-
 					<Show
 						when={!emailSent()}
 						fallback={

--- a/docs/_now-next-later.md
+++ b/docs/_now-next-later.md
@@ -167,6 +167,7 @@
 - **Rate-limit magic link resend buttons**: Add debounce/cooldown to "Resend email" buttons on login page and listing form to prevent abuse and avoid hitting Resend API rate limits.
 - **Server-side pending listings**: Store unconfirmed listings and user state in the database instead of sessionStorage. This preserves form data if user opens magic link in a different browser/tab. Add `status: 'pending_verification' | 'active'` to listings and clean up unverified listings after 24 hours.
 - **Owner view of private listings**: Allow owners to view their own private listings on the detail page. Pass session context through the loader so `getPublicListingById` can include private listings owned by the requesting user. (flagged during listing-status review)
+- **Post-sign-out navigation**: After calling `signOut()`, navigate to home page. Pre-existing in both home page and SiteHeader component. Relevant files: `SiteHeader.tsx`, `index.tsx`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a reusable `SiteHeader` component with breadcrumb navigation and auth links (My Garden / Sign In / Sign Out)
- Applied to listing detail, My Garden, new listing, and login pages for consistent navigation
- Uses semantic `<ol>` breadcrumbs with CSS-generated separators per WAI-ARIA pattern
- Removes standalone breadcrumb from listing detail page and logo header from login page (both replaced by SiteHeader)

## Test Plan

- [x] Verify breadcrumbs render correctly on each page: listing detail, My Garden, new listing, login
- [x] Verify "Sign In" shows when logged out; "My Garden" + "Sign Out" show when logged in
- [x] Verify login page still centers properly with SiteHeader above it
- [x] Verify listing detail breadcrumb shows the listing name (not generic "Listing")
- [x] Verify home page is unchanged (keeps its own logo-based header)

## Review Notes

Self-reviewed via deliver skill.
- Deferred post-sign-out navigation (navigate to home after sign-out) to Later — pre-existing in both home page and new SiteHeader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)