### PR TITLE
feat(www): run DB migrations on first request in production

### DIFF
--- a/apps/www/Dockerfile
+++ b/apps/www/Dockerfile
@@ -53,6 +53,12 @@ WORKDIR /app
 COPY --from=builder /app/apps/www/.output ./.output
 COPY --from=builder /app/apps/www/package.json ./package.json
 
+# Migration SQL files are read from disk at runtime by drizzle-orm/libsql/migrator.
+# They must be at ./drizzle relative to the working directory (/app/drizzle).
+COPY --from=builder /app/apps/www/drizzle ./drizzle
+RUN test -f /app/drizzle/meta/_journal.json || \
+  (echo "ERROR: drizzle migrations missing from image" && exit 1)
+
 # Create directory for SQLite database
 RUN mkdir -p /app/data
 
@@ -60,7 +66,7 @@ RUN mkdir -p /app/data
 EXPOSE 3000
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3000/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
 
 # Start the server

--- a/apps/www/src/lib/env.server.ts
+++ b/apps/www/src/lib/env.server.ts
@@ -8,6 +8,7 @@ const baseSchema = z.object({
 	EMAIL_FROM: z.string(),
 	EMAIL_PROVIDER: z.string(),
 	HMAC_SECRET: z.string().min(32),
+	MIGRATE_ON_REQUEST: z.stringbool().default(false),
 	NODE_ENV: z.string(),
 })
 

--- a/apps/www/src/lib/migrations.ts
+++ b/apps/www/src/lib/migrations.ts
@@ -1,0 +1,34 @@
+import { migrate } from 'drizzle-orm/libsql/migrator'
+import { db } from '@/data/db'
+import { Sentry } from '@/lib/sentry'
+import { serverEnv } from '@/lib/env.server'
+
+let pending: Promise<void> | undefined
+let failureCount = 0
+const MAX_ATTEMPTS = 3
+
+/**
+ * Runs pending database migrations, retrying up to 3 times across requests.
+ *
+ * No-ops outside production — dev and test use `db:push`/`db:migrate` directly.
+ * Failures are captured to Sentry. After MAX_ATTEMPTS the promise permanently
+ * rejects so a broken migration does not hammer the database on every request.
+ */
+export function runMigrations(): Promise<void> {
+	if (!serverEnv.MIGRATE_ON_REQUEST) return Promise.resolve()
+
+	if (failureCount >= MAX_ATTEMPTS) {
+		return Promise.reject(
+			new Error(`Database migrations failed after ${MAX_ATTEMPTS} attempts`)
+		)
+	}
+
+	pending ??= migrate(db, { migrationsFolder: './drizzle' }).catch((err) => {
+		Sentry.captureException(err)
+		failureCount++
+		pending = undefined
+		throw err
+	})
+
+	return pending
+}

--- a/apps/www/src/middleware/migrations.ts
+++ b/apps/www/src/middleware/migrations.ts
@@ -1,0 +1,21 @@
+import { createMiddleware } from '@tanstack/solid-start'
+import { runMigrations } from '@/lib/migrations'
+
+/**
+ * Ensures all database migrations have run before handling any request.
+ * @todo address race condition before supporting multiple processes.
+ * @see https://github.com/jamesarosen/PickMyFruit/issues/134
+ */
+export const migrationsMiddleware = createMiddleware().server(
+	async ({ next }) => {
+		try {
+			await runMigrations()
+		} catch {
+			return Response.json(
+				{ status: 'error', error: 'Service temporarily unavailable' },
+				{ status: 503 }
+			)
+		}
+		return next()
+	}
+)

--- a/apps/www/src/start.ts
+++ b/apps/www/src/start.ts
@@ -1,10 +1,12 @@
 import { createStart } from '@tanstack/solid-start'
+import { migrationsMiddleware } from '@/middleware/migrations'
 import { securityHeadersMiddleware } from '@/middleware/security-headers'
 import { tlsMiddleware } from '@/middleware/tls'
 
 export const startInstance = createStart(() => ({
 	requestMiddleware: [
-		tlsMiddleware, // Must run first: may short-circuit with a redirect
+		migrationsMiddleware, // schema must exist before any handler runs
+		tlsMiddleware, // May short-circuit with a redirect
 		securityHeadersMiddleware, // Applies to all non-redirect responses
 	],
 }))

--- a/fly.toml
+++ b/fly.toml
@@ -49,6 +49,7 @@ primary_region = 'sjc'
 # Environment variables
 [env]
   EMAIL_PROVIDER = 'resend'
+  MIGRATE_ON_REQUEST = 'true'
   NODE_ENV = 'production'
 
 # VM resources - Start with minimal for MVP


### PR DESCRIPTION
## Summary

- Adds `lib/migrations.ts`: singleton promise that runs `drizzle-orm/libsql/migrator` once per process, with Sentry capture and a 3-attempt cap before permanently rejecting
- Adds `middleware/migrations.ts`: request middleware that awaits migrations before any handler; returns 503 on failure (which Fly.io's health check sees correctly)
- Registers `migrationsMiddleware` first in `start.ts`
- Dockerfile now copies `drizzle/` SQL files into the runner image with a build-time assertion, and bumps HEALTHCHECK `start_period` (15s→30s) and `timeout` (3s→5s) to give migrations room to complete

`lib/migrations.ts` is a no-op outside production; dev/test continue using `db:push` / `db:migrate` directly.

## Why this approach

- **Fly.io `release_command`** was ruled out — volumes are not mounted in release VMs, so the SQLite file is unreachable
- **Nitro server plugins** were ruled out — `initNitroPlugins()` calls plugins synchronously and does not await async return values
- **Lazy-first-request middleware** works: the singleton promise is shared across all concurrent requests, the server stays up during migration, and a 503 is returned on failure rather than crashing

## Test Plan

- [x] `flyctl deploy` — first request after deploy should succeed; `fly logs` should show no migration errors
- [x] Roll back a migration file from the image and confirm the server returns 503 until corrected
- [x] Confirm `/api/health` returns 503 (not 200) when migrations are failing

## Review Notes

Self-reviewed via deliver skill — all 5 agents (Architect, User-Advocate, Adversary, Standards, Operator) ran in parallel.

- **CRITICAL** (migration errors unhandled) → addressed: middleware catches and returns 503, Sentry captures in migrations.ts
- **HIGH** (fragile relative path) → addressed: Dockerfile build-time assertion; healthcheck timeouts increased
- **HIGH** (health check unaware of migrations) → addressed: middleware 503 propagates to health check path
- **HIGH** (no retry cap) → addressed: MAX_ATTEMPTS=3
- **MEDIUM** (multi-process race on >1 machine) → deferred #134
- **MEDIUM** (NODE_ENV guard makes code untestable) → addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)