### PR TITLE
fix(auth): fix session sync

### DIFF
--- a/apps/www/src/components/InquiryForm.tsx
+++ b/apps/www/src/components/InquiryForm.tsx
@@ -1,5 +1,6 @@
 import { createEffect, createSignal, on, Show } from 'solid-js'
-import { authClient, useSession } from '@/lib/auth-client'
+import { useRouteContext } from '@tanstack/solid-router'
+import { authClient } from '@/lib/auth-client'
 import { submitInquiry as submitInquiryFn } from '@/api/inquiries'
 import MagicLinkWaiting from '@/components/MagicLinkWaiting'
 import '@/components/InquiryForm.css'
@@ -20,14 +21,14 @@ type FormState =
 const PENDING_INQUIRY_KEY = 'pendingInquiry'
 
 export default function InquiryForm(props: InquiryFormProps) {
-	const session = useSession()
+	const context = useRouteContext({ from: '__root__' })
 	const [formState, setFormState] = createSignal<FormState>('initial')
 	const [email, setEmail] = createSignal('')
 	const [note, setNote] = createSignal('')
 	const [error, setError] = createSignal<string | null>(null)
 	const [emailSent, setEmailSent] = createSignal(true)
 
-	const isAuthenticated = () => Boolean(session().data?.user)
+	const isAuthenticated = () => Boolean(context().session?.user)
 
 	async function submitInquiry() {
 		setFormState('submitting')
@@ -100,7 +101,7 @@ export default function InquiryForm(props: InquiryFormProps) {
 	let hasAutoSubmitted = false
 	createEffect(
 		on(
-			() => session().data?.user,
+			() => context().session?.user,
 			(user) => {
 				if (!user || hasAutoSubmitted || typeof window === 'undefined') return
 

--- a/apps/www/src/components/ListingForm.tsx
+++ b/apps/www/src/components/ListingForm.tsx
@@ -1,7 +1,6 @@
 import { createSignal, Show, For } from 'solid-js'
-import { Link } from '@tanstack/solid-router'
+import { Link, useRouteContext } from '@tanstack/solid-router'
 import { listingFormSchema, fruitTypes } from '@/lib/validation'
-import { useSession } from '@/lib/auth-client'
 import FormField, { capitalize } from '@/components/FormField'
 import '@/components/ListingForm.css'
 
@@ -10,7 +9,7 @@ interface FieldErrors {
 }
 
 export default function ListingForm() {
-	const session = useSession()
+	const context = useRouteContext({ from: '__root__' })
 	const [isSubmitting, setIsSubmitting] = createSignal(false)
 	const [submitError, setSubmitError] = createSignal<string | null>(null)
 	const [isSuccess, setIsSuccess] = createSignal(false)
@@ -85,7 +84,7 @@ export default function ListingForm() {
 					<div class="form-message error">{submitError()}</div>
 				</Show>
 
-				<Show when={session().data?.user}>
+				<Show when={context().session?.user}>
 					{(user) => (
 						<p class="form-identity">
 							Posting as {user().name} ({user().email})

--- a/apps/www/src/components/MagicLinkWaiting.tsx
+++ b/apps/www/src/components/MagicLinkWaiting.tsx
@@ -6,7 +6,7 @@ interface MagicLinkWaitingProps {
 	email: string
 	callbackURL: string
 	onCancel: () => void
-	onVerified: () => void
+	onVerified: () => void | Promise<void>
 }
 
 // Refactoring signal: if this component gains 5+ state signals, retry logic,
@@ -43,7 +43,7 @@ export default function MagicLinkWaiting(props: MagicLinkWaitingProps) {
 			}
 
 			// Verification successful
-			props.onVerified()
+			await props.onVerified()
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to verify token')
 		} finally {

--- a/apps/www/src/components/SiteHeader.tsx
+++ b/apps/www/src/components/SiteHeader.tsx
@@ -1,13 +1,25 @@
-import { Link } from '@tanstack/solid-router'
+import {
+	Link,
+	useNavigate,
+	useRouteContext,
+	useRouter,
+} from '@tanstack/solid-router'
 import { For, Show } from 'solid-js'
-import { useSession, signOut } from '@/lib/auth-client'
+import { performSignOut } from '@/lib/auth-client'
 import './SiteHeader.css'
 
 export type Breadcrumb = { label: string; to?: string }
 
 /** Shared page header with breadcrumbs and auth navigation. */
 export default function SiteHeader(props: { breadcrumbs?: Breadcrumb[] }) {
-	const session = useSession()
+	const router = useRouter()
+	const navigate = useNavigate()
+	const context = useRouteContext({ from: '__root__' })
+
+	async function handleSignOut() {
+		await performSignOut(router)
+		navigate({ to: '/', replace: true })
+	}
 
 	return (
 		<header class="site-header">
@@ -32,7 +44,7 @@ export default function SiteHeader(props: { breadcrumbs?: Breadcrumb[] }) {
 			</nav>
 			<nav class="header-nav" aria-label="Account">
 				<Show
-					when={session().data?.user}
+					when={context().session?.user}
 					fallback={
 						<Link to="/login" class="nav-link">
 							Sign In
@@ -42,7 +54,7 @@ export default function SiteHeader(props: { breadcrumbs?: Breadcrumb[] }) {
 					<Link to="/listings/mine" class="nav-link">
 						My Garden
 					</Link>
-					<button type="button" class="nav-link sign-out" onClick={() => signOut()}>
+					<button type="button" class="nav-link sign-out" onClick={handleSignOut}>
 						Sign Out
 					</button>
 				</Show>

--- a/apps/www/src/lib/auth-client.ts
+++ b/apps/www/src/lib/auth-client.ts
@@ -1,10 +1,24 @@
 import { createAuthClient } from 'better-auth/solid'
 import { magicLinkClient } from 'better-auth/client/plugins'
+import { Sentry } from './sentry'
 
 export const authClient = createAuthClient({
 	plugins: [magicLinkClient()],
 })
 
-// Export commonly used functions and hooks
-export const { useSession, signOut } = authClient
+// Session state: use useRouteContext({ from: '__root__' }).session in components.
+// Do not re-export useSession — it bypasses route context and causes hydration bugs.
+export const { signOut } = authClient
 export const { magicLink } = authClient
+
+/** Signs out and refreshes route data so UI reflects logged-out state. */
+export async function performSignOut(router: {
+	invalidate: () => Promise<void>
+}): Promise<void> {
+	try {
+		await signOut()
+	} catch (error) {
+		Sentry.captureException(error)
+	}
+	await router.invalidate()
+}

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -17,8 +17,8 @@ import '../styles/focus.css'
 import '../styles/surfaces.css'
 
 export const Route = createRootRoute({
-	beforeLoad: async ({ context }) => {
-		const session = await getSession(context)
+	beforeLoad: async () => {
+		const session = await getSession()
 		return { session }
 	},
 	head: () => ({

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -1,8 +1,13 @@
-import { createFileRoute, Link } from '@tanstack/solid-router'
+import {
+	createFileRoute,
+	Link,
+	useRouteContext,
+	useRouter,
+} from '@tanstack/solid-router'
 import { For, Show } from 'solid-js'
 import Layout from '@/components/Layout'
 import { getAvailableListings } from '@/api/listings'
-import { useSession, signOut } from '@/lib/auth-client'
+import { performSignOut } from '@/lib/auth-client'
 import '@/routes/index.css'
 
 export const Route = createFileRoute('/')({
@@ -12,7 +17,12 @@ export const Route = createFileRoute('/')({
 
 function HomePage() {
 	const listings = Route.useLoaderData()
-	const session = useSession()
+	const router = useRouter()
+	const context = useRouteContext({ from: '__root__' })
+
+	async function handleSignOut() {
+		await performSignOut(router)
+	}
 
 	return (
 		<Layout title="Pick My Fruit - Turn your backyard abundance into community food">
@@ -24,7 +34,7 @@ function HomePage() {
 					</div>
 					<nav class="header-nav">
 						<Show
-							when={session().data?.user}
+							when={context().session?.user}
 							fallback={
 								<Link to="/login" class="nav-link">
 									Sign In
@@ -34,11 +44,7 @@ function HomePage() {
 							<Link to="/listings/mine" class="nav-link">
 								My Garden
 							</Link>
-							<button
-								type="button"
-								class="nav-link sign-out"
-								onClick={() => signOut()}
-							>
+							<button type="button" class="nav-link sign-out" onClick={handleSignOut}>
 								Sign Out
 							</button>
 						</Show>

--- a/apps/www/src/routes/listings.$id.tsx
+++ b/apps/www/src/routes/listings.$id.tsx
@@ -1,9 +1,8 @@
-import { createFileRoute, Link } from '@tanstack/solid-router'
+import { createFileRoute, Link, useRouteContext } from '@tanstack/solid-router'
 import { createSignal, For, onCleanup, Show } from 'solid-js'
 import Layout from '@/components/Layout'
 import SiteHeader from '@/components/SiteHeader'
 import InquiryForm from '@/components/InquiryForm'
-import { useSession } from '@/lib/auth-client'
 import {
 	getStatusClass,
 	VISIBILITY_OPTIONS,
@@ -117,11 +116,11 @@ function OwnerControls(props: {
 
 function ListingDetailPage() {
 	const data = Route.useLoaderData()
-	const session = useSession()
+	const context = useRouteContext({ from: '__root__' })
 	const params = Route.useParams()
 
 	const listing = () => data() as PublicListing | undefined
-	const isOwner = () => session().data?.user?.id === listing()?.userId
+	const isOwner = () => context().session?.user?.id === listing()?.userId
 	const canInquire = () => {
 		const l = listing()
 		return l && l.status === ListingStatus.available && !isOwner()

--- a/apps/www/src/routes/listings/mine.tsx
+++ b/apps/www/src/routes/listings/mine.tsx
@@ -1,8 +1,7 @@
-import { createFileRoute, Link } from '@tanstack/solid-router'
+import { createFileRoute, Link, useRouteContext } from '@tanstack/solid-router'
 import { createSignal, For, Show } from 'solid-js'
 import Layout from '@/components/Layout'
 import SiteHeader from '@/components/SiteHeader'
-import { useSession } from '@/lib/auth-client'
 import { authMiddleware } from '@/middleware/auth'
 import { getStatusClass } from '@/lib/listing-status'
 import type { Listing } from '@/data/schema'
@@ -64,10 +63,10 @@ function EmptyState() {
 
 function MyGardenPage() {
 	const listings = Route.useLoaderData()
-	const session = useSession()
+	const context = useRouteContext({ from: '__root__' })
 	const search = Route.useSearch()
 	const [showMarkedMessage, setShowMarkedMessage] = createSignal(
-		() => (search as () => { marked?: string })()?.marked === 'unavailable'
+		(search as () => { marked?: string })()?.marked === 'unavailable'
 	)
 
 	return (
@@ -76,19 +75,19 @@ function MyGardenPage() {
 			<main class="page-container">
 				<header class="page-header">
 					<h1>My Garden</h1>
-					<Show when={session().data?.user}>
-						<p>Welcome back, {session().data?.user?.name || 'friend'}!</p>
+					<Show when={context().session?.user}>
+						{(user) => <p>Welcome back, {user().name || 'friend'}!</p>}
 					</Show>
 				</header>
 
-				<Show when={showMarkedMessage()()}>
+				<Show when={showMarkedMessage()}>
 					<div class="success-message">
 						Listing marked as unavailable. Gleaners won't be able to contact you about
 						this listing.
 						<button
 							type="button"
 							class="dismiss-button"
-							onClick={() => setShowMarkedMessage(() => () => false)}
+							onClick={() => setShowMarkedMessage(false)}
 						>
 							Dismiss
 						</button>

--- a/apps/www/src/routes/login.tsx
+++ b/apps/www/src/routes/login.tsx
@@ -2,6 +2,7 @@ import {
 	createFileRoute,
 	redirect,
 	useNavigate,
+	useRouter,
 	useSearch,
 } from '@tanstack/solid-router'
 import { createSignal, Show } from 'solid-js'
@@ -32,6 +33,7 @@ export const Route = createFileRoute('/login')({
 })
 
 function LoginPage() {
+	const router = useRouter()
 	const navigate = useNavigate()
 	const search = useSearch({ from: '/login' })
 	const returnTo = () => search().returnTo || '/listings/mine'
@@ -79,13 +81,29 @@ function LoginPage() {
 									setEmailSent(false)
 									setEmail('')
 								}}
-								onVerified={() => navigate({ to: returnTo() })}
+								onVerified={async () => {
+									await router.invalidate()
+									navigate({ to: returnTo() })
+								}}
 							/>
 						}
 					>
 						<div class="login-content">
 							<h1>Sign in to Pick My Fruit</h1>
-							<p>Enter your email and we'll send you a sign-in link.</p>
+							<Show
+								when={search().returnTo}
+								fallback={<p>Enter your email and we'll send you a sign-in link.</p>}
+							>
+								<p>
+									Sign in to continue to{' '}
+									{returnTo() === '/listings/new'
+										? 'list your fruit tree'
+										: returnTo() === '/listings/mine'
+											? 'your garden'
+											: 'your destination'}
+									.
+								</p>
+							</Show>
 
 							<form class="login-form" onSubmit={handleSubmit}>
 								<Show when={error()}>

--- a/apps/www/tests/e2e/auth.test.ts
+++ b/apps/www/tests/e2e/auth.test.ts
@@ -1,49 +1,44 @@
+import type { Page } from '@playwright/test'
 import { test, expect } from './helpers/fixtures'
-import { getMagicLinkToken } from './helpers/test-db'
+import { type TestUser, getMagicLinkToken } from './helpers/test-db'
+
+/** Signs in via magic link and waits for redirect to /listings/mine. */
+async function signIn(page: Page, testUser: TestUser) {
+	await page.goto('/login')
+	await expect(
+		page.getByRole('heading', { name: 'Sign in to Pick My Fruit' })
+	).toBeVisible()
+
+	const emailInput = page.locator('input#email')
+	await expect(emailInput).toBeVisible()
+	await emailInput.pressSequentially(testUser.email, { delay: 30 })
+	await expect(emailInput).toHaveValue(testUser.email)
+
+	const responsePromise = page.waitForResponse((resp) =>
+		resp.url().includes('/api/auth/sign-in/magic-link')
+	)
+	await page.locator('button.submit-button').click()
+	await responsePromise
+
+	await expect(
+		page.getByRole('heading', { name: 'Check your email' })
+	).toBeVisible({ timeout: 10000 })
+
+	const token = await getMagicLinkToken(testUser.email)
+	await page
+		.locator('input#magic-link-token')
+		.pressSequentially(token, { delay: 20 })
+	await page.getByRole('button', { name: 'Verify' }).click()
+
+	await expect(page).toHaveURL('/listings/mine')
+}
 
 test.describe('Authentication', () => {
 	// Run serially to avoid SQLite lock conflicts from parallel DB writes
 	test.describe.configure({ mode: 'serial' })
 
 	test('magic link sign-in flow', async ({ page, testUser }) => {
-		await page.goto('/login')
-
-		// Wait for login page to fully load
-		await expect(
-			page.getByRole('heading', { name: 'Sign in to Pick My Fruit' })
-		).toBeVisible()
-
-		// Wait for form to be ready
-		const emailInput = page.locator('input#email')
-		await expect(emailInput).toBeVisible()
-
-		// Type email using pressSequentially which properly triggers input events
-		await emailInput.pressSequentially(testUser.email, { delay: 30 })
-
-		// Verify the email was entered correctly
-		await expect(emailInput).toHaveValue(testUser.email)
-
-		// Submit the form and wait for network response
-		const submitButton = page.locator('button.submit-button')
-		const responsePromise = page.waitForResponse((resp) =>
-			resp.url().includes('/api/auth/sign-in/magic-link')
-		)
-		await submitButton.click()
-		await responsePromise
-
-		// Wait for "Check your email" view
-		await expect(
-			page.getByRole('heading', { name: 'Check your email' })
-		).toBeVisible({ timeout: 10000 })
-
-		// Get token from database and verify
-		const token = await getMagicLinkToken(testUser.email)
-		const tokenInput = page.locator('input#magic-link-token')
-		await tokenInput.pressSequentially(token, { delay: 20 })
-		await page.getByRole('button', { name: 'Verify' }).click()
-
-		// Should redirect to listings
-		await expect(page).toHaveURL('/listings/mine')
+		await signIn(page, testUser)
 	})
 
 	test('protected route redirects to login', async ({ page }) => {
@@ -93,5 +88,26 @@ test.describe('Authentication', () => {
 
 		// Should show error
 		await expect(page.locator('.token-error')).toBeVisible({ timeout: 10000 })
+	})
+
+	test('session survives page refresh', async ({ page, testUser }) => {
+		await signIn(page, testUser)
+
+		await expect(page.getByRole('link', { name: 'My Garden' })).toBeVisible()
+
+		await page.reload()
+
+		await expect(page.getByRole('link', { name: 'My Garden' })).toBeVisible()
+		await expect(page.getByRole('link', { name: 'Sign In' })).not.toBeVisible()
+	})
+
+	test('sign-out redirects from protected page', async ({ page, testUser }) => {
+		await signIn(page, testUser)
+
+		await page.getByRole('button', { name: 'Sign Out' }).click()
+
+		await expect(page).toHaveURL('/')
+		await expect(page.getByRole('link', { name: 'Sign In' })).toBeVisible()
+		await expect(page.getByRole('link', { name: 'My Garden' })).not.toBeVisible()
 	})
 })


### PR DESCRIPTION
## Summary

- **Fix session lost on page refresh**: Replaced `createIsomorphicFn` with `createServerFn` in `session.ts`. The isomorphic approach compiled separate client/server handlers at build time — after SSR hydration the client handler didn't share state with the hydrated route context. Session is now always fetched server-side (directly during SSR, via RPC during client navigation).
- **Fix sign-out not redirecting**: Sign-out on protected pages now calls `performSignOut()` (shared utility) + `navigate('/')`, so users leave the page instead of seeing stale content.
- **Fix header stale after sign-in**: After magic link verification, `router.invalidate()` forces a session re-fetch before navigating, so the header immediately reflects auth state.
- **Unify session source**: Replaced Better Auth's `useSession()` with `useRouteContext({ from: '__root__' })` across all components. Removed `useSession` export to prevent regression. Extracted `performSignOut` to `auth-client.ts` for consistent sign-out behavior.
- **Minor fixes**: Fixed `showMarkedMessage` double-invocation bug in mine.tsx; added contextual login message when redirected; updated roadmap.

## Test Plan

- [x] E2E: Session survives page refresh (sign in → reload → header retains auth state)
- [x] E2E: Sign-out redirects from protected page (sign in → /listings/mine → Sign Out → home with "Sign In")
- [x] E2E: Magic link sign-in flow (existing)
- [ ] Manual: View own private listing after sign-in → owner controls visible
- [ ] Manual: `/login?returnTo=/listings/new` → "Sign in to continue to list your fruit tree"

## Review Notes

Self-reviewed with 5 parallel agents (Architect, User-Advocate, Adversary, Standards, Operator). Findings addressed:
- Extracted shared `performSignOut` utility (was duplicated with inconsistent error handling)
- Removed unused `useSession` export (maintenance trap)
- Added comment explaining silent-error-as-null tradeoff in session.ts
- Used idiomatic `<Show>` callback in mine.tsx

Deferred to roadmap:
- Sign-out loading state / double-click guard
- Deduplicate auth nav (home page vs SiteHeader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)