### PR TITLE
fix(www): polyfill __dirname in h3-js ESM bundle

### DIFF
--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -4,6 +4,23 @@ import { tanstackStart } from '@tanstack/solid-start/plugin/vite'
 import { nitro } from 'nitro/vite'
 import solid from 'vite-plugin-solid'
 
+// h3-js is an Emscripten-generated bundle that uses `__dirname` to locate its
+// WASM initializer. When Nitro bundles it as ESM, `__dirname` is undefined.
+// The WASM is inlined as a base64 data URI so the path is never actually used,
+// but the reference still throws at module load. Replace it with the ESM
+// equivalent (`import.meta.dirname`, available in Node.js 21.2+).
+const h3jsDirnamePolyfill = {
+	name: 'h3js-dirname-polyfill',
+	transform(code: string, id: string) {
+		if (id.includes('h3-js') && code.includes('__dirname')) {
+			return {
+				code: code.replaceAll('__dirname', 'import.meta.dirname'),
+				map: null,
+			}
+		}
+	},
+}
+
 export default defineConfig(({ command, mode }) => {
 	if (command === 'serve') {
 		// Merge .env.[mode] files into process.env so server-side modules
@@ -17,6 +34,12 @@ export default defineConfig(({ command, mode }) => {
 
 	return {
 		server: {},
-		plugins: [tsconfigPaths(), tanstackStart(), nitro(), solid({ ssr: true })],
+		plugins: [
+			tsconfigPaths(),
+			tanstackStart(),
+			nitro(),
+			h3jsDirnamePolyfill,
+			solid({ ssr: true }),
+		],
 	}
 })


### PR DESCRIPTION
## Summary

- `h3-js` (Emscripten-generated) references `__dirname` to locate its WASM binary at module load time
- Nitro bundles it as `.mjs`, where `__dirname` is undefined in ES module scope → server crashes on boot with `ReferenceError: __dirname is not defined`
- The WASM is inlined as a base64 `data:` URI, so `__dirname` / `scriptDirectory` is never actually used for file I/O — the bare reference just can't exist in ESM

Adds a Vite transform plugin that replaces `__dirname` with `import.meta.dirname` (Node.js 21.2+, native ESM equivalent) in the h3-js source before bundling.

## Test plan

- [ ] Build and deploy to staging; confirm server boots without `ReferenceError`
- [ ] Verify H3 cell operations (map clustering, area filtering) still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)