### PR TITLE
feat(security): add timestamp expiration to HMAC-signed URLs

### DIFF
--- a/apps/www/src/lib/email-templates.ts
+++ b/apps/www/src/lib/email-templates.ts
@@ -66,6 +66,7 @@ export function buildInquiryEmailHtml(data: InquiryEmailData): string {
   <p style="color: #666; font-size: 14px;">
     All done with this listing?
     <a href="${unavailableUrl}" style="color: #4a7c23;">Mark as unavailable</a>
+    (link expires in 7 days)
   </p>
 </body>
 </html>`

--- a/apps/www/src/lib/hmac.ts
+++ b/apps/www/src/lib/hmac.ts
@@ -1,34 +1,57 @@
 import { createHmac, timingSafeEqual, randomUUID } from 'crypto'
 
-const HMAC_SECRET = process.env.HMAC_SECRET || 'dev-secret-change-in-prod'
+const secret = process.env.HMAC_SECRET
+if (!secret && process.env.NODE_ENV === 'production') {
+	throw new Error('HMAC_SECRET must be set in production')
+}
+if (!secret) {
+	console.warn('[hmac] HMAC_SECRET not set, using insecure development default')
+}
+const HMAC_SECRET = secret || 'dev-secret-change-in-prod'
 
-export function signUrl(listingId: number): { nonce: string; sig: string } {
+/** Signed URLs expire after 7 days. */
+export const SIGNATURE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+/** Signs a listing ID with a nonce and timestamp for URL construction. */
+export function signUrl(listingId: number): {
+	nonce: string
+	ts: number
+	sig: string
+} {
 	const nonce = randomUUID()
-	const message = `${listingId}:${nonce}`
+	const ts = Date.now()
+	const message = `${listingId}:${nonce}:${ts}`
 	const sig = createHmac('sha256', HMAC_SECRET).update(message).digest('hex')
-	return { nonce, sig }
+	return { nonce, ts, sig }
 }
 
+/** Verifies an HMAC signature, rejecting expired or tampered URLs. */
 export function verifySignature(
 	listingId: number,
 	nonce: string,
-	sig: string
+	ts: number,
+	sig: string,
+	now: number = Date.now()
 ): boolean {
-	const message = `${listingId}:${nonce}`
+	const age = now - ts
+	if (age < 0 || age > SIGNATURE_MAX_AGE_MS) {
+		return false
+	}
+	const message = `${listingId}:${nonce}:${ts}`
 	const expected = createHmac('sha256', HMAC_SECRET)
 		.update(message)
 		.digest('hex')
-	// Timing-safe comparison
 	if (sig.length !== expected.length) {
 		return false
 	}
 	return timingSafeEqual(Buffer.from(sig), Buffer.from(expected))
 }
 
+/** Builds a signed "mark unavailable" URL for email links. */
 export function buildUnavailableUrl(
 	baseUrl: string,
 	listingId: number
 ): string {
-	const { nonce, sig } = signUrl(listingId)
-	return `${baseUrl}/api/listings/${listingId}/unavailable?nonce=${nonce}&sig=${sig}`
+	const { nonce, ts, sig } = signUrl(listingId)
+	return `${baseUrl}/api/listings/${listingId}/unavailable?nonce=${nonce}&ts=${ts}&sig=${sig}`
 }

--- a/apps/www/src/routes/api/listings.$id.unavailable.ts
+++ b/apps/www/src/routes/api/listings.$id.unavailable.ts
@@ -1,5 +1,7 @@
 import { createFileRoute, redirect } from '@tanstack/solid-router'
 import { z } from 'zod'
+import { Sentry } from '@/lib/sentry'
+import { SIGNATURE_MAX_AGE_MS } from '@/lib/hmac'
 
 const paramsSchema = z.object({
 	id: z.coerce.number().int().positive(),
@@ -7,6 +9,7 @@ const paramsSchema = z.object({
 
 const querySchema = z.object({
 	nonce: z.string().min(1),
+	ts: z.coerce.number().int().positive(),
 	sig: z.string().min(1),
 })
 
@@ -14,49 +17,77 @@ export const Route = createFileRoute('/api/listings/$id/unavailable')({
 	server: {
 		handlers: {
 			async GET({ request, params }) {
-				// Dynamic imports to avoid bundling server-only code for browser
 				const { verifySignature } = await import('@/lib/hmac')
 				const { markListingUnavailable } = await import('@/data/queries')
 
-				// Validate params
 				const parsedParams = paramsSchema.safeParse(params)
 				if (!parsedParams.success) {
 					return Response.json({ error: 'Invalid listing ID' }, { status: 400 })
 				}
 
-				// Parse query params
 				const url = new URL(request.url)
 				const parsedQuery = querySchema.safeParse({
 					nonce: url.searchParams.get('nonce'),
+					ts: url.searchParams.get('ts'),
 					sig: url.searchParams.get('sig'),
 				})
 
 				if (!parsedQuery.success) {
 					return Response.json(
-						{ error: 'Missing nonce or sig parameter' },
+						{ error: 'Missing nonce, ts, or sig parameter' },
 						{ status: 400 }
 					)
 				}
 
 				const { id } = parsedParams.data
-				const { nonce, sig } = parsedQuery.data
+				const { nonce, ts, sig } = parsedQuery.data
+				const age = Date.now() - ts
 
-				// Verify HMAC signature
-				if (!verifySignature(id, nonce, sig)) {
+				if (age > SIGNATURE_MAX_AGE_MS) {
+					Sentry.captureMessage('Expired HMAC link accessed', {
+						level: 'warning',
+						extra: { listingId: id, ageMs: age },
+					})
+					return Response.json(
+						{
+							error:
+								'This link has expired. Please visit your listings page to update status.',
+						},
+						{ status: 410 }
+					)
+				}
+
+				if (!verifySignature(id, nonce, ts, sig)) {
+					Sentry.captureMessage('Invalid HMAC signature', {
+						level: 'warning',
+						extra: { listingId: id, ageMs: age },
+					})
 					return Response.json({ error: 'Invalid signature' }, { status: 403 })
 				}
 
-				// Mark listing as unavailable
-				const updated = await markListingUnavailable(id)
-				if (!updated) {
-					return Response.json({ error: 'Listing not found' }, { status: 404 })
-				}
+				try {
+					const updated = await markListingUnavailable(id)
+					if (!updated) {
+						return Response.json({ error: 'Listing not found' }, { status: 404 })
+					}
 
-				// Redirect to my listings page with success message
-				throw redirect({
-					to: '/listings/mine',
-					search: { marked: 'unavailable' },
-				})
+					throw redirect({
+						to: '/listings/mine',
+						search: { marked: 'unavailable' },
+					})
+				} catch (error) {
+					if (
+						error instanceof Response ||
+						(error as Record<string, unknown>)?.isRedirect
+					) {
+						throw error
+					}
+					Sentry.captureException(error)
+					return Response.json(
+						{ error: 'Failed to update listing' },
+						{ status: 500 }
+					)
+				}
 			},
 		},
 	},

--- a/apps/www/tests/hmac.test.ts
+++ b/apps/www/tests/hmac.test.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from 'crypto'
+import { faker } from '@faker-js/faker'
+import { describe, it, expect } from 'vitest'
+import {
+	signUrl,
+	verifySignature,
+	buildUnavailableUrl,
+	SIGNATURE_MAX_AGE_MS,
+} from '../src/lib/hmac'
+
+describe('signUrl', () => {
+	it('returns nonce, timestamp, and signature', () => {
+		const result = signUrl(faker.number.int({ min: 1, max: 9999 }))
+		expect(result.nonce).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+		)
+		expect(result.ts).toBeGreaterThan(0)
+		expect(result.sig).toMatch(/^[0-9a-f]{64}$/)
+	})
+
+	it('generates unique nonces per call', () => {
+		const id = faker.number.int({ min: 1, max: 9999 })
+		const a = signUrl(id)
+		const b = signUrl(id)
+		expect(a.nonce).not.toBe(b.nonce)
+	})
+})
+
+describe('verifySignature', () => {
+	it('accepts a valid, fresh signature', () => {
+		const id = faker.number.int({ min: 1, max: 9999 })
+		const { nonce, ts, sig } = signUrl(id)
+		expect(verifySignature(id, nonce, ts, sig)).toBe(true)
+	})
+
+	it('rejects a tampered listing ID', () => {
+		const id = faker.number.int({ min: 1, max: 4999 })
+		const { nonce, ts, sig } = signUrl(id)
+		expect(verifySignature(id + 5000, nonce, ts, sig)).toBe(false)
+	})
+
+	it('rejects a tampered nonce', () => {
+		const id = faker.number.int({ min: 1, max: 9999 })
+		const { nonce, ts, sig } = signUrl(id)
+		const tampered = randomUUID()
+		expect(tampered).not.toBe(nonce)
+		expect(verifySignature(id, tampered, ts, sig)).toBe(false)
+	})
+
+	it('rejects a tampered timestamp', () => {
+		const id = faker.number.int({ min: 1, max: 9999 })
+		const { nonce, ts, sig } = signUrl(id)
+		expect(verifySignature(id, nonce, ts + 1, sig)).toBe(false)
+	})
+
+	it('rejects a tampered signature', () => {
+		const id = faker.number.int({ min: 1, max: 9999 })
+		const { nonce, ts } = signUrl(id)
+		const other = signUrl(id + 1)
+		expect(verifySignature(id, nonce, ts, other.sig)).toBe(false)
+	})
+
+	it('rejects a signature older than max age', () => {
+		const id = faker.number.int({ min: 1, max: 9999 })
+		const { nonce, ts, sig } = signUrl(id)
+		const afterExpiry = ts + SIGNATURE_MAX_AGE_MS + 1
+		expect(verifySignature(id, nonce, ts, sig, afterExpiry)).toBe(false)
+	})
+
+	it('accepts a signature just under max age', () => {
+		const id = faker.number.int({ min: 1, max: 9999 })
+		const { nonce, ts, sig } = signUrl(id)
+		const justUnderMaxAge = ts + SIGNATURE_MAX_AGE_MS - 1000
+		expect(verifySignature(id, nonce, ts, sig, justUnderMaxAge)).toBe(true)
+	})
+
+	it('rejects a timestamp from the future', () => {
+		const id = faker.number.int({ min: 1, max: 9999 })
+		const { nonce, ts, sig } = signUrl(id)
+		const beforeSigning = ts - 1000
+		expect(verifySignature(id, nonce, ts, sig, beforeSigning)).toBe(false)
+	})
+})
+
+describe('buildUnavailableUrl', () => {
+	it('includes listing ID, nonce, ts, and sig in the URL', () => {
+		const id = faker.number.int({ min: 1, max: 9999 })
+		const url = buildUnavailableUrl('https://example.com', id)
+		const parsed = new URL(url)
+		expect(parsed.pathname).toBe(`/api/listings/${id}/unavailable`)
+		expect(parsed.searchParams.get('nonce')).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}/)
+		expect(parsed.searchParams.get('ts')).toMatch(/^\d+$/)
+		expect(parsed.searchParams.get('sig')).toMatch(/^[0-9a-f]{64}$/)
+	})
+})

--- a/docs/_now-next-later.md
+++ b/docs/_now-next-later.md
@@ -42,12 +42,6 @@
 
 ---
 
-## HMAC Replay Protection
-
-Add timestamp expiration to HMAC-signed "mark unavailable" URLs. Currently these URLs are replayable forever. Include a timestamp in the HMAC message and reject signatures older than 30 days.
-
----
-
 ## Resolve Dead-End After Creating Listing
 
 After creating a listing, the user has no clear next step. Add navigation (e.g., "View My Listings" link or redirect) so users aren't left on a dead-end page.
@@ -149,8 +143,7 @@ The `hasRecentInquiry` check and `createInquiry` insert are not atomic — concu
 
 ## Inquiry System Hardening (from PR #7 review)
 
-- **HMAC secret fail-fast**: Throw on startup if `HMAC_SECRET` is not set in production instead of falling back to a predictable dev value.
-- **Sentry error handling in new routes**: Replace `console.error` in `email-templates.ts` with `Sentry.captureException`. Add try/catch or `errorMiddleware` to the three new API route handlers (`api/inquiries.ts`, `api/listings.$id.ts`, `api/listings.$id.unavailable.ts`).
+- **Sentry error handling in new routes**: Replace `console.error` in `email-templates.ts` with `Sentry.captureException`. Add try/catch or `errorMiddleware` to the two remaining API route handlers (`api/inquiries.ts`, `api/listings.$id.ts`).
 - **Soft delete in `getListingById`**: Add `isNull(listings.deletedAt)` filter so deleted listings aren't visible via direct URL.
 - **Standardize API error format**: All endpoints should return `{ error: string, code?: string }`. Return structured codes (e.g., `code: 'RATE_LIMITED'`) so the client can match on codes instead of substring-matching error messages.
 - **Email failure UX**: The success message implies owners can "check their listings" to see inquiries, but no inbox exists. Either fail the inquiry if email fails (allowing retry) or add background retry for failed emails.


### PR DESCRIPTION
## Summary

- HMAC-signed "mark unavailable" URLs now include a timestamp in the signed message; signatures are rejected after 7 days or if the timestamp is in the future
- `HMAC_SECRET` throws on startup in production if unset, matching the `BETTER_AUTH_SECRET` pattern
- Expired links return 410 Gone with a user-friendly message; invalid signatures log to Sentry
- Email footer notes the 7-day link expiry
- 11 unit tests cover sign/verify roundtrip, tamper rejection, expiry boundaries, and future timestamps

## Test Plan

- [x] `pnpm vitest run tests/hmac.test.ts` — 11 tests pass
- [x] Quality gate passes (typecheck, lint, tests, formatting)
- [x] Manual: trigger inquiry, click "mark unavailable" link, verify listing becomes unavailable
- [x] Manual: submit inquiry for unavailable listing, verify "not accepting inquiries" response

## Known Limitation

The success redirect targets `/listings/mine` (a protected route). If the email link is opened in an unauthenticated browser, the listing is marked unavailable but the user hits the auth guard instead of seeing a confirmation. Not blocking for MVP.

## Review Notes

Self-reviewed (5 perspectives: Architect, User-Advocate, Adversary, Standards, Operator).

**Addressed:** HMAC_SECRET fail-fast, Sentry logging, try/catch on DB mutation, future timestamp rejection, 410 for expired links, JSDoc on exports, faker in tests, email expiry notice.

**Deferred:** `plantId` → `listingId` rename (pre-existing, tracked in roadmap). Nonce single-use enforcement (operation is idempotent; accepted for MVP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)