### PR TITLE
feat(www): add maps via MapLibre GL

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -40,6 +40,8 @@
 		"better-auth": "^1.4.18",
 		"drizzle-orm": "^0.45.1",
 		"h3-js": "^4.4.0",
+		"lucide-solid": "^0.564.0",
+		"maplibre-gl": "^5.18.0",
 		"resend": "^6.9.2",
 		"solid-js": "^1.9.11",
 		"zod": "^4.3.6"

--- a/apps/www/src/api/listings.ts
+++ b/apps/www/src/api/listings.ts
@@ -43,6 +43,23 @@ export const getAvailableListings = createServerFn({ method: 'GET' })
 		return query(limit)
 	})
 
+const nearbyListingsSchema = z.object({
+	lat: z.number(),
+	lng: z.number(),
+	limit: z.number().int().positive().max(50).default(12),
+})
+
+/** Fetches available listings ordered by proximity to a point. */
+export const getNearbyListings = createServerFn({ method: 'GET' })
+	.middleware([errorMiddleware])
+	.inputValidator((input: { lat: number; lng: number; limit?: number }) =>
+		nearbyListingsSchema.parse(input)
+	)
+	.handler(async ({ data }) => {
+		const { getNearbyListings: query } = await import('@/data/queries')
+		return query(data.lat, data.lng, data.limit)
+	})
+
 const getListingByIdValidator = z.coerce.number().int().positive()
 
 /** Fetches a single listing by ID, omitting sensitive fields. Excludes private listings. */

