### PR TITLE
test(db): add golden DB pattern for vitest

### DIFF
--- a/apps/www/.gitignore
+++ b/apps/www/.gitignore
@@ -29,5 +29,8 @@ pnpm-debug.log*
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+# Test databases
 test.db
 test.db-journal
+.test-dbs/

--- a/apps/www/.oxlintrc.json
+++ b/apps/www/.oxlintrc.json
@@ -77,6 +77,18 @@
 	"overrides": [
 		{
 			"files": [
+				"tests/helpers/**/*.ts",
+				"tests/vitest-global-setup.ts",
+				"tests/e2e/**/*.ts",
+				"vitest.config.ts",
+				"playwright.config.ts"
+			],
+			"rules": {
+				"import/no-nodejs-modules": "off"
+			}
+		},
+		{
+			"files": [
 				"src/**/*.test.ts",
 				"src/**/*.test.tsx",
 				"tests/**/*.ts",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -22,7 +22,7 @@
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",
 		"typecheck": "tsc --noEmit",
-		"clean": "rm -rf .output dist .nitro && git checkout HEAD -- src/routeTree.gen.ts",
+		"clean": "rm -rf .output dist .nitro .test-dbs && git checkout HEAD -- src/routeTree.gen.ts",
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
 		"db:push": "drizzle-kit push",

--- a/apps/www/tests/helpers/test-db-connection.ts
+++ b/apps/www/tests/helpers/test-db-connection.ts
@@ -1,0 +1,84 @@
+/**
+ * Database connection helpers for tests.
+ *
+ * Import in individual test files, NOT in setup.ts (which runs in jsdom
+ * and cannot load native libsql bindings).
+ */
+
+import { drizzle } from 'drizzle-orm/libsql'
+import { createClient } from '@libsql/client'
+import { beforeEach, afterEach } from 'vitest'
+import * as schema from '../../src/data/schema'
+import { setupTestDatabase, type TestDbContext } from './test-db-setup'
+
+/** Convert a database file path to a libsql connection URL. */
+export function toLibsqlUrl(dbPath: string): string {
+	return `file:${dbPath}`
+}
+
+/** Creates a Drizzle database connection for testing. */
+export function createTestDbConnection(dbPath: string) {
+	const client = createClient({ url: toLibsqlUrl(dbPath) })
+	const db = drizzle(client, { schema })
+
+	return {
+		client,
+		db,
+		close() {
+			client.close()
+		},
+	}
+}
+
+export type TestDbConnection = ReturnType<typeof createTestDbConnection>
+
+/**
+ * Opt-in test database lifecycle. Call at the top of a `describe` block to
+ * get a fresh database copy for each test. Returns accessors for the db path
+ * and a connected Drizzle instance.
+ */
+export function useTestDb() {
+	let ctx: TestDbContext | null = null
+	let conn: TestDbConnection | null = null
+
+	beforeEach((vitestCtx) => {
+		ctx = setupTestDatabase(vitestCtx.task.id)
+	})
+
+	afterEach(() => {
+		try {
+			conn?.close()
+		} finally {
+			conn = null
+		}
+		try {
+			ctx?.cleanup()
+		} finally {
+			ctx = null
+		}
+	})
+
+	return {
+		/** Returns the file path to the current test's database. */
+		getPath() {
+			if (!ctx) {
+				throw new Error(
+					'No test database available. Call getDb()/getPath() inside a test (it/beforeEach/afterEach), not at describe-scope or module level.'
+				)
+			}
+			return ctx.path
+		},
+		/** Returns a Drizzle connection to the current test's database. Lazily created, auto-closed in afterEach. */
+		getDb() {
+			if (!ctx) {
+				throw new Error(
+					'No test database available. Call getDb()/getPath() inside a test (it/beforeEach/afterEach), not at describe-scope or module level.'
+				)
+			}
+			if (!conn) {
+				conn = createTestDbConnection(ctx.path)
+			}
+			return conn.db
+		},
+	}
+}

--- a/apps/www/tests/helpers/test-db-setup.ts
+++ b/apps/www/tests/helpers/test-db-setup.ts
@@ -1,0 +1,150 @@
+/**
+ * File-system operations for test database isolation.
+ *
+ * Database connections live in test-db-connection.ts to avoid
+ * import issues with vitest's jsdom environment.
+ */
+
+import { execSync } from 'node:child_process'
+import {
+	copyFileSync,
+	existsSync,
+	unlinkSync,
+	mkdirSync,
+	readdirSync,
+} from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const wwwRoot = resolve(__dirname, '../..')
+const testDbDir = resolve(wwwRoot, '.test-dbs')
+
+/** Path to the "golden" migrated database. */
+export const GOLDEN_DB_PATH = resolve(testDbDir, 'golden.db')
+
+/** Get the path for a per-test database. */
+export function getTestDbPath(testId: string): string {
+	const safeId = testId.replace(/[^a-zA-Z0-9_-]/g, '_')
+	return resolve(testDbDir, `test-${safeId}.db`)
+}
+
+function ensureTestDbDir(): void {
+	mkdirSync(testDbDir, { recursive: true })
+}
+
+/** Removes a database file and its SQLite sidecar files. */
+function removeDatabaseFiles(dbPath: string): void {
+	for (const suffix of ['', '-wal', '-shm', '-journal']) {
+		const filePath = dbPath + suffix
+		try {
+			if (existsSync(filePath)) {
+				unlinkSync(filePath)
+			}
+		} catch (err) {
+			const error = new Error(`Failed to remove ${filePath}`)
+			;(error as unknown as { cause: unknown }).cause = err
+			throw error
+		}
+	}
+}
+
+/** Extracts stdout and stderr from an execSync error. */
+function extractExecOutput(err: unknown): string {
+	if (!(err instanceof Error)) {
+		return ''
+	}
+	const parts: string[] = []
+	if ('stdout' in err) {
+		const stdout = String((err as { stdout: Buffer }).stdout).trim()
+		if (stdout) {
+			parts.push(stdout)
+		}
+	}
+	if ('stderr' in err) {
+		const stderr = String((err as { stderr: Buffer }).stderr).trim()
+		if (stderr) {
+			parts.push(stderr)
+		}
+	}
+	return parts.join('\n')
+}
+
+/** Creates the "golden" database with migrations applied. Call once before the test suite. */
+export function createGoldenDatabase(): void {
+	ensureTestDbDir()
+	removeDatabaseFiles(GOLDEN_DB_PATH)
+
+	try {
+		execSync('pnpm db:migrate', {
+			cwd: wwwRoot,
+			env: { ...process.env, DATABASE_URL: `file:${GOLDEN_DB_PATH}` },
+			stdio: 'pipe',
+			timeout: 30_000,
+		})
+	} catch (err: unknown) {
+		const output = extractExecOutput(err)
+		const error = new Error(
+			`Failed to create golden test database.\nCommand: pnpm db:migrate\nDatabase: ${GOLDEN_DB_PATH}${output ? `\n\nOutput:\n${output}` : ''}`
+		)
+		;(error as unknown as { cause: unknown }).cause = err
+		throw error
+	}
+}
+
+/** Removes leftover per-test database files from `.test-dbs/`. */
+export function sweepOrphanedTestDbs(): void {
+	if (!existsSync(testDbDir)) {
+		return
+	}
+	for (const file of readdirSync(testDbDir)) {
+		if (file.startsWith('test-')) {
+			try {
+				unlinkSync(resolve(testDbDir, file))
+			} catch {
+				// Best-effort cleanup; file may be locked by another process
+			}
+		}
+	}
+}
+
+/** Copies the golden database to a per-test database file. */
+export function copyGoldenDatabase(testId: string): string {
+	const testDbPath = getTestDbPath(testId)
+
+	if (!existsSync(GOLDEN_DB_PATH)) {
+		throw new Error(
+			`Golden database not found at ${GOLDEN_DB_PATH}. ` +
+				`Run tests via "pnpm test" to ensure globalSetup creates this file.`
+		)
+	}
+
+	removeDatabaseFiles(testDbPath)
+	copyFileSync(GOLDEN_DB_PATH, testDbPath)
+	return testDbPath
+}
+
+/** Deletes a per-test database file and its sidecars. */
+export function cleanupTestDatabase(testId: string): void {
+	removeDatabaseFiles(getTestDbPath(testId))
+}
+
+/** Full test database context for a single test. */
+export interface TestDbContext {
+	path: string
+	testId: string
+	cleanup: () => void
+}
+
+/** Sets up a database file for a single test. Returns context with path and cleanup function. */
+export function setupTestDatabase(testId: string): TestDbContext {
+	const path = copyGoldenDatabase(testId)
+
+	return {
+		path,
+		testId,
+		cleanup() {
+			cleanupTestDatabase(testId)
+		},
+	}
+}

--- a/apps/www/tests/vitest-global-setup.ts
+++ b/apps/www/tests/vitest-global-setup.ts
@@ -1,0 +1,15 @@
+import {
+	createGoldenDatabase,
+	sweepOrphanedTestDbs,
+} from './helpers/test-db-setup'
+
+export default function globalSetup() {
+	sweepOrphanedTestDbs()
+	console.log('[test-db] Creating golden database...')
+	createGoldenDatabase()
+	console.log('[test-db] Golden database ready.')
+}
+
+export async function teardown() {
+	sweepOrphanedTestDbs()
+}

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 	test: {
 		environment: 'jsdom',
 		globals: true,
+		globalSetup: ['./tests/vitest-global-setup.ts'],
 		setupFiles: ['./tests/setup.ts'],
 		exclude: ['**/node_modules/**', '**/tests/e2e/**'],
 		env: {


### PR DESCRIPTION
## Summary

Introduces per-test database isolation using a "golden copy" pattern. A vitest globalSetup creates a single migrated SQLite database, and each test that opts in via `useTestDb()` gets a fresh file-system copy. This avoids running migrations per test while keeping tests fully isolated.

New files:
- `tests/helpers/test-db-setup.ts` — file-system operations for golden DB creation, per-test copying, and cleanup
- `tests/helpers/test-db-connection.ts` — Drizzle connection wrapper and `useTestDb()` lifecycle hook
- `tests/vitest-global-setup.ts` — creates golden DB before suite, sweeps orphaned test DBs after

Also adds an oxlint override to allow Node.js module imports in test helpers and config files, updates `.gitignore` for the `.test-dbs/` directory, and adds it to the `clean` script.

## Review

- Migration output was swallowed (only stderr captured) and had no timeout — addressed via `extractExecOutput` helper and a 30-second timeout on `execSync`.
- `conn.close()` throw in `afterEach` could skip `ctx.cleanup()`, leaking test DB files — addressed with try/finally ensuring both are always cleaned up.
- Non-atomic golden DB creation (failed migration leaves no golden DB) — rebutted: globalSetup throws on failure and vitest aborts before any tests run.
- globalSetup runs `pnpm db:migrate` even for pure-unit tests that never touch a DB — deferred to #66.
- No error handling in `removeDatabaseFiles` and `sweepOrphanedTestDbs` — addressed: `removeDatabaseFiles` throws with file-path context, `sweepOrphanedTestDbs` catches and continues.
- `useTestDb` error message was misleading ("must be called inside a describe block") — addressed with improved message referencing the actual timing constraint.
- `error.cause` set via double-cast instead of Error constructor option — ignored (ES2020 target lacks ErrorOptions typing).
- `copyGoldenDatabase` error message referenced an internal filename — addressed to say "Run tests via pnpm test".
- `sweepOrphanedTestDbs` gives no visibility into what was cleaned — ignored.
- `createGoldenDatabase` declared async but fully synchronous — addressed by dropping async.
- Minor findings (unexported internal, unused field, missing JSDoc, relative import) — ignored.

## Conversation

User asked to squash two commits on the `test-db-setup` branch into one. The first commit attempt was blocked by the lint hook — fixed lint errors (curly braces, preserve-caught- error, prefer-template) and added an oxlint override to disable `import/no-nodejs-modules` for test helpers and config files after the user rejected an inline eslint-disable comment approach. A typecheck failure from ES2020 lacking ErrorOptions support was fixed with a cast-and-assign pattern. A 5-agent review then ran in parallel, producing 14 findings; 6 were addressed, 1 rebutted, and 1 deferred to issue #66.