### PR TITLE
fix(e2e): wait for hydration before interacting with listing status radios

### DIFF
--- a/apps/www/tests/e2e/listing-status.test.ts
+++ b/apps/www/tests/e2e/listing-status.test.ts
@@ -12,6 +12,7 @@ test.describe('Listing Status', () => {
 	}) => {
 		await loginViaUI(page, testUser)
 		await page.goto(`/listings/${testListing.id}`)
+		await page.waitForLoadState('networkidle')
 
 		const availableRadio = page.getByRole('radio', { name: /^Available / })
 		const unavailableRadio = page.getByRole('radio', { name: /^Unavailable / })
@@ -41,6 +42,7 @@ test.describe('Listing Status', () => {
 
 		await loginViaUI(page, testUser)
 		await page.goto(`/listings/${listing.id}`)
+		await page.waitForLoadState('networkidle')
 
 		const availableRadio = page.getByRole('radio', { name: /^Available / })
 		const unavailableRadio = page.getByRole('radio', { name: /^Unavailable / })
@@ -65,6 +67,7 @@ test.describe('Listing Status', () => {
 
 		await loginViaUI(page, testUser)
 		await page.goto(`/listings/${listing.id}`)
+		await page.waitForLoadState('networkidle')
 
 		const privateRadio = page.getByRole('radio', { name: /^Private / })
 


### PR DESCRIPTION
## Summary
- Fix flaky E2E listing-status tests that time out waiting for PATCH responses
- Root cause: TanStack Router code-splits route components, so `page.goto` resolves while component JS is still loading. SSR-rendered radio buttons are in the DOM but Solid.js `onChange` handlers aren't attached yet — clicking natively checks the radio but no PATCH fires
- Fix: add `page.waitForLoadState('networkidle')` after navigating to listing detail pages in the three tests that interact with radio buttons

## Test Plan
- [x] All 4 listing-status E2E tests pass consistently (3/3 consecutive local runs)
- [x] Full 17-test E2E suite passes
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)