--- a/apps/www/src/components/ListingMap.css
+++ b/apps/www/src/components/ListingMap.css
@@ -1,0 +1,36 @@
+@layer components {
+	.listing-map-container {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.listing-map {
+		width: 100%;
+		height: 280px;
+		border-radius: 12px;
+		overflow: hidden;
+		border: 1px solid oklch(from var(--color-quiet) l calc(c * 0.2) h);
+	}
+
+	.listing-map-legend {
+		display: flex;
+		justify-content: center;
+		gap: 1rem;
+		font-size: 14px;
+		color: var(--color-quiet);
+	}
+
+	.legend-item {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	@media (max-width: 600px) {
+		.listing-map {
+			height: 200px;
+			border-radius: 8px;
+		}
+	}
+}

--- a/apps/www/src/components/ListingMap.tsx
+++ b/apps/www/src/components/ListingMap.tsx
@@ -1,0 +1,204 @@
+import { onMount, onCleanup, Show } from 'solid-js'
+import { cellToLatLng, cellToBoundary, cellToParent } from 'h3-js'
+import MapPin from 'lucide-solid/icons/map-pin'
+import Hexagon from 'lucide-solid/icons/hexagon'
+import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
+import { Sentry } from '@/lib/sentry'
+import '@/components/ListingMap.css'
+
+interface OwnerProps {
+	mode: 'owner'
+	lat: number
+	lng: number
+	h3Index: string
+}
+
+interface PublicProps {
+	mode: 'public'
+	approximateH3Index: string
+}
+
+type Props = OwnerProps | PublicProps
+
+// MapLibre paint properties require literal color strings, not CSS variables.
+const COLOR_MARKER = '#ff6b5a' // --color-sunset-coral
+const COLOR_AREA = '#10b981' // --color-fresh-green
+
+/** Builds a closed GeoJSON polygon ring from an H3 cell index. */
+function h3ToPolygonRing(h3Index: string): number[][] {
+	const ring = cellToBoundary(h3Index).map(([lat, lng]) => [lng, lat])
+	ring.push(ring[0])
+	return ring
+}
+
+/** Map showing a single listing's location. */
+export default function ListingMap(props: Props) {
+	let containerRef!: HTMLDivElement
+	let map: import('maplibre-gl').Map | undefined
+	let mounted = true
+
+	onMount(async () => {
+		try {
+			const maplibregl = await import('maplibre-gl')
+			await import('maplibre-gl/dist/maplibre-gl.css')
+			if (!mounted) return
+
+			if (props.mode === 'owner') {
+				initOwnerMap(maplibregl, props.lat, props.lng, props.h3Index)
+			} else {
+				initPublicMap(maplibregl, props.approximateH3Index)
+			}
+		} catch (err) {
+			Sentry.captureException(err)
+		}
+	})
+
+	function initOwnerMap(
+		maplibregl: typeof import('maplibre-gl'),
+		lat: number,
+		lng: number,
+		h3Index: string
+	) {
+		const publicH3 = cellToParent(h3Index, H3_RESOLUTIONS.PUBLIC_DETAIL)
+
+		map = new maplibregl.Map({
+			container: containerRef,
+			style: 'https://tiles.openfreemap.org/styles/liberty',
+			center: [lng, lat],
+			zoom: 13,
+			attributionControl: false,
+		})
+
+		map.addControl(
+			new maplibregl.AttributionControl({ compact: true }),
+			'bottom-right'
+		)
+		map.addControl(new maplibregl.NavigationControl({ showCompass: false }))
+
+		map.on('load', () => {
+			if (!map) return
+
+			const ring = h3ToPolygonRing(publicH3)
+			map.addSource('public-area', {
+				type: 'geojson',
+				data: {
+					type: 'Feature',
+					geometry: { type: 'Polygon', coordinates: [ring] },
+					properties: {},
+				},
+			})
+
+			map.addLayer({
+				id: 'public-area-fill',
+				type: 'fill',
+				source: 'public-area',
+				paint: {
+					'fill-color': COLOR_AREA,
+					'fill-opacity': 0.15,
+				},
+			})
+
+			map.addLayer({
+				id: 'public-area-outline',
+				type: 'line',
+				source: 'public-area',
+				paint: {
+					'line-color': COLOR_AREA,
+					'line-width': 2,
+				},
+			})
+		})
+
+		new maplibregl.Marker({ color: COLOR_MARKER })
+			.setLngLat([lng, lat])
+			.addTo(map)
+	}
+
+	function initPublicMap(
+		maplibregl: typeof import('maplibre-gl'),
+		h3Index: string
+	) {
+		const [lat, lng] = cellToLatLng(h3Index)
+		const boundary = h3ToPolygonRing(h3Index)
+
+		map = new maplibregl.Map({
+			container: containerRef,
+			style: 'https://tiles.openfreemap.org/styles/liberty',
+			center: [lng, lat],
+			zoom: 14,
+			attributionControl: false,
+		})
+
+		map.addControl(
+			new maplibregl.AttributionControl({ compact: true }),
+			'bottom-right'
+		)
+		map.addControl(new maplibregl.NavigationControl({ showCompass: false }))
+
+		map.on('load', () => {
+			if (!map) return
+
+			map.addSource('listing-area', {
+				type: 'geojson',
+				data: {
+					type: 'Feature',
+					geometry: { type: 'Polygon', coordinates: [boundary] },
+					properties: {},
+				},
+			})
+
+			map.addLayer({
+				id: 'listing-area-fill',
+				type: 'fill',
+				source: 'listing-area',
+				paint: {
+					'fill-color': COLOR_AREA,
+					'fill-opacity': 0.2,
+				},
+			})
+
+			map.addLayer({
+				id: 'listing-area-outline',
+				type: 'line',
+				source: 'listing-area',
+				paint: {
+					'line-color': COLOR_AREA,
+					'line-width': 2,
+				},
+			})
+		})
+	}
+
+	onCleanup(() => {
+		mounted = false
+		map?.remove()
+		map = undefined
+	})
+
+	return (
+		<div class="listing-map-container">
+			<div
+				ref={containerRef}
+				class="listing-map"
+				role="img"
+				aria-label={
+					props.mode === 'owner'
+						? 'Map showing exact listing location and public area'
+						: 'Map showing approximate listing area'
+				}
+			/>
+			<Show when={props.mode === 'owner'}>
+				<div class="listing-map-legend">
+					<span class="legend-item">
+						<MapPin size="1.25em" color={COLOR_MARKER} />
+						Exact location
+					</span>
+					<span class="legend-item">
+						<Hexagon size="1.25em" color={COLOR_AREA} />
+						What others see
+					</span>
+				</div>
+			</Show>
+		</div>
+	)
+}

--- a/apps/www/src/components/ListingsMap.css
+++ b/apps/www/src/components/ListingsMap.css
@@ -1,0 +1,16 @@
+@layer components {
+	.listings-map {
+		width: 100%;
+		height: 350px;
+		border-radius: 12px;
+		overflow: hidden;
+		border: 1px solid oklch(from var(--color-quiet) l calc(c * 0.2) h);
+	}
+
+	@media (max-width: 768px) {
+		.listings-map {
+			height: 250px;
+			border-radius: 8px;
+		}
+	}
+}

--- a/apps/www/src/components/ListingsMap.tsx
+++ b/apps/www/src/components/ListingsMap.tsx
@@ -1,0 +1,288 @@
+import { onMount, onCleanup, createEffect, on } from 'solid-js'
+import type { PublicListing } from '@/data/queries'
+import { cellToLatLng, cellToBoundary, cellToParent } from 'h3-js'
+import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
+import { Sentry } from '@/lib/sentry'
+import '@/components/ListingsMap.css'
+
+/** A group of listings sharing the same approximate H3 cell. */
+export interface ListingGroup {
+	h3Index: string
+	center: [lng: number, lat: number]
+	listings: PublicListing[]
+}
+
+// MapLibre paint properties require literal color strings, not CSS variables.
+const COLOR_SELECTED = '#ff6b5a' // --color-sunset-coral
+const COLOR_DEFAULT = '#10b981' // --color-fresh-green
+const COLOR_LABEL = '#ffffff'
+const COLOR_REGION_FILL = '#10b981' // --color-fresh-green
+const COLOR_REGION_STROKE = '#10b981'
+
+/** Groups public listings by their home-grouping H3 parent cell. */
+export function groupByH3(listings: PublicListing[]): ListingGroup[] {
+	const groups = new Map<string, PublicListing[]>()
+	for (const listing of listings) {
+		const key = cellToParent(
+			listing.approximateH3Index,
+			H3_RESOLUTIONS.HOME_GROUPING
+		)
+		const arr = groups.get(key)
+		if (arr) {
+			arr.push(listing)
+		} else {
+			groups.set(key, [listing])
+		}
+	}
+	return Array.from(groups, ([h3Index, listings]) => {
+		const [lat, lng] = cellToLatLng(h3Index)
+		return { h3Index, center: [lng, lat] as [number, number], listings }
+	})
+}
+
+/** Builds a closed GeoJSON polygon ring from an H3 cell index. */
+function h3ToPolygonCoordinates(h3Index: string): number[][] {
+	// cellToBoundary returns [lat, lng] pairs; convert to [lng, lat] for GeoJSON
+	const ring = cellToBoundary(h3Index).map(([lat, lng]) => [lng, lat])
+	ring.push(ring[0]) // close the ring
+	return ring
+}
+
+interface Props {
+	listings: PublicListing[]
+	/** Called when a group marker is clicked. Null clears the filter. */
+	onGroupSelect?: (h3Index: string | null) => void
+	/** Currently selected H3 index, for highlighting. */
+	selectedH3?: string | null
+}
+
+/** Map showing nearby listings grouped by H3 cell. */
+export default function ListingsMap(props: Props) {
+	let containerRef!: HTMLDivElement
+	let map: import('maplibre-gl').Map | undefined
+	let mounted = true
+	let layersReady = false
+
+	onMount(async () => {
+		try {
+			const maplibregl = await import('maplibre-gl')
+			await import('maplibre-gl/dist/maplibre-gl.css')
+			if (!mounted) return
+
+			const groups = groupByH3(props.listings)
+			const bounds = new maplibregl.LngLatBounds()
+			for (const group of groups) {
+				bounds.extend(group.center)
+			}
+
+			map = new maplibregl.Map({
+				container: containerRef,
+				style: 'https://tiles.openfreemap.org/styles/liberty',
+				bounds: groups.length > 0 ? bounds : undefined,
+				center: groups.length === 0 ? [-122.2893688, 38.2966234] : undefined,
+				zoom: groups.length === 0 ? 13 : undefined,
+				fitBoundsOptions: { padding: 60, maxZoom: 14 },
+				attributionControl: false,
+			})
+
+			map.addControl(
+				new maplibregl.AttributionControl({ compact: true }),
+				'bottom-right'
+			)
+			map.addControl(new maplibregl.NavigationControl({ showCompass: false }))
+
+			map.on('load', () => {
+				addGroupLayers(groups)
+				addRegionLayers()
+				layersReady = true
+				// Show region if selectedH3 was set before the map loaded
+				if (props.selectedH3) {
+					updateRegion(props.selectedH3)
+					updateHighlight()
+				}
+			})
+		} catch (err) {
+			Sentry.captureException(err)
+		}
+	})
+
+	function addGroupLayers(groups: ListingGroup[]) {
+		if (!map) return
+
+		const geojson: GeoJSON.FeatureCollection = {
+			type: 'FeatureCollection',
+			features: groups.map((g) => ({
+				type: 'Feature',
+				geometry: { type: 'Point', coordinates: g.center },
+				properties: {
+					h3Index: g.h3Index,
+					count: g.listings.length,
+					label: String(g.listings.length),
+				},
+			})),
+		}
+
+		map.addSource('listing-groups', { type: 'geojson', data: geojson })
+
+		map.addLayer({
+			id: 'listing-groups-circle',
+			type: 'circle',
+			source: 'listing-groups',
+			paint: {
+				'circle-radius': [
+					'interpolate',
+					['linear'],
+					['get', 'count'],
+					1,
+					16,
+					10,
+					28,
+				],
+				'circle-color': [
+					'case',
+					['==', ['get', 'h3Index'], ''],
+					COLOR_SELECTED,
+					COLOR_DEFAULT,
+				],
+				'circle-stroke-width': 2,
+				'circle-stroke-color': COLOR_LABEL,
+			},
+		})
+
+		map.addLayer({
+			id: 'listing-groups-label',
+			type: 'symbol',
+			source: 'listing-groups',
+			layout: {
+				'text-field': ['get', 'label'],
+				'text-size': 13,
+				'text-font': ['Open Sans Bold'],
+				'text-allow-overlap': true,
+			},
+			paint: {
+				'text-color': COLOR_LABEL,
+			},
+		})
+
+		map.on('click', 'listing-groups-circle', (e) => {
+			const feature = e.features?.[0]
+			if (!feature) return
+			const clickedH3 = feature.properties?.h3Index
+			if (props.selectedH3 === clickedH3) {
+				props.onGroupSelect?.(null)
+			} else {
+				props.onGroupSelect?.(clickedH3)
+			}
+		})
+
+		map.on('mouseenter', 'listing-groups-circle', () => {
+			if (map) map.getCanvas().style.cursor = 'pointer'
+		})
+
+		map.on('mouseleave', 'listing-groups-circle', () => {
+			if (map) map.getCanvas().style.cursor = ''
+		})
+	}
+
+	/** Adds the region outline source and layers (initially empty). */
+	function addRegionLayers() {
+		if (!map) return
+
+		const emptyPolygon: GeoJSON.FeatureCollection = {
+			type: 'FeatureCollection',
+			features: [],
+		}
+
+		map.addSource('selected-region', { type: 'geojson', data: emptyPolygon })
+
+		// Region fill — rendered below the pip layers
+		map.addLayer(
+			{
+				id: 'selected-region-fill',
+				type: 'fill',
+				source: 'selected-region',
+				paint: {
+					'fill-color': COLOR_REGION_FILL,
+					'fill-opacity': 0.15,
+				},
+			},
+			'listing-groups-circle' // insert before circle layer
+		)
+
+		map.addLayer(
+			{
+				id: 'selected-region-outline',
+				type: 'line',
+				source: 'selected-region',
+				paint: {
+					'line-color': COLOR_REGION_STROKE,
+					'line-width': 2,
+				},
+			},
+			'listing-groups-circle'
+		)
+	}
+
+	/** Updates the region outline to show the boundary of the given H3 cell. */
+	function updateRegion(h3Index: string | null | undefined) {
+		if (!map || !layersReady) return
+
+		const source = map.getSource('selected-region') as
+			| import('maplibre-gl').GeoJSONSource
+			| undefined
+		if (!source) return
+
+		if (!h3Index) {
+			source.setData({ type: 'FeatureCollection', features: [] })
+			return
+		}
+
+		try {
+			const ring = h3ToPolygonCoordinates(h3Index)
+			source.setData({
+				type: 'Feature',
+				geometry: { type: 'Polygon', coordinates: [ring] },
+				properties: {},
+			})
+		} catch (err) {
+			Sentry.captureException(err)
+			source.setData({ type: 'FeatureCollection', features: [] })
+		}
+	}
+
+	function updateHighlight() {
+		if (!map?.getLayer('listing-groups-circle')) return
+
+		map.setPaintProperty('listing-groups-circle', 'circle-color', [
+			'case',
+			['==', ['get', 'h3Index'], props.selectedH3 ?? ''],
+			COLOR_SELECTED,
+			COLOR_DEFAULT,
+		])
+	}
+
+	createEffect(
+		on(
+			() => props.selectedH3,
+			() => {
+				updateHighlight()
+				updateRegion(props.selectedH3)
+			}
+		)
+	)
+
+	onCleanup(() => {
+		mounted = false
+		map?.remove()
+		map = undefined
+	})
+
+	return (
+		<div
+			ref={containerRef}
+			class="listings-map"
+			role="application"
+			aria-label="Map of nearby fruit listings"
+		/>
+	)
+}

--- a/apps/www/src/data/public-listing.ts
+++ b/apps/www/src/data/public-listing.ts
@@ -1,8 +1,6 @@
 import { cellToParent } from 'h3-js'
 import type { Listing } from './schema'
-
-// ~1.2km hexagons — neighborhood-level, prevents identifying the exact property
-const PUBLIC_H3_RESOLUTION = 7
+import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
 
 /** Public listing fields safe to expose to any visitor. */
 export type PublicListing = Omit<
@@ -17,7 +15,7 @@ export type PublicListing = Omit<
 > & { approximateH3Index: string }
 
 /**
- * Strips sensitive location fields and coarsens h3Index to ~1.2km precision.
+ * Strips sensitive location fields and coarsens h3Index to neighborhood precision.
  * Returns null if the h3Index is invalid so callers can skip bad rows.
  */
 export function toPublicListing(
@@ -36,7 +34,7 @@ export function toPublicListing(
 	} = listing
 	let approximateH3Index: string
 	try {
-		approximateH3Index = cellToParent(h3Index, PUBLIC_H3_RESOLUTION)
+		approximateH3Index = cellToParent(h3Index, H3_RESOLUTIONS.PUBLIC_DETAIL)
 	} catch (error) {
 		onError?.(listing.id, error)
 		return null

--- a/apps/www/src/data/schema.ts
+++ b/apps/www/src/data/schema.ts
@@ -121,7 +121,7 @@ export const listings = sqliteTable(
 		zip: text('zip'),
 		lat: real('lat').notNull(),
 		lng: real('lng').notNull(),
-		h3Index: text('h3_index').notNull(), // H3 index at resolution 13 (~3m precision)
+		h3Index: text('h3_index').notNull(), // H3 index at H3_RES_STORAGE (resolution 13)
 
 		// Owner — Better Auth user reference
 		userId: text('user_id')

--- a/apps/www/src/lib/geocoding.ts
+++ b/apps/www/src/lib/geocoding.ts
@@ -1,7 +1,5 @@
 import { latLngToCell } from 'h3-js'
-
-// H3 resolution 13 gives ~3m edge length for tree-level precision
-const H3_RESOLUTION = 13
+import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
 
 export interface GeocodingResult {
 	lat: number
@@ -62,8 +60,7 @@ export async function geocodeAddress(
 	const lat = parseFloat(result.lat)
 	const lng = parseFloat(result.lon)
 
-	// Generate H3 index at tree-level precision
-	const h3Index = latLngToCell(lat, lng, H3_RESOLUTION)
+	const h3Index = latLngToCell(lat, lng, H3_RESOLUTIONS.STORAGE)
 
 	return {
 		lat,

--- a/apps/www/src/lib/h3-area.ts
+++ b/apps/www/src/lib/h3-area.ts
@@ -1,0 +1,42 @@
+import { getResolution, cellToParent, isValidCell } from 'h3-js'
+import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
+
+/**
+ * Normalizes an area H3 index: clamps finer resolutions to the home-page
+ * grouping resolution and rejects cells coarser than the minimum area.
+ * Returns null for invalid indices.
+ */
+export function normalizeArea(area: string | null): string | null {
+	if (!area) return null
+	if (!isValidCell(area)) return null
+	const res = getResolution(area)
+	if (res < H3_RESOLUTIONS.MIN_AREA) return null
+	if (res > H3_RESOLUTIONS.HOME_GROUPING) {
+		return cellToParent(area, H3_RESOLUTIONS.HOME_GROUPING)
+	}
+	return area
+}
+
+/** Checks whether a listing's H3 index falls within an area cell. */
+export function listingMatchesArea(listingH3: string, area: string): boolean {
+	const areaRes = getResolution(area)
+	const listingRes = getResolution(listingH3)
+
+	if (areaRes === listingRes) {
+		return listingH3 === area
+	}
+	if (areaRes < listingRes) {
+		// Coarser area: check if the listing is a descendant
+		try {
+			return cellToParent(listingH3, areaRes) === area
+		} catch {
+			return false
+		}
+	}
+	// Area is finer than the listing — compare at listing resolution
+	try {
+		return cellToParent(area, listingRes) === listingH3
+	} catch {
+		return false
+	}
+}

--- a/apps/www/src/lib/h3-resolutions.ts
+++ b/apps/www/src/lib/h3-resolutions.ts
@@ -1,0 +1,28 @@
+/**
+ * H3 resolution constants used across the application.
+ *
+ * @see {@link https://gist.github.com/colbyn/001064f00385d253b42693c3889f9beb} for
+ * a table of H3 resolutions, average areas, and physical analogies.
+ */
+export const H3_RESOLUTIONS = {
+	/** Resolution for stored coordinates — tree-level precision (~9m² edge). */
+	STORAGE: 13,
+
+	/** Resolution for grouping listings on the home page map (~5.2 km²). */
+	HOME_GROUPING: 7,
+
+	/** Resolution for public listing detail — approximate area (~0.74 km², ~Central Park). */
+	PUBLIC_DETAIL: 8,
+
+	/** Resolution for owner listing detail — near-exact location (~9m² edge). */
+	OWNER_DETAIL: 13,
+
+	/** Coarsest resolution allowed for area filtering (~12,400 km²). */
+	MIN_AREA: 3,
+
+	/** Finest resolution allowed in public-facing area queries. */
+	MAX_PUBLIC_AREA: 8,
+
+	/** Finest resolution allowed for owner-facing views. */
+	MAX_OWNER_AREA: 13,
+} as const

--- a/apps/www/src/routes/index.css
+++ b/apps/www/src/routes/index.css
@@ -246,6 +246,30 @@
 		text-align: center;
 	}
 
+	.clear-filter {
+		display: block;
+		margin: 16px auto 0;
+		padding: 6px 16px;
+		font-size: 14px;
+		font-weight: 500;
+		color: var(--color-primary);
+		background: none;
+		border: 1px solid var(--color-primary);
+		border-radius: 6px;
+		cursor: pointer;
+		transition: background-color 0.15s;
+	}
+
+	.clear-filter:hover {
+		background: oklch(from var(--color-primary) l c h / 0.08);
+	}
+
+	.no-filtered-listings {
+		text-align: center;
+		color: var(--color-quiet);
+		margin: 24px 0 0;
+	}
+
 	.listings-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));

--- a/apps/www/src/routes/listings.$id.tsx
+++ b/apps/www/src/routes/listings.$id.tsx
@@ -5,6 +5,7 @@ import Layout from '@/components/Layout'
 import SiteHeader from '@/components/SiteHeader'
 import Banner from '@/components/Banner'
 import InquiryForm from '@/components/InquiryForm'
+import ListingMap from '@/components/ListingMap'
 import {
 	getStatusClass,
 	VISIBILITY_OPTIONS,
@@ -223,6 +224,35 @@ function ListingDetailPage() {
 										<span class="info-label">Notes</span>
 										<span class="info-value">{l().notes}</span>
 									</div>
+								</Show>
+							</div>
+
+							<div class="listing-map-section">
+								<Show
+									when={isOwner() && 'lat' in l() ? (l() as Listing) : undefined}
+									fallback={
+										<Show
+											when={
+												'approximateH3Index' in l() ? (l() as PublicListing) : undefined
+											}
+										>
+											{(pub) => (
+												<ListingMap
+													mode="public"
+													approximateH3Index={pub().approximateH3Index}
+												/>
+											)}
+										</Show>
+									}
+								>
+									{(owner) => (
+										<ListingMap
+											mode="owner"
+											lat={owner().lat}
+											lng={owner().lng}
+											h3Index={owner().h3Index}
+										/>
+									)}
 								</Show>
 							</div>
 

--- a/apps/www/src/routes/listings.css
+++ b/apps/www/src/routes/listings.css
@@ -93,6 +93,10 @@
 		line-height: 1.5;
 	}
 
+	.listing-map-section {
+		margin-top: 24px;
+	}
+
 	.listing-unavailable,
 	.listing-owner-notice {
 		margin-top: 32px;

--- a/apps/www/tests/e2e/area-filter.test.ts
+++ b/apps/www/tests/e2e/area-filter.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from './helpers/fixtures'
+
+test.describe('Home page area filter', () => {
+	test.describe.configure({ mode: 'serial' })
+
+	test('resolution-7 area shows matching listings', async ({
+		page,
+		testListing,
+	}) => {
+		// 872830053ffffff is the resolution-7 parent of the test listing at 38.3, -122.3
+		await page.goto('/?area=872830053ffffff')
+		const card = page.locator(`a[href="/listings/${testListing.id}"]`)
+		await expect(card).toBeVisible()
+	})
+
+	test('coarser area (resolution 6) includes descendant listings', async ({
+		page,
+		testListing,
+	}) => {
+		// 862830057ffffff is the resolution-6 parent
+		await page.goto('/?area=862830057ffffff')
+		const card = page.locator(`a[href="/listings/${testListing.id}"]`)
+		await expect(card).toBeVisible()
+	})
+
+	test('fine resolution (> 7) is clamped and does not leak location data', async ({
+		page,
+		testListing,
+	}) => {
+		// 8828300531fffff is resolution 8 — should be clamped to resolution 7
+		await page.goto('/?area=8828300531fffff')
+		const card = page.locator(`a[href="/listings/${testListing.id}"]`)
+		await expect(card).toBeVisible()
+	})
+
+	test('unrelated area shows no listings', async ({ page, testListing: _ }) => {
+		// A valid resolution-7 cell far from Napa (near Susanville, CA)
+		await page.goto('/?area=872816903ffffff')
+		await expect(page.getByText('No listings in this area.')).toBeVisible()
+	})
+
+	test('invalid area param is ignored and shows all listings', async ({
+		page,
+		testListing,
+	}) => {
+		await page.goto('/?area=not-a-valid-cell')
+		const card = page.locator(`a[href="/listings/${testListing.id}"]`)
+		await expect(card).toBeVisible()
+		// No filter UI should be shown
+		await expect(page.getByText('Show all listings')).not.toBeVisible()
+	})
+})

--- a/apps/www/tests/h3-area.test.ts
+++ b/apps/www/tests/h3-area.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { latLngToCell, cellToParent } from 'h3-js'
+import { normalizeArea, listingMatchesArea } from '../src/lib/h3-area'
+import { H3_RESOLUTIONS } from '../src/lib/h3-resolutions'
+
+const NAPA = { lat: 38.2975, lng: -122.2869 }
+const res8Cell = latLngToCell(NAPA.lat, NAPA.lng, H3_RESOLUTIONS.PUBLIC_DETAIL)
+const res7Cell = cellToParent(res8Cell, H3_RESOLUTIONS.HOME_GROUPING)
+const res9Cell = latLngToCell(NAPA.lat, NAPA.lng, 9)
+const res13Cell = latLngToCell(NAPA.lat, NAPA.lng, 13)
+const res6Cell = cellToParent(res7Cell, 6)
+const res5Cell = cellToParent(res7Cell, 5)
+const res3Cell = cellToParent(res7Cell, H3_RESOLUTIONS.MIN_AREA)
+const res2Cell = cellToParent(res7Cell, 2)
+
+describe('normalizeArea', () => {
+	it('returns null for null input', () => {
+		expect(normalizeArea(null)).toBeNull()
+	})
+
+	it('returns null for empty string', () => {
+		expect(normalizeArea('')).toBeNull()
+	})
+
+	it('returns null for invalid H3 index', () => {
+		expect(normalizeArea('not-a-cell')).toBeNull()
+		expect(normalizeArea('zzzzzzzzzzzzzzz')).toBeNull()
+	})
+
+	it('passes through resolution-7 cells unchanged', () => {
+		expect(normalizeArea(res7Cell)).toBe(res7Cell)
+	})
+
+	it('passes through coarser cells unchanged', () => {
+		expect(normalizeArea(res6Cell)).toBe(res6Cell)
+		expect(normalizeArea(res5Cell)).toBe(res5Cell)
+		expect(normalizeArea(res3Cell)).toBe(res3Cell)
+	})
+
+	it('returns null for cells coarser than minimum area', () => {
+		expect(normalizeArea(res2Cell)).toBeNull()
+	})
+
+	it.each([
+		['resolution 8', res8Cell],
+		['resolution 9', res9Cell],
+		['resolution 13', res13Cell],
+	])('clamps %s to home-grouping resolution', (_label, fineCell) => {
+		const result = normalizeArea(fineCell)
+		expect(result).toBe(cellToParent(fineCell, H3_RESOLUTIONS.HOME_GROUPING))
+	})
+
+	it('never returns a cell finer than home-grouping resolution', () => {
+		for (let res = H3_RESOLUTIONS.HOME_GROUPING + 1; res <= 15; res++) {
+			const cell = latLngToCell(NAPA.lat, NAPA.lng, res)
+			const result = normalizeArea(cell)
+			expect(result).not.toBe(cell)
+			expect(result).toBe(cellToParent(cell, H3_RESOLUTIONS.HOME_GROUPING))
+		}
+	})
+})
+
+describe('listingMatchesArea', () => {
+	it('matches when listing H3 equals the area exactly', () => {
+		expect(listingMatchesArea(res8Cell, res8Cell)).toBe(true)
+	})
+
+	it('does not match a different cell at the same resolution', () => {
+		const otherRes8 = latLngToCell(40.0, -120.0, H3_RESOLUTIONS.PUBLIC_DETAIL)
+		expect(listingMatchesArea(res8Cell, otherRes8)).toBe(false)
+	})
+
+	it('matches listings in a coarser parent cell', () => {
+		expect(listingMatchesArea(res8Cell, res7Cell)).toBe(true)
+		expect(listingMatchesArea(res8Cell, res6Cell)).toBe(true)
+		expect(listingMatchesArea(res8Cell, res5Cell)).toBe(true)
+	})
+
+	it('does not match a coarser cell the listing is not in', () => {
+		const otherRes7 = cellToParent(latLngToCell(40.0, -120.0, 8), 7)
+		expect(listingMatchesArea(res8Cell, otherRes7)).toBe(false)
+	})
+})

--- a/apps/www/tests/toPublicListing.test.ts
+++ b/apps/www/tests/toPublicListing.test.ts
@@ -72,12 +72,12 @@ describe('toPublicListing', () => {
 		expect(Object.keys(result).sort()).toEqual(EXPECTED_PUBLIC_KEYS)
 	})
 
-	it('coarsens h3Index from resolution 13 to 7', () => {
+	it('coarsens h3Index from resolution 13 to 8', () => {
 		const listing = makeListing()
 		const result = toPublicListing(listing)!
 
-		expect(getResolution(result.approximateH3Index)).toBe(7)
-		expect(result.approximateH3Index).toBe(cellToParent(listing.h3Index, 7))
+		expect(getResolution(result.approximateH3Index)).toBe(8)
+		expect(result.approximateH3Index).toBe(cellToParent(listing.h3Index, 8))
 	})
 
 	it('preserves safe fields unchanged', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,12 @@ importers:
       h3-js:
         specifier: ^4.4.0
         version: 4.4.0
+      lucide-solid:
+        specifier: ^0.564.0
+        version: 0.564.0(solid-js@1.9.11)
+      maplibre-gl:
+        specifier: ^5.18.0
+        version: 5.18.0
       resend:
         specifier: ^6.9.2
         version: 6.9.2
@@ -845,10 +851,47 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@mapbox/geojson-rewind@0.5.2':
+    resolution: {integrity: sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==}
+    hasBin: true
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2':
+    resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
+    engines: {node: '>= 0.6'}
+
   '@mapbox/node-pre-gyp@2.0.3':
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.0.7':
+    resolution: {integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/vector-tile@2.0.4':
+    resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@5.0.4':
+    resolution: {integrity: sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==}
+
+  '@maplibre/maplibre-gl-style-spec@24.4.1':
+    resolution: {integrity: sha512-UKhA4qv1h30XT768ccSv5NjNCX+dgfoq2qlLVmKejspPcSQTYD4SrVucgqegmYcKcmwf06wcNAa/kRd0NHWbUg==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.6':
+    resolution: {integrity: sha512-rgtY3x65lrrfXycLf6/T22ZnjTg5WgIOsptOIoCaMZy4O4UAKTyZlYY0h6v8le721pTptF94U65yMDQkug+URw==}
+
+  '@maplibre/vt-pbf@4.2.1':
+    resolution: {integrity: sha512-IxZBGq/+9cqf2qdWlFuQ+ZfoMhWpxDUGQZ/poPHOJBvwMUT1GuxLo6HgYTou+xxtsOsjfbcjI8PZaPCtmt97rA==}
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -2225,6 +2268,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -2248,6 +2294,9 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -2983,6 +3032,9 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -3196,6 +3248,10 @@ packages:
   get-port-please@3.2.0:
     resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
@@ -3206,6 +3262,9 @@ packages:
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -3477,10 +3536,16 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kdbush@4.0.2:
+    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -3537,6 +3602,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-solid@0.564.0:
+    resolution: {integrity: sha512-gZdibdRlnooRdKek2zhNGnep/N5TSlOSMWgUXiVtglys728zLLRupyaI7IfZ3USS/p6MG5eu2RKM2CARRYiXVg==}
+    peerDependencies:
+      solid-js: ^1.4.7
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -3553,6 +3623,10 @@ packages:
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  maplibre-gl@5.18.0:
+    resolution: {integrity: sha512-UtWxPBpHuFvEkM+5FVfcFG9ZKEWZQI6+PZkvLErr8Zs5ux+O7/KQ3JjSUvAfOlMeMgd/77qlHpOw0yHL7JU5cw==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
@@ -3633,6 +3707,9 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3652,6 +3729,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3857,6 +3937,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pbf@4.0.1:
+    resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+    hasBin: true
+
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
@@ -3921,6 +4005,9 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
@@ -3951,6 +4038,9 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  protocol-buffers-schema@3.6.0:
+    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -3963,6 +4053,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -4058,6 +4151,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -4090,6 +4186,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -4284,6 +4383,9 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -4344,6 +4446,9 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
@@ -5506,6 +5611,13 @@ snapshots:
   '@libsql/win32-x64-msvc@0.5.22':
     optional: true
 
+  '@mapbox/geojson-rewind@0.5.2':
+    dependencies:
+      get-stream: 6.0.1
+      minimist: 1.2.8
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+
   '@mapbox/node-pre-gyp@2.0.3':
     dependencies:
       consola: 3.4.2
@@ -5518,6 +5630,46 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.0.7': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/vector-tile@2.0.4':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.1
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@5.0.4': {}
+
+  '@maplibre/maplibre-gl-style-spec@24.4.1':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      rw: 1.3.3
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.6':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.2.1':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/vector-tile': 2.0.4
+      '@maplibre/geojson-vt': 5.0.4
+      '@types/geojson': 7946.0.16
+      '@types/supercluster': 7.1.3
+      pbf: 4.0.1
+      supercluster: 8.0.1
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -6869,6 +7021,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -6900,6 +7054,10 @@ snapshots:
       pg-types: 2.2.0
 
   '@types/resolve@1.20.2': {}
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/tedious@4.0.14':
     dependencies:
@@ -6941,7 +7099,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.4
       get-port-please: 3.2.0
-      h3: 1.15.3
+      h3: 1.15.5
       http-shutdown: 1.2.2
       jiti: 1.21.7
       mlly: 1.8.0
@@ -7526,6 +7684,8 @@ snapshots:
 
   duplexer@0.1.2: {}
 
+  earcut@3.0.2: {}
+
   eastasianwidth@0.2.0: {}
 
   ee-first@1.1.1: {}
@@ -7764,6 +7924,8 @@ snapshots:
 
   get-port-please@3.2.0: {}
 
+  get-stream@6.0.1: {}
+
   get-stream@8.0.1: {}
 
   get-tsconfig@4.13.6:
@@ -7778,6 +7940,8 @@ snapshots:
       node-fetch-native: 1.6.7
       nypm: 0.6.5
       pathe: 2.0.3
+
+  gl-matrix@3.4.4: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -8087,7 +8251,11 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@2.2.3: {}
+
+  kdbush@4.0.2: {}
 
   kleur@4.1.5: {}
 
@@ -8161,6 +8329,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucide-solid@0.564.0(solid-js@1.9.11):
+    dependencies:
+      solid-js: 1.9.11
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -8182,6 +8354,31 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
+
+  maplibre-gl@5.18.0:
+    dependencies:
+      '@mapbox/geojson-rewind': 0.5.2
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.0.7
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 5.0.4
+      '@maplibre/maplibre-gl-style-spec': 24.4.1
+      '@maplibre/mlt': 1.1.6
+      '@maplibre/vt-pbf': 4.2.1
+      '@types/geojson': 7946.0.16
+      '@types/supercluster': 7.1.3
+      earcut: 3.0.2
+      gl-matrix: 3.4.4
+      kdbush: 4.0.2
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      supercluster: 8.0.1
+      tinyqueue: 3.0.0
 
   mdast-util-to-hast@13.2.1:
     dependencies:
@@ -8255,6 +8452,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  minimist@1.2.8: {}
+
   minipass@7.1.2: {}
 
   minizlib@3.1.0:
@@ -8273,6 +8472,8 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
+
+  murmurhash-js@1.0.0: {}
 
   nanoid@3.3.11: {}
 
@@ -8627,6 +8828,10 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   perfect-debounce@2.1.0: {}
 
   pg-int8@1.0.1: {}
@@ -8685,6 +8890,8 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  potpack@2.1.0: {}
+
   prettier@3.8.1: {}
 
   pretty-bytes@7.1.0: {}
@@ -8705,6 +8912,8 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  protocol-buffers-schema@3.6.0: {}
+
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
@@ -8712,6 +8921,8 @@ snapshots:
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  quickselect@3.0.0: {}
 
   radix3@1.1.2: {}
 
@@ -8810,6 +9021,10 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.0
+
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
@@ -8863,6 +9078,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safe-buffer@5.1.2: {}
 
@@ -9084,6 +9301,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.0.2
+
   supports-color@10.2.2: {}
 
   supports-preserve-symlinks-flag@1.0.0: {}
@@ -9146,6 +9367,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyqueue@3.0.0: {}
 
   tinyrainbow@3.0.3: {}
 


### PR DESCRIPTION
## Summary

- **Home page map**: Nearby listings grouped by H3 resolution-7 cells as circle markers with count labels. Clicking a group highlights the pip, renders an H3 hexagon region outline, filters listing cards, and stores the selection in `?area=` query params (URL-shareable, back-button friendly).
- **Listing detail map (owner)**: Exact-location pin plus a green H3 hexagon (resolution 8) showing what non-owners see, with a Lucide icon legend explaining both markers.
- **Listing detail map (public)**: H3 hexagon polygon at resolution 8 (~0.74 km², ~Central Park), preserving address privacy.
- **H3 resolution system**: All resolution constants centralized in `h3-resolutions.ts` (storage=13, home grouping=7, public detail=8, min area=3). Public listings coarsened to resolution 8 instead of 7 for better utility. Links to [H3 resolution reference](https://gist.github.com/colbyn/001064f00385d253b42693c3889f9beb).
- **Area filtering**: Coarser areas include descendant listings; finer areas clamped to resolution 7 to prevent location leakage. Invalid area params silently ignored.
- **Backend**: `getNearbyListings` query using Euclidean distance ordering in SQLite, exposed via `createServerFn` with Zod validation.
- Uses **MapLibre GL JS** + **OpenFreeMap** tiles (no API key, no telemetry). Dynamic imports in `onMount` for SSR safety.

## Test Plan

- [x] Visit home page — map renders with grouped markers
- [x] Click a marker group — pip highlights, region outline appears, cards filter, URL updates
- [x] Navigate to `/?area=<res-6-cell>` — descendant listings included
- [x] Navigate to `/?area=<res-8-cell>` — clamped to resolution 7
- [x] Visit a listing as owner — pin + green hex overlay + legend visible
- [x] Visit a listing as non-owner — hex polygon only, no exact location
- [x] `pnpm test` — all unit tests pass (h3-area clamping, toPublicListing res 8, etc.)
- [x] `pnpm exec playwright test tests/e2e/area-filter.test.ts` — E2E area filter tests pass

## Review Notes

Self-reviewed via deliver skill with 5 parallel reviewers (Architect, User-Advocate, Adversary, Standards, Operator). Addressed: Sentry error handling, mounted-flag guard, color constants referencing design system, `role="application"` for interactive map, `Show` callback type narrowing.

Deferred to `_now-next-later.md`: shared map init boilerplate, loading skeletons, keyboard accessibility, interaction hints, OTel instrumentation, server-side spatial filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)