### PR TITLE
refactor(www): centralize env vars with validated modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist
 .env.*
 !.env.common
 !.env.development
+!.env.test
 !.env.sample
 !.env.example
 !.env.*.sample

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ We use a monorepo structure
 ## Important Notes
 
 - Validate input at system boundaries with Zod
+- Use Vite's `.env.[mode]` files (`.env.development`, `.env.test`) for environment-specific defaults rather than conditional logic in Zod schemas. Validation schemas should be uniform across environments — always require what production requires, and let configuration files supply non-production values.
 - HTML: write semantically-meaningful and accessible markup
 - Use SQLite for the data layer
 - Use the ORM for simple operations; use SQL and prepared statements for complex ones

--- a/apps/www/.env.development
+++ b/apps/www/.env.development
@@ -1,0 +1,7 @@
+# This file is committed to git. DO NOT add real secrets here.
+# Override locally with .env.development.local (gitignored).
+DATABASE_URL=file:local.db
+BETTER_AUTH_SECRET=dev-secret-do-not-use-in-production-min32chars
+BETTER_AUTH_URL=http://localhost:3000
+HMAC_SECRET=dev-hmac-secret-do-not-use-in-production
+LOG_DEV_EMAILS=true

--- a/apps/www/.env.test
+++ b/apps/www/.env.test
@@ -1,0 +1,7 @@
+# This file is committed to git. DO NOT add real secrets here.
+# Override locally with .env.test.local (gitignored).
+# NOTE: vitest.config.ts also duplicates these values — keep them in sync.
+DATABASE_URL=file:local.db
+BETTER_AUTH_SECRET=test-secret-do-not-use-in-production-min32chars
+HMAC_SECRET=test-secret-do-not-use-in-production-min32chars
+LOG_DEV_EMAILS=false

