### PR TITLE
feat(map): dynamic H3 grouping resolution based on map zoom

### DIFF
--- a/apps/www/src/lib/h3-area.ts
+++ b/apps/www/src/lib/h3-area.ts
@@ -2,8 +2,8 @@ import { getResolution, cellToParent, isValidCell } from 'h3-js'
 import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
 
 /**
- * Normalizes an area H3 index: clamps finer resolutions to the home-page
- * grouping resolution and rejects cells coarser than the minimum area.
+ * Normalizes an area H3 index: clamps finer resolutions to the maximum public
+ * area resolution and rejects cells coarser than the minimum area.
  * Returns null for invalid indices.
  */
 export function normalizeArea(area: string | null): string | null {
@@ -11,8 +11,8 @@ export function normalizeArea(area: string | null): string | null {
 	if (!isValidCell(area)) return null
 	const res = getResolution(area)
 	if (res < H3_RESOLUTIONS.MIN_AREA) return null
-	if (res > H3_RESOLUTIONS.HOME_GROUPING) {
-		return cellToParent(area, H3_RESOLUTIONS.HOME_GROUPING)
+	if (res > H3_RESOLUTIONS.MAX_PUBLIC_AREA) {
+		return cellToParent(area, H3_RESOLUTIONS.MAX_PUBLIC_AREA)
 	}
 	return area
 }

--- a/apps/www/src/lib/h3-resolutions.ts
+++ b/apps/www/src/lib/h3-resolutions.ts
@@ -26,3 +26,29 @@ export const H3_RESOLUTIONS = {
 	/** Finest resolution allowed for owner-facing views. */
 	MAX_OWNER_AREA: 13,
 } as const
+
+/**
+ * ln(4) / ln(7) ≈ 0.7124 — the zoom-per-H3-resolution ratio.
+ *
+ * Each H3 resolution subdivides cell area by 7; each OSM zoom level
+ * subdivides visible area by 4. The ratio converts between the two scales.
+ */
+const ZOOM_PER_H3_RES = Math.log(4) / Math.log(7)
+
+/**
+ * Offset calibrated so OSM zoom 13 maps to H3 resolution 8, yielding
+ * ≈ 5 H3 cells in a typical map viewport (finer grouping).
+ */
+const ZOOM_OFFSET = 8 - ZOOM_PER_H3_RES * 13
+
+/**
+ * Maps an OSM zoom level to the H3 resolution that keeps roughly 3–20 cells
+ * visible on screen. Clamped to [MIN_AREA, MAX_PUBLIC_AREA].
+ */
+export function zoomToH3Resolution(zoom: number): number {
+	const raw = Math.round(ZOOM_PER_H3_RES * zoom + ZOOM_OFFSET)
+	return Math.max(
+		H3_RESOLUTIONS.MIN_AREA,
+		Math.min(H3_RESOLUTIONS.MAX_PUBLIC_AREA, raw)
+	)
+}

--- a/apps/www/tests/e2e/area-filter.test.ts
+++ b/apps/www/tests/e2e/area-filter.test.ts
@@ -23,11 +23,8 @@ test.describe('Home page area filter', () => {
 		await expect(card).toBeVisible()
 	})
 
-	test('fine resolution (> 7) is clamped and does not leak location data', async ({
-		page,
-		testListing,
-	}) => {
-		// 8828300531fffff is resolution 8 — should be clamped to resolution 7
+	test('resolution 8 area matches listings', async ({ page, testListing }) => {
+		// 8828300531fffff is resolution 8 (MAX_PUBLIC_AREA) — passes through unchanged
 		await page.goto('/?area=8828300531fffff')
 		const card = page.locator(`a[href="/listings/${testListing.id}"]`)
 		await expect(card).toBeVisible()

--- a/apps/www/tests/h3-area.test.ts
+++ b/apps/www/tests/h3-area.test.ts
@@ -41,21 +41,24 @@ describe('normalizeArea', () => {
 		expect(normalizeArea(res2Cell)).toBeNull()
 	})
 
-	it.each([
-		['resolution 8', res8Cell],
-		['resolution 9', res9Cell],
-		['resolution 13', res13Cell],
-	])('clamps %s to home-grouping resolution', (_label, fineCell) => {
-		const result = normalizeArea(fineCell)
-		expect(result).toBe(cellToParent(fineCell, H3_RESOLUTIONS.HOME_GROUPING))
+	it('passes through resolution-8 cells unchanged', () => {
+		expect(normalizeArea(res8Cell)).toBe(res8Cell)
 	})
 
-	it('never returns a cell finer than home-grouping resolution', () => {
-		for (let res = H3_RESOLUTIONS.HOME_GROUPING + 1; res <= 15; res++) {
+	it.each([
+		['resolution 9', res9Cell],
+		['resolution 13', res13Cell],
+	])('clamps %s to max public area resolution', (_label, fineCell) => {
+		const result = normalizeArea(fineCell)
+		expect(result).toBe(cellToParent(fineCell, H3_RESOLUTIONS.MAX_PUBLIC_AREA))
+	})
+
+	it('never returns a cell finer than max public area resolution', () => {
+		for (let res = H3_RESOLUTIONS.MAX_PUBLIC_AREA + 1; res <= 15; res++) {
 			const cell = latLngToCell(NAPA.lat, NAPA.lng, res)
 			const result = normalizeArea(cell)
 			expect(result).not.toBe(cell)
-			expect(result).toBe(cellToParent(cell, H3_RESOLUTIONS.HOME_GROUPING))
+			expect(result).toBe(cellToParent(cell, H3_RESOLUTIONS.MAX_PUBLIC_AREA))
 		}
 	})
 })

--- a/apps/www/tests/h3-resolutions.test.ts
+++ b/apps/www/tests/h3-resolutions.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { zoomToH3Resolution, H3_RESOLUTIONS } from '../src/lib/h3-resolutions'
+
+describe('zoomToH3Resolution', () => {
+	it('maps zoom 13 to H3 resolution 8', () => {
+		expect(zoomToH3Resolution(13)).toBe(8)
+	})
+
+	it.each([
+		[0, H3_RESOLUTIONS.MIN_AREA],
+		[1, H3_RESOLUTIONS.MIN_AREA],
+		[5, H3_RESOLUTIONS.MIN_AREA],
+		[6, H3_RESOLUTIONS.MIN_AREA],
+		[7, 4],
+		[8, 4],
+		[9, 5],
+		[10, 6],
+		[11, 7],
+		[12, 7],
+		[13, 8],
+		[14, H3_RESOLUTIONS.MAX_PUBLIC_AREA],
+		[15, H3_RESOLUTIONS.MAX_PUBLIC_AREA],
+		[18, H3_RESOLUTIONS.MAX_PUBLIC_AREA],
+		[20, H3_RESOLUTIONS.MAX_PUBLIC_AREA],
+	])('zoom %d → H3 resolution %d', (zoom, expectedRes) => {
+		expect(zoomToH3Resolution(zoom)).toBe(expectedRes)
+	})
+
+	it('never returns below MIN_AREA', () => {
+		for (let z = 0; z <= 7; z++) {
+			expect(zoomToH3Resolution(z)).toBeGreaterThanOrEqual(H3_RESOLUTIONS.MIN_AREA)
+		}
+	})
+
+	it('never returns above MAX_PUBLIC_AREA', () => {
+		for (let z = 14; z <= 22; z++) {
+			expect(zoomToH3Resolution(z)).toBeLessThanOrEqual(
+				H3_RESOLUTIONS.MAX_PUBLIC_AREA
+			)
+		}
+	})
+
+	it('is monotonically non-decreasing', () => {
+		let prev = zoomToH3Resolution(0)
+		for (let z = 1; z <= 22; z++) {
+			const cur = zoomToH3Resolution(z)
+			expect(cur).toBeGreaterThanOrEqual(prev)
+			prev = cur
+		}
+	})
+
+	it('handles fractional zoom levels', () => {
+		const res = zoomToH3Resolution(13.5)
+		expect(res).toBeGreaterThanOrEqual(H3_RESOLUTIONS.MIN_AREA)
+		expect(res).toBeLessThanOrEqual(H3_RESOLUTIONS.MAX_PUBLIC_AREA)
+	})
+})

--- a/docs/_now-next-later.md
+++ b/docs/_now-next-later.md
@@ -18,8 +18,8 @@
 # Next
 
 - Upload cover image to listing. Show image on home page tiles.
-- Home page map: automatically adjust H3 grouping resolution as the user zooms.
 - silence email logging in E2E tests
+- E2E test for dynamic H3 zoom grouping: programmatically zoom the MapLibre map and verify that listing group markers update. Requires WebGL in headless Chromium and a strategy for map tile loading.
 
 ## Unit Tests for Security-Critical Modules
 
@@ -140,6 +140,8 @@ The `hasRecentInquiry` check and `createInquiry` insert are not atomic — concu
 - **Add map loading states**: Show a placeholder/skeleton while MapLibre initializes asynchronously in both map components.
 - **Map accessibility**: Add keyboard-accessible group filter (buttons alongside map), screen reader announcements for filter changes (`aria-live`), and non-color selection indicators (size/stroke) for color-blind users.
 - **Map interaction hints**: Add instructional text ("Click a marker to filter by area"), hover tooltips on markers, and descriptive filter status ("Showing 3 of 12 listings").
+- **Preserve area selection across zoom changes**: When the H3 grouping resolution changes on zoom, coarsen or refine the selected area to match the new resolution instead of clearing it. Use `cellToParent` when zooming out or descendant matching when zooming in.
+- **Lift map resolution state to route layer**: Move H3 resolution tracking out of `ListingsMap` into the route component so the map is a pure presentation component and the route coordinates filtering and grouping consistently.
 - **Server-side spatial filtering**: `listingMatchesArea` currently runs client-side on the 12 listings returned by `getNearbyListings`. This has two scaling limits: (1) `getNearbyListings` does a full table scan with `ORDER BY distance` — no spatial index, so it degrades at ~1K+ listings; (2) coarse area filters produce false negatives because matching listings may exist in the DB but fall outside the top-12 by distance. Fix: add a precomputed `h3_res7` column (or use `cellToParent` in a generated column), index it, and filter `WHERE h3_res7 = $area` (or `WHERE h3_parent(h3_res7, $areaRes) = $area` for coarser areas) server-side. **Trigger**: OTel shows `getNearbyListings` p95 > 200ms, or expansion beyond one city makes the distance-only ordering insufficient.
 
 ---


### PR DESCRIPTION
## Summary

- Add `zoomToH3Resolution()` that maps OSM zoom levels to H3 resolutions using the `ln(4)/ln(7)` area-subdivision ratio, calibrated so zoom 13 → H3 resolution 8 (~5 cells visible), clamped to `[MIN_AREA(3), MAX_PUBLIC_AREA(8)]`
- `ListingsMap` listens for `zoomend` events and regroups listings dynamically — finer cells when zoomed in, coarser when zoomed out
- `groupByH3` now accepts a resolution parameter (defaults to `HOME_GROUPING` for backwards compatibility)
- `normalizeArea` clamp boundary widened from `HOME_GROUPING` (7) to `MAX_PUBLIC_AREA` (8) so area filters work at all dynamic grouping resolutions
- 20 unit tests covering formula correctness, boundary clamping, monotonicity, and fractional zoom levels

## Test Plan

- [x] 20 unit tests for `zoomToH3Resolution` (each zoom level, clamping, monotonicity, fractional values)
- [x] Updated `normalizeArea` tests for new `MAX_PUBLIC_AREA` boundary
- [x] Updated E2E area-filter test for resolution-8 pass-through
- [x] All 86 unit tests pass; quality gate passes (typecheck, lint, tests, formatting)
- [x] Manual: zoom in/out on home page map, verify group markers regroup at different resolutions
- [x] E2E zoom test deferred to roadmap (MapLibre + WebGL in headless browser)

## Review Notes

Self-reviewed with 5 agents (Architect, User-Advocate, Adversary, Standards, Operator). Key decisions:

- **Selection clearing on zoom:** Currently clears the area filter when grouping resolution changes. Preserving selection across resolutions (via `cellToParent` coarsening) deferred to roadmap.
- **Resolution state in component:** `ListingsMap` manages its own resolution state. Lifting to route layer deferred to roadmap.
- **Privacy:** `normalizeArea` now allows res 8 in URLs. This matches `PUBLIC_DETAIL` — area filters don't expose listings more precisely than detail pages already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)