### PR TITLE
feat(listings): redirect to detail page after creating listing

### DIFF
--- a/apps/www/src/components/Banner.css
+++ b/apps/www/src/components/Banner.css
@@ -1,0 +1,41 @@
+@layer components {
+	.banner {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+		padding: 16px 20px;
+		border-radius: 8px;
+		font-size: 14px;
+	}
+
+	.banner-success {
+		background: oklch(from var(--color-secondary) l c h / 0.1);
+		color: var(--color-secondary);
+	}
+
+	.banner-error {
+		background: oklch(from var(--color-primary) l c h / 0.1);
+		color: var(--color-primary);
+	}
+
+	.banner-warning {
+		background: oklch(from var(--color-accent) l c h / 0.1);
+		color: var(--color-accent);
+	}
+
+	.banner-dismiss {
+		background: none;
+		border: none;
+		color: inherit;
+		text-decoration: underline;
+		cursor: pointer;
+		font-size: 14px;
+		padding: 0;
+		flex-shrink: 0;
+	}
+
+	.banner-dismiss:hover {
+		text-decoration: none;
+	}
+}

--- a/apps/www/src/components/Banner.tsx
+++ b/apps/www/src/components/Banner.tsx
@@ -1,0 +1,33 @@
+import { createSignal, Show, type JSX } from 'solid-js'
+import '@/components/Banner.css'
+
+type BannerVariant = 'success' | 'error' | 'warning'
+
+interface BannerProps {
+	variant: BannerVariant
+	children: JSX.Element
+	dismissible?: boolean
+}
+
+/** Inline status banner with semantic color variants. */
+export default function Banner(props: BannerProps) {
+	const [dismissed, setDismissed] = createSignal(false)
+
+	return (
+		<Show when={!dismissed()}>
+			<div class={`banner banner-${props.variant}`} role="status">
+				<div class="banner-content">{props.children}</div>
+				<Show when={props.dismissible}>
+					<button
+						type="button"
+						class="banner-dismiss"
+						aria-label="Dismiss"
+						onClick={() => setDismissed(true)}
+					>
+						Dismiss
+					</button>
+				</Show>
+			</div>
+		</Show>
+	)
+}

--- a/apps/www/src/components/ListingForm.css
+++ b/apps/www/src/components/ListingForm.css
@@ -165,12 +165,6 @@
 		border: 1px solid oklch(from var(--color-primary) l c h / 0.3);
 	}
 
-	.form-message.success {
-		background: oklch(from var(--color-secondary) l c h / 0.1);
-		color: var(--color-secondary);
-		border: 1px solid oklch(from var(--color-secondary) l c h / 0.3);
-	}
-
 	/* Readonly input styling */
 	.form-group input[readonly] {
 		background: oklch(from var(--color-quiet) l c h / 0.1);

--- a/apps/www/src/routes/listings.css
+++ b/apps/www/src/routes/listings.css
@@ -5,6 +5,10 @@
 		padding: 40px 20px;
 	}
 
+	.listing-page > .banner {
+		margin-bottom: 20px;
+	}
+
 	.listing-detail {
 		background: var(--color-background);
 		border: 1px solid oklch(from var(--color-quiet) l calc(c * 0.2) h);

--- a/apps/www/src/routes/listings/mine.css
+++ b/apps/www/src/routes/listings/mine.css
@@ -72,33 +72,6 @@
 		color: var(--color-accent);
 	}
 
-	.success-message {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 16px;
-		padding: 16px 20px;
-		background: oklch(from var(--color-secondary) l c h / 0.1);
-		color: var(--color-secondary);
-		border-radius: 8px;
-		margin-bottom: 24px;
-		font-size: 14px;
-	}
-
-	.success-message .dismiss-button {
-		background: none;
-		border: none;
-		color: var(--color-secondary);
-		text-decoration: underline;
-		cursor: pointer;
-		font-size: 14px;
-		padding: 0;
-	}
-
-	.success-message .dismiss-button:hover {
-		text-decoration: none;
-	}
-
 	.empty-state {
 		text-align: center;
 		padding: 60px 20px;

--- a/apps/www/src/routes/listings/mine.tsx
+++ b/apps/www/src/routes/listings/mine.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useRouteContext } from '@tanstack/solid-router'
-import { createSignal, For, Show } from 'solid-js'
+import { For, Show } from 'solid-js'
 import Layout from '@/components/Layout'
 import SiteHeader from '@/components/SiteHeader'
 import { authMiddleware } from '@/middleware/auth'