--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -29,10 +29,11 @@ export default defineConfig({
 		stdout: 'pipe',
 		stderr: 'pipe',
 		env: {
-			AUTH_LOG_MAGIC_LINK: 'false',
+			LOG_DEV_EMAILS: 'false',
 			PORT: '5174',
 			DATABASE_URL: `file:${testDbPath}`,
 			BETTER_AUTH_SECRET: 'test-secret-for-e2e-minimum-32-characters',
+			HMAC_SECRET: 'test-secret-for-e2e-minimum-32-characters',
 			BETTER_AUTH_URL: 'http://localhost:5174',
 		},
 	},

--- a/apps/www/src/data/db.ts
+++ b/apps/www/src/data/db.ts
@@ -1,11 +1,11 @@
 import { drizzle } from 'drizzle-orm/libsql'
 import { createClient } from '@libsql/client'
 import * as schema from './schema'
+import { serverEnv } from '@/lib/env.server'
 
-// For local development, use a local SQLite file
 const client = createClient({
-	url: process.env.DATABASE_URL || 'file:local.db',
-	authToken: process.env.DATABASE_AUTH_TOKEN,
+	url: serverEnv.DATABASE_URL,
+	authToken: serverEnv.DATABASE_AUTH_TOKEN,
 })
 
 export const db = drizzle(client, { schema })

--- a/apps/www/src/lib/auth.ts
+++ b/apps/www/src/lib/auth.ts
@@ -3,8 +3,8 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { magicLink } from 'better-auth/plugins'
 import { tanstackStartCookies } from 'better-auth/tanstack-start/solid'
 import { db } from '../data/db'
+import { serverEnv } from './env.server'
 
-// Conditionally import Resend only if API key is available
 const sendMagicLinkEmail = async ({
 	email,
 	url,
@@ -14,11 +14,8 @@ const sendMagicLinkEmail = async ({
 	url: string
 	token: string
 }) => {
-	const resendApiKey = process.env.RESEND_API_KEY
-
-	if (!resendApiKey) {
-		// Development mode: log to console (can be disabled via AUTH_LOG_MAGIC_LINK=false)
-		if (process.env.AUTH_LOG_MAGIC_LINK !== 'false') {
+	if (!serverEnv.RESEND_API_KEY) {
+		if (serverEnv.LOG_DEV_EMAILS) {
 			console.log('\n========================================')
 			console.log('MAGIC LINK (dev mode - no RESEND_API_KEY)')
 			console.log('========================================')
@@ -30,12 +27,11 @@ const sendMagicLinkEmail = async ({
 		return
 	}
 
-	// Production mode: send via Resend
 	const { Resend } = await import('resend')
-	const resend = new Resend(resendApiKey)
+	const resend = new Resend(serverEnv.RESEND_API_KEY)
 
 	await resend.emails.send({
-		from: process.env.EMAIL_FROM || 'Pick My Fruit <noreply@pickmyfruit.com>',
+		from: serverEnv.EMAIL_FROM || 'Pick My Fruit <noreply@pickmyfruit.com>',
 		to: email,
 		subject: 'Sign in to Pick My Fruit',
 		html: `
@@ -56,23 +52,12 @@ const sendMagicLinkEmail = async ({
 	})
 }
 
-// Development fallback for BETTER_AUTH_SECRET
-const secret = process.env.BETTER_AUTH_SECRET
-if (!secret && process.env.NODE_ENV === 'production') {
-	throw new Error('BETTER_AUTH_SECRET must be set in production')
-}
-if (!secret) {
-	console.warn(
-		'[auth] BETTER_AUTH_SECRET not set, using insecure development default'
-	)
-}
-
 export const auth = betterAuth({
 	database: drizzleAdapter(db, {
 		provider: 'sqlite',
 	}),
-	baseURL: process.env.BETTER_AUTH_URL,
-	secret: secret || 'dev-secret-do-not-use-in-production-min32chars',
+	baseURL: serverEnv.BETTER_AUTH_URL,
+	secret: serverEnv.BETTER_AUTH_SECRET,
 	plugins: [
 		magicLink({
 			sendMagicLink: sendMagicLinkEmail,

--- a/apps/www/src/lib/email-templates.ts
+++ b/apps/www/src/lib/email-templates.ts
@@ -1,4 +1,6 @@
 import { buildUnavailableUrl } from './hmac'
+import { Sentry } from './sentry'
+import { serverEnv } from './env.server'
 
 interface InquiryEmailData {
 	ownerName: string
@@ -84,29 +86,28 @@ function escapeHtml(text: string): string {
 export async function sendInquiryEmail(
 	data: InquiryEmailData
 ): Promise<boolean> {
-	const resendApiKey = process.env.RESEND_API_KEY
-
-	if (!resendApiKey) {
-		// Development mode: log to console
-		console.log('\n========================================')
-		console.log('INQUIRY EMAIL (dev mode - no RESEND_API_KEY)')
-		console.log('========================================')
-		console.log(`To: ${data.ownerEmail}`)
-		console.log(`Reply-To: ${data.gleanerEmail}`)
-		console.log(`Subject: ${buildInquiryEmailSubject(data)}`)
-		console.log('----------------------------------------')
-		console.log(buildInquiryEmailHtml(data))
-		console.log('========================================\n')
+	if (!serverEnv.RESEND_API_KEY) {
+		if (serverEnv.LOG_DEV_EMAILS) {
+			console.log('\n========================================')
+			console.log('INQUIRY EMAIL (dev mode - no RESEND_API_KEY)')
+			console.log('========================================')
+			console.log(`To: ${data.ownerEmail}`)
+			console.log(`Reply-To: ${data.gleanerEmail}`)
+			console.log(`Subject: ${buildInquiryEmailSubject(data)}`)
+			console.log('----------------------------------------')
+			console.log(buildInquiryEmailHtml(data))
+			console.log('========================================\n')
+		}
 		return true
 	}
 
 	try {
 		const { Resend } = await import('resend')
-		const resend = new Resend(resendApiKey)
+		const resend = new Resend(serverEnv.RESEND_API_KEY)
 
 		await resend.emails.send({
 			from:
-				process.env.EMAIL_FROM || 'Pick My Fruit <notifications@pickmyfruit.com>',
+				serverEnv.EMAIL_FROM || 'Pick My Fruit <notifications@pickmyfruit.com>',
 			to: data.ownerEmail,
 			replyTo: data.gleanerEmail,
 			subject: buildInquiryEmailSubject(data),
@@ -115,7 +116,7 @@ export async function sendInquiryEmail(
 
 		return true
 	} catch (error) {
-		console.error('Failed to send inquiry email:', error)
+		Sentry.captureException(error)
 		return false
 	}
 }

--- a/apps/www/src/lib/env.client.ts
+++ b/apps/www/src/lib/env.client.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+const isProd = import.meta.env.PROD as boolean
+
+const schema = z
+	.object({
+		VITE_SENTRY_DSN: z.url().optional(),
+		VITE_SENTRY_ENABLED: z
+			.enum(['true', 'false'])
+			.transform((v) => v === 'true')
+			.optional(),
+	})
+	.transform((data) => ({
+		sentryDsn: data.VITE_SENTRY_DSN,
+		// In prod: default to true if DSN is available
+		// In other envs: default to false (reporting off, opt-in for testing)
+		sentryEnabled: data.VITE_SENTRY_ENABLED ?? (isProd && !!data.VITE_SENTRY_DSN),
+		mode: import.meta.env.MODE as string,
+		prod: isProd,
+	}))
+	.refine((data) => !isProd || data.sentryDsn, {
+		message: 'VITE_SENTRY_DSN must be set in production',
+	})
+	.refine((data) => !isProd || data.sentryEnabled, {
+		message: 'VITE_SENTRY_ENABLED cannot be false in production',
+	})
+
+/**
+ * Validated client-side environment variables.
+ *
+ * Properties use camelCase with the VITE_ prefix stripped since that prefix
+ * is a build-tool detail. Compare with serverEnv, which keeps canonical
+ * SCREAMING_SNAKE_CASE names matching what operators set in .env / Docker.
+ */
+export const clientEnv = schema.parse({
+	VITE_SENTRY_DSN: import.meta.env.VITE_SENTRY_DSN,
+	VITE_SENTRY_ENABLED: import.meta.env.VITE_SENTRY_ENABLED,
+})

--- a/apps/www/src/lib/env.server.ts
+++ b/apps/www/src/lib/env.server.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+
+let fileEnv: Record<string, string> = {}
+if (process.env.NODE_ENV !== 'production') {
+	try {
+		const { loadEnv } = await import('vite')
+		try {
+			fileEnv = loadEnv(process.env.NODE_ENV || 'development', process.cwd(), '')
+		} catch (err) {
+			console.warn(
+				'env.server: loadEnv failed, falling back to process.env only',
+				err
+			)
+		}
+	} catch {
+		// vite not installed — production runtime or standalone script, expected
+	}
+}
+
+const schema = z.object({
+	NODE_ENV: z.string().default('development'),
+	DATABASE_URL: z.string().min(1),
+	DATABASE_AUTH_TOKEN: z.string().optional(),
+	BETTER_AUTH_SECRET: z.string().min(32),
+	BETTER_AUTH_URL: z.string().optional(),
+	RESEND_API_KEY: z.string().optional(),
+	EMAIL_FROM: z.string().optional(),
+	LOG_DEV_EMAILS: z.string().transform((v) => v === 'true'),
+	HMAC_SECRET: z.string().min(32),
+})
+
+const result = schema.safeParse({ ...fileEnv, ...process.env })
+if (!result.success) {
+	const missing = result.error.issues.map(
+		(i) => `  ${i.path.join('.')}: ${i.message}`
+	)
+	throw new Error(
+		`Environment validation failed. Check .env files or deployment secrets:\n${missing.join('\n')}`
+	)
+}
+
+/**
+ * Validated server-side environment variables.
+ *
+ * Properties use their canonical SCREAMING_SNAKE_CASE names so they match
+ * what operators set in .env files, Docker, and Fly secrets.
+ * Compare with clientEnv, which strips the VITE_ prefix into camelCase
+ * since that prefix is a build-tool detail.
+ */
+export const serverEnv = result.data

--- a/apps/www/src/lib/hmac.ts
+++ b/apps/www/src/lib/hmac.ts
@@ -1,13 +1,5 @@
 import { createHmac, timingSafeEqual, randomUUID } from 'crypto'
-
-const secret = process.env.HMAC_SECRET
-if (!secret && process.env.NODE_ENV === 'production') {
-	throw new Error('HMAC_SECRET must be set in production')
-}
-if (!secret) {
-	console.warn('[hmac] HMAC_SECRET not set, using insecure development default')
-}
-const HMAC_SECRET = secret || 'dev-secret-change-in-prod'
+import { serverEnv } from './env.server'
 
 /** Signed URLs expire after 7 days. */
 export const SIGNATURE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
@@ -21,7 +13,9 @@ export function signUrl(listingId: number): {
 	const nonce = randomUUID()
 	const ts = Date.now()
 	const message = `${listingId}:${nonce}:${ts}`
-	const sig = createHmac('sha256', HMAC_SECRET).update(message).digest('hex')
+	const sig = createHmac('sha256', serverEnv.HMAC_SECRET)
+		.update(message)
+		.digest('hex')
 	return { nonce, ts, sig }
 }
 
@@ -38,7 +32,7 @@ export function verifySignature(
 		return false
 	}
 	const message = `${listingId}:${nonce}:${ts}`
-	const expected = createHmac('sha256', HMAC_SECRET)
+	const expected = createHmac('sha256', serverEnv.HMAC_SECRET)
 		.update(message)
 		.digest('hex')
 	if (sig.length !== expected.length) {

--- a/apps/www/src/lib/sentry.ts
+++ b/apps/www/src/lib/sentry.ts
@@ -1,27 +1,5 @@
 import * as Sentry from '@sentry/solidstart'
-import { z } from 'zod'
-
-const isProd = import.meta.env.PROD
-
-const sentryConfigSchema = z
-	.object({
-		VITE_SENTRY_DSN: z.url(),
-		VITE_SENTRY_ENABLED: z
-			.enum(['true', 'false'])
-			.transform((v) => v === 'true')
-			.optional(),
-	})
-	.transform((data) => ({
-		dsn: data.VITE_SENTRY_DSN,
-		// In prod: default to true (reporting on)
-		// In other envs: default to false (reporting off, opt-in for testing)
-		enabled: data.VITE_SENTRY_ENABLED ?? isProd,
-	}))
-	.refine((data) => !isProd || data.enabled !== false, {
-		message: 'VITE_SENTRY_ENABLED cannot be false in production',
-	})
-
-const config = sentryConfigSchema.parse(import.meta.env)
+import { clientEnv } from './env.client'
 
 function logError(error: unknown, context?: Record<string, unknown>): void {
 	const timestamp = new Date().toISOString()
@@ -36,15 +14,19 @@ function logError(error: unknown, context?: Record<string, unknown>): void {
 	})
 }
 
-Sentry.init({
-	dsn: config.dsn,
-	enabled: config.enabled,
-	environment: import.meta.env.MODE,
-	tracesSampleRate: 1.0,
-	beforeSend(event, hint) {
-		logError(hint.originalException, { sentryEventId: event.event_id })
-		return event
-	},
-})
+if (clientEnv.sentryDsn) {
+	Sentry.init({
+		dsn: clientEnv.sentryDsn,
+		enabled: clientEnv.sentryEnabled,
+		environment: clientEnv.mode,
+		tracesSampleRate: 1.0,
+		beforeSend(event, hint) {
+			logError(hint.originalException, {
+				sentryEventId: event.event_id,
+			})
+			return event
+		},
+	})
+}
 
 export { Sentry }

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -8,12 +8,17 @@ export default defineConfig({
 	test: {
 		environment: 'jsdom',
 		globals: true,
+		// loadEnv doesn't work in vitest's jsdom environment, so we
+		// duplicate .env.test values here for test-time injection.
+		env: {
+			DATABASE_URL: 'file:local.db',
+			BETTER_AUTH_SECRET: 'test-secret-do-not-use-in-production-min32chars',
+			HMAC_SECRET: 'test-secret-do-not-use-in-production-min32chars',
+			LOG_DEV_EMAILS: 'false',
+		},
 		globalSetup: ['./tests/vitest-global-setup.ts'],
 		setupFiles: ['./tests/setup.ts'],
 		exclude: ['**/node_modules/**', '**/tests/e2e/**'],
-		env: {
-			AUTH_LOG_MAGIC_LINK: 'false',
-		},
 		deps: {
 			optimizer: {
 				web: {


### PR DESCRIPTION
## Summary

- Introduce `env.server.ts` (Vite `loadEnv` + `process.env` merge + Zod validation) and `env.client.ts` (`import.meta.env` + Zod validation) to centralize all environment variable handling
- Migrate all consumers (`auth`, `db`, `hmac`, `sentry`, `email-templates`) from direct `process.env` / `import.meta.env` reads to the validated modules
- Move per-environment defaults into `.env.development` and `.env.test` (committed to git) instead of conditional schema logic — staging/preview environments no longer silently inherit well-known dev secrets
- Rename `AUTH_LOG_MAGIC_LINK` → `LOG_DEV_EMAILS`, gate inquiry email logging behind it
- Guard `Sentry.init` on DSN presence; enforce DSN + enabled in production via refines
- Enforce `min(32)` on `BETTER_AUTH_SECRET` and `HMAC_SECRET`
- Add `env-file-first` convention to CLAUDE.md

## Test plan

- [x] TypeScript typecheck passes
- [x] All 86 unit tests pass
- [x] Quality gate (typecheck + lint + tests + format) passes
- [x] Manual: `pnpm dev` starts without errors
- [x] Manual: `pnpm run db:seed` works (exercises `env.server.ts` via `tsx`)
- [ ] Manual: Deploy to staging with all required env vars set

## Review notes

Three review rounds (18 total reviewer invocations):
1. Full 5-agent review — 13 findings (10 addressed, 2 rebutted, 1 deferred)
2. Security-focused (Adversary + Operator) — surfaced the staging security gap that led to the `.env.[mode]` redesign
3. Full 5-agent re-review — 12 findings (5 addressed, 7 deferred)

Deferred issues:
- #113 — EMAIL_FROM validation
- #115 — Unit tests for env modules
- #116 — Load .env.test programmatically in vitest.config.ts
- #117 — Split sentry.ts into server and client modules
- #118 — Consolidate EMAIL_FROM defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)