@@ -64,10 +64,6 @@ function EmptyState() {
 function MyGardenPage() {
 	const listings = Route.useLoaderData()
 	const context = useRouteContext({ from: '__root__' })
-	const search = Route.useSearch()
-	const [showMarkedMessage, setShowMarkedMessage] = createSignal(
-		(search as () => { marked?: string })()?.marked === 'unavailable'
-	)
 
 	return (
 		<Layout title="My Garden - Pick My Fruit">
@@ -79,20 +75,6 @@ function MyGardenPage() {
 						{(user) => <p>Welcome back, {user().name || 'friend'}!</p>}
 					</Show>
 				</header>
-
-				<Show when={showMarkedMessage()}>
-					<div class="success-message">
-						Listing marked as unavailable. Gleaners won't be able to contact you about
-						this listing.
-						<button
-							type="button"
-							class="dismiss-button"
-							onClick={() => setShowMarkedMessage(false)}
-						>
-							Dismiss
-						</button>
-					</div>
-				</Show>
 
 				<Show when={(listings() ?? []).length > 0} fallback={<EmptyState />}>
 					<div class="listings-grid">

--- a/docs/_now-next-later.md
+++ b/docs/_now-next-later.md
@@ -133,6 +133,7 @@ The `hasRecentInquiry` check and `createInquiry` insert are not atomic — concu
 - **Extract shared handleSignOut**: Sign-out logic is duplicated between `SiteHeader.tsx` and `index.tsx` with slight differences. Extract to a shared utility.
 - **Deduplicate auth nav**: Home page (`index.tsx`) has its own header with auth nav duplicating `SiteHeader` functionality. Consider unifying.
 - **E2E tests for sign-out flow**: No E2E coverage for sign-out behavior — add tests verifying redirect, UI state update, and protected-route rejection after sign-out.
+- **Extract shared banner message strings**: Deduplicate "Listing marked as unavailable…" text shared between `listings.$id.tsx` and `listings/mine.tsx` into a constants module.
 
 ---
 


### PR DESCRIPTION
feat(listings): redirect to detail page after creating listing

## Summary

- Resolve dead-end after creating a listing: redirect to
  `/listings/$id?created=true` with a dismissible "Your fruit is listed!" banner
  instead of an inline success page
- Add reusable `Banner` component (success/error/warning variants, dismissible,
  `role="status"` for a11y)
- Add Zod `validateSearch` schema to the listing detail route for `created` and
  `marked` search params
- Gate banners on `isOwner()` so shared URLs don't show stale messages to
  non-owners
- Add `Sentry.captureException` to ListingForm error handling
- Remove dead `?marked=unavailable` handling from My Garden page (the HMAC route
  redirects to `/listings/$id`, not `/listings/mine`)
- Clean up dead CSS (`.form-message.success`, `.success-message`,
  `.dismiss-button`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Test Plan

- [x] Create a listing → verify redirect to detail page with "Your fruit is listed!" banner
- [x] Dismiss the banner → verify it disappears
- [x] Visit `/listings/$id?created=true` as non-owner → verify no banner shows
- [x] Mark a listing unavailable via HMAC link → verify banner on detail page
- [x] Visit My Garden with `?marked=unavailable` → no banner

## Review Notes

Self-reviewed via deliver skill (2 rounds).

**Round 1 fixes:** owner-gated banners, validateSearch on mine route, Sentry in form error handler, tightened `marked` to `z.enum`, single JSON parse.

**Round 2 fix:** resilient JSON parsing (try/catch for non-JSON responses).

**Deferred:** Extract duplicated banner message strings into shared constants module (added to Later in roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)