### PR TITLE
refactor(www): replace console.log/error with structured Pino logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ A site for gardeners to share surplus produce with their community.
 - Use semantic names for variables and functions to document what they do. Use comments to document why, especially for non-intuitive or unusual code.
 - Use idiomatic Solid JS, TanStack Router, TypeScript, SQLite.
 - Use context7
-- When handling exceptions, import Sentry from `@/lib/sentry` and use `Sentry.captureException`. Do not separately log errors — `src/lib/sentry.ts` is the designated exception handler and manages console output itself.
+- When handling exceptions, import Sentry from `@/lib/sentry` and use `Sentry.captureException`. Do not separately log errors — `src/lib/sentry.ts` is the designated exception handler and manages console output itself. (Exception: `sentry.ts` itself uses `console.error` because it runs on both client and server and cannot depend on Pino.)
+- For server-side informational/debug logging, import `logger` from `@/lib/logger.server` (Pino). Always pass structured data as the first argument: `logger.info(fields, msg)`, `logger.debug(fields, msg)`, `logger.warn(fields, msg)`. Use `logger.error(fields, msg)` only in CLI scripts (e.g. `seed.ts`) where Sentry is not initialized — in all other server code, use `Sentry.captureException` for errors. Do **not** use `console.log` or `console.error` in application code. (Exception: test infrastructure files such as `vitest-global-setup.ts` may use `console.log`.)
 
 ### Solid JS
 

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -42,6 +42,7 @@
 		"h3-js": "^4.4.0",
 		"lucide-solid": "^0.564.0",
 		"maplibre-gl": "^5.18.0",
+		"pino": "^10.3.1",
 		"resend": "^6.9.2",
 		"solid-js": "^1.9.11",
 		"zod": "^4.3.6"
@@ -57,6 +58,7 @@
 		"jsdom": "^27.4.0",
 		"nitro": "3.0.1-alpha.2",
 		"oxlint": "^1.47.0",
+		"pino-pretty": "^13.1.3",
 		"prettier": "^3.8.1",
 		"tsx": "^4.21.0",
 		"typescript": "^5.9.3",

--- a/apps/www/src/api/inquiries.ts
+++ b/apps/www/src/api/inquiries.ts
@@ -61,16 +61,11 @@ export const submitInquiry = createServerFn({ method: 'POST' })
 		const { sendInquiryEmail } = await import('@/lib/email-templates')
 		try {
 			await sendInquiryEmail({
-				ownerName: owner.name,
-				ownerEmail: owner.email,
-				gleanerName: gleaner.name,
-				gleanerEmail: gleaner.email,
-				gleanerNote: note,
-				produceType: listing.type,
-				quantity: listing.quantity,
-				listingNotes: listing.notes,
-				plantId: listing.id,
 				baseUrl,
+				gleaner,
+				gleanerNote: note,
+				listing,
+				owner,
 			})
 		} catch (error) {
 			const { Sentry } = await import('@/lib/sentry')

--- a/apps/www/src/data/seed.ts
+++ b/apps/www/src/data/seed.ts
@@ -8,6 +8,7 @@ import {
 	type NewListing,
 	type NewUser,
 } from './schema'
+import { logger } from '@/lib/logger.server'
 import { ListingStatus } from '@/lib/validation'
 
 // Napa Valley approximate bounds
@@ -143,7 +144,7 @@ function generateListing(userId: string): NewListing {
 }
 
 async function seed() {
-	console.log('🌱 Seeding database...')
+	logger.info('Seeding database...')
 
 	// Clear data in FK-safe order — preserve existing auth users
 	await db.delete(inquiries)
@@ -159,8 +160,13 @@ async function seed() {
 
 	// Use all users (seed + existing) for listing assignment
 	const allUsers = await db.select().from(user)
-	console.log(
-		`✅ ${allUsers.length} users available (${inserted.length} new, ${allUsers.length - inserted.length} existing)`
+	logger.info(
+		{
+			total: allUsers.length,
+			inserted: inserted.length,
+			existing: allUsers.length - inserted.length,
+		},
+		'Users available'
 	)
 
 	// Generate 50 listings with random users
@@ -172,21 +178,23 @@ async function seed() {
 	// Insert listings
 	await db.insert(listings).values(listingsData)
 
-	console.log(`✅ Seeded ${listingsData.length} listings`)
+	logger.info({ count: listingsData.length }, 'Listings seeded')
 
 	// Show a few examples
 	const examples = await db.select().from(listings).limit(3)
-	console.log('\n📋 Sample listings:')
-	examples.forEach((listing, i) => {
-		console.log(
-			`${i + 1}. ${listing.name} - ${listing.type} (${listing.variety}) in ${listing.city}`
-		)
-	})
+	logger.info(
+		{
+			samples: examples.map(
+				(l) => `${l.name} - ${l.type} (${l.variety}) in ${l.city}`
+			),
+		},
+		'Sample listings'
+	)
 
 	process.exit(0)
 }
 
 seed().catch((error) => {
-	console.error('❌ Seed failed:', error)
+	logger.error({ err: error }, 'Seed failed')
 	process.exit(1)
 })

--- a/apps/www/src/lib/auth.ts
+++ b/apps/www/src/lib/auth.ts
@@ -4,6 +4,7 @@ import { magicLink } from 'better-auth/plugins'
 import { tanstackStartCookies } from 'better-auth/tanstack-start/solid'
 import { db } from '../data/db'
 import { serverEnv } from './env.server'
+import { logger } from './logger.server'
 
 const sendMagicLinkEmail = async ({
 	email,
@@ -17,13 +18,7 @@ const sendMagicLinkEmail = async ({
 	if (serverEnv.EMAIL_PROVIDER === 'silent') return
 
 	if (serverEnv.EMAIL_PROVIDER === 'console') {
-		console.log('\n========================================')
-		console.log('MAGIC LINK (EMAIL_PROVIDER=console)')
-		console.log('========================================')
-		console.log(`Email: ${email}`)
-		console.log(`URL: ${url}`)
-		console.log(`Token: ${token}`)
-		console.log('========================================\n')
+		logger.info({ email, token, url }, 'Magic link (EMAIL_PROVIDER=console)')
 		return
 	}
 

--- a/apps/www/src/lib/email-templates.ts
+++ b/apps/www/src/lib/email-templates.ts
@@ -1,38 +1,46 @@
 import { buildUnavailableUrl } from './hmac'
 import { serverEnv } from './env.server'
+import { logger } from './logger.server'
 
 interface InquiryEmailData {
-	ownerName: string
-	ownerEmail: string
-	gleanerName: string
-	gleanerEmail: string
-	gleanerNote?: string | null
-	produceType: string
-	quantity?: string | null
-	listingNotes?: string | null
-	plantId: number
 	baseUrl: string
+	gleaner: {
+		name: string
+		email: string
+	}
+	gleanerNote?: string | null
+	listing: {
+		id: number
+		notes?: string | null
+		type: string
+		quantity: string | null
+	}
+	owner: {
+		name: string
+		email: string
+	}
+	unavailableUrl: string
 }
 
 export function buildInquiryEmailSubject(data: InquiryEmailData): string {
-	return `${data.gleanerName} wants your ${data.produceType}`
+	return `${data.gleaner.name} wants your ${data.listing.type}`
 }
 
 export function buildInquiryEmailHtml(data: InquiryEmailData): string {
-	const unavailableUrl = buildUnavailableUrl(data.baseUrl, data.plantId)
+	const { unavailableUrl } = data
 
-	const quantitySection = data.quantity
-		? `<p style="margin: 0 0 8px 0;"><strong>Quantity:</strong> ${escapeHtml(data.quantity)}</p>`
+	const quantitySection = data.listing.quantity
+		? `<p style="margin: 0 0 8px 0;"><strong>Quantity:</strong> ${escapeHtml(data.listing.quantity)}</p>`
 		: ''
 
-	const notesSection = data.listingNotes
-		? `<p style="margin: 0;"><strong>Your notes:</strong> ${escapeHtml(data.listingNotes)}</p>`
+	const notesSection = data.listing.notes
+		? `<p style="margin: 0;"><strong>Your notes:</strong> ${escapeHtml(data.listing.notes)}</p>`
 		: ''
 
 	const gleanerNoteSection = data.gleanerNote
 		? `
   <div style="background: #fef3c7; border-radius: 8px; padding: 16px; margin: 24px 0;">
-    <h3 style="margin: 0 0 8px 0; color: #92400e;">Message from ${escapeHtml(data.gleanerName)}</h3>
+    <h3 style="margin: 0 0 8px 0; color: #92400e;">Message from ${escapeHtml(data.gleaner.name)}</h3>
     <p style="margin: 0;">${escapeHtml(data.gleanerNote)}</p>
   </div>
   `
@@ -45,22 +53,22 @@ export function buildInquiryEmailHtml(data: InquiryEmailData): string {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-  <h1 style="color: #2d5016; margin-bottom: 24px;">Someone wants your ${escapeHtml(data.produceType)}!</h1>
+  <h1 style="color: #2d5016; margin-bottom: 24px;">Someone wants your ${escapeHtml(data.listing.type)}!</h1>
 
-  <p>Hi ${escapeHtml(data.ownerName)},</p>
+  <p>Hi ${escapeHtml(data.owner.name)},</p>
 
-  <p><strong>${escapeHtml(data.gleanerName)}</strong> is interested in your ${escapeHtml(data.produceType)}.</p>
+  <p><strong>${escapeHtml(data.gleaner.name)}</strong> is interested in your ${escapeHtml(data.listing.type)}.</p>
 
   <div style="background: #f9fafb; border-radius: 8px; padding: 16px; margin: 24px 0;">
     <h3 style="margin: 0 0 12px 0; color: #2d5016;">Listing Details</h3>
-    <p style="margin: 0 0 8px 0;"><strong>Type:</strong> ${escapeHtml(data.produceType)}</p>
+    <p style="margin: 0 0 8px 0;"><strong>Type:</strong> ${escapeHtml(data.listing.type)}</p>
     ${quantitySection}
     ${notesSection}
   </div>
 
   ${gleanerNoteSection}
 
-  <p>Simply <strong>reply to this email</strong> to get in touch with ${escapeHtml(data.gleanerName)}.</p>
+  <p>Simply <strong>reply to this email</strong> to get in touch with ${escapeHtml(data.gleaner.name)}.</p>
 
   <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 32px 0;">
 
@@ -83,19 +91,25 @@ function escapeHtml(text: string): string {
 }
 
 /** Sends an inquiry notification email. Throws on failure. */
-export async function sendInquiryEmail(data: InquiryEmailData): Promise<void> {
+export async function sendInquiryEmail(
+	input: Omit<InquiryEmailData, 'unavailableUrl'>
+): Promise<void> {
+	const data: InquiryEmailData = {
+		...input,
+		unavailableUrl: buildUnavailableUrl(input.baseUrl, input.listing.id),
+	}
+
 	if (serverEnv.EMAIL_PROVIDER === 'silent') return
 
 	if (serverEnv.EMAIL_PROVIDER === 'console') {
-		console.log('\n========================================')
-		console.log('INQUIRY EMAIL (EMAIL_PROVIDER=console)')
-		console.log('========================================')
-		console.log(`To: ${data.ownerEmail}`)
-		console.log(`Reply-To: ${data.gleanerEmail}`)
-		console.log(`Subject: ${buildInquiryEmailSubject(data)}`)
-		console.log('----------------------------------------')
-		console.log(buildInquiryEmailHtml(data))
-		console.log('========================================\n')
+		/**
+		 * `data` contains sensitive information, only some of which is covered by
+		 * our centralized redaction policy. This is intentional. We need the
+		 * signed URL in development. This email strategy can't be used in
+		 * production anyway.
+		 * @todo consider replacing with Mailpit or similar for local dev
+		 */
+		logger.info(data, 'Inquiry email (EMAIL_PROVIDER=console)')
 		return
 	}
 
@@ -105,8 +119,8 @@ export async function sendInquiryEmail(data: InquiryEmailData): Promise<void> {
 
 		const { error } = await resend.emails.send({
 			from: serverEnv.EMAIL_FROM,
-			to: data.ownerEmail,
-			replyTo: data.gleanerEmail,
+			to: data.owner.email,
+			replyTo: data.gleaner.email,
 			subject: buildInquiryEmailSubject(data),
 			html: buildInquiryEmailHtml(data),
 		})

--- a/apps/www/src/lib/logger.server.ts
+++ b/apps/www/src/lib/logger.server.ts
@@ -1,0 +1,100 @@
+import pino from 'pino'
+
+// Only enable pino-pretty in local development — not in test or production.
+// pino-pretty is a devDependency and is not available in the production image.
+const isDev = process.env.NODE_ENV === 'development'
+
+/**
+ * Paths redacted to prevent credentials and PII from reaching log sinks. Uses
+ * deep-wildcard syntax (`**`) to match at any nesting depth. Add freely; never
+ * remove without a privacy review.
+ */
+const REDACTED_PATHS = [
+	// Auth tokens and credentials
+	'**.token',
+	'**.accessToken',
+	'**.refreshToken',
+	'**.password',
+	'**.secret',
+	'**.key',
+	'**.apiKey',
+
+	// PII
+	'**.address',
+	'**.email',
+	'**.h3_index',
+	'**.lat',
+	'**.lng',
+	'**.name',
+	'**.phone',
+
+	// URLs — query params stripped rather than fully redacted (see censor below)
+	'**.url',
+
+	// HTTP layer
+	'req.headers.authorization',
+	'req.headers.cookie',
+	'res.headers["set-cookie"]',
+]
+
+const URL_KEY = /(^url$)|(U[rR][lL]$)/
+const EMAIL_KEY = /(^email$)|(E[mM][aA][iI][lL]$)/
+
+/**
+ * Production censor: strips query params from URLs (keeps origin+path
+ * readable), masks the local part of email addresses (keeps domain for
+ * debugging), and replaces everything else with `'[Redacted]'`.
+ */
+function prodCensor(value: unknown, path: string[]): unknown {
+	const key = path[path.length - 1]
+	if (URL_KEY.test(key) && (typeof value === 'string' || value instanceof URL)) {
+		try {
+			const u = new URL(value)
+			u.search = ''
+			return u.toString()
+		} catch {
+			return '[Redacted]'
+		}
+	}
+	if (EMAIL_KEY.test(key) && typeof value === 'string') {
+		const at = value.indexOf('@')
+		return at > 0 ? `xxx${value.slice(at)}` : '[Redacted]'
+	}
+	return '[Redacted]'
+}
+
+/**
+ * Development censor: wraps values with `[[…]]` markers so it's obvious which
+ * fields would be redacted in production without hiding the values themselves.
+ */
+function devCensor(value: unknown): unknown {
+	return `[[${String(value)}]]`
+}
+
+/**
+ * Server-side structured logger. Uses pino-pretty in development; JSON in
+ * production. Sensitive fields are redacted centrally so call sites never need
+ * to scrub values manually. In development, matched fields are wrapped with
+ * `[[…]]` markers so it's obvious what would be redacted in production. In
+ * production, URL query params are stripped, email local-parts are masked
+ * (`xxx@domain`), and everything else is replaced with `[Redacted]`.
+ *
+ * When logging structured fields alongside a message, the object must come
+ * first — `logger.info('msg', { field })` silently drops the object.
+ *
+ * @example
+ * logger.info('App started')
+ * logger.info({ userId, action: 'login' }, 'User authenticated')
+ *
+ * @see https://getpino.io/#/docs/redaction
+ */
+export const logger = pino({
+	name: 'pickmyfruit',
+	level: isDev ? 'debug' : 'info',
+	// dev:  wrap matched values with [[…]] so it's clear what would be redacted in prod.
+	// prod: strip query params from URLs, mask email local-parts, redact everything else.
+	redact: { paths: REDACTED_PATHS, censor: isDev ? devCensor : prodCensor },
+	transport: isDev
+		? { target: 'pino-pretty', options: { colorize: true } }
+		: undefined,
+})

--- a/apps/www/src/lib/sentry.ts
+++ b/apps/www/src/lib/sentry.ts
@@ -6,6 +6,9 @@ function logError(error: unknown, context?: Record<string, unknown>): void {
 	const isServer = typeof window === 'undefined'
 	const environment = isServer ? 'server' : 'client'
 
+	// console.error is intentional here — this module runs on both client and server
+	// and cannot depend on Pino (a Node.js-only library). This is the designated
+	// exception handler; all other code should use Sentry.captureException instead.
 	console.error(`[${environment.toUpperCase()} ERROR]:`, {
 		error: error instanceof Error ? error.message : String(error),
 		stack: error instanceof Error ? error.stack : undefined,

--- a/apps/www/src/routes/api/inquiries.ts
+++ b/apps/www/src/routes/api/inquiries.ts
@@ -89,16 +89,11 @@ export const Route = createFileRoute('/api/inquiries')({
 				const baseUrl = new URL(request.url).origin
 				try {
 					await sendInquiryEmail({
-						ownerName: owner.name,
-						ownerEmail: owner.email,
-						gleanerName: gleaner.name,
-						gleanerEmail: gleaner.email,
-						gleanerNote: note,
-						produceType: listing.type,
-						quantity: listing.quantity,
-						listingNotes: listing.notes,
-						plantId: listing.id,
 						baseUrl,
+						gleaner,
+						gleanerNote: note,
+						listing,
+						owner,
 					})
 				} catch (error) {
 					const { Sentry } = await import('@/lib/sentry')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       maplibre-gl:
         specifier: ^5.18.0
         version: 5.18.0
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
       resend:
         specifier: ^6.9.2
         version: 6.9.2
@@ -77,6 +80,9 @@ importers:
       oxlint:
         specifier: ^1.47.0
         version: 1.47.0
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -1623,6 +1629,9 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2495,6 +2504,10 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   b4a@1.7.4:
     resolution: {integrity: sha512-u20zJLDaSWpxaZ+zaAkEIB2dZZ1o+DF4T/MRbmsvGp9nletHOyiai19OzX1fF8xUBYsO1bPXxODvcd0978pnug==}
     peerDependencies:
@@ -2742,6 +2755,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -2839,6 +2855,9 @@ packages:
   data-urls@6.0.1:
     resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
     engines: {node: '>=20'}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   dax-sh@0.43.2:
     resolution: {integrity: sha512-uULa1sSIHgXKGCqJ/pA0zsnzbHlVnuq7g8O2fkHokWFNwEGIhh5lAJlxZa1POG5En5ba7AU4KcBAvGQWMMf8rg==}
@@ -3093,6 +3112,9 @@ packages:
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -3185,12 +3207,18 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  fast-copy@4.0.2:
+    resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
+
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
@@ -3305,10 +3333,6 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@13.0.3:
-    resolution: {integrity: sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==}
-    engines: {node: 20 || >=22}
-
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -3356,6 +3380,9 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -3542,6 +3569,10 @@ packages:
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
@@ -3748,10 +3779,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3887,9 +3914,16 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -3966,10 +4000,6 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.1:
-    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
-    engines: {node: 20 || >=22}
-
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -4011,6 +4041,20 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -4070,6 +4114,9 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -4090,6 +4137,9 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4099,6 +4149,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   quickselect@3.0.0:
     resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
@@ -4140,6 +4193,10 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
@@ -4242,6 +4299,10 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -4251,6 +4312,9 @@ packages:
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4339,6 +4403,9 @@ packages:
     peerDependencies:
       solid-js: ^1.7
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -4356,6 +4423,10 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   srvx@0.10.1:
     resolution: {integrity: sha512-A//xtfak4eESMWWydSRFUVvCTQbSwivnGCEf8YGPe2eHU0+Z6znfUTCPF0a7oV3sObSOcrXHlL6Bs9vVctfXdg==}
@@ -4426,6 +4497,10 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
@@ -4475,6 +4550,10 @@ packages:
 
   text-decoder@1.2.6:
     resolution: {integrity: sha512-27FeW5GQFDfw0FpwMQhMagB7BztOOlmjcSRi97t2oplhKVTZtp0DZbSegSaXS5IIC6mxMvBG4AR1Sgc6BX3CQg==}
+
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -4997,6 +5076,9 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -5559,7 +5641,7 @@ snapshots:
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6269,6 +6351,8 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -7137,7 +7221,7 @@ snapshots:
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
-      glob: 13.0.3
+      glob: 13.0.6
       graceful-fs: 4.2.11
       node-gyp-build: 4.8.4
       picomatch: 4.0.3
@@ -7327,6 +7411,8 @@ snapshots:
   async-sema@3.1.1: {}
 
   async@3.2.6: {}
+
+  atomic-sleep@1.0.0: {}
 
   b4a@1.7.4: {}
 
@@ -7555,6 +7641,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   comma-separated-tokens@2.0.3: {}
 
   commander@2.20.3: {}
@@ -7646,6 +7734,8 @@ snapshots:
     dependencies:
       whatwg-mimetype: 5.0.0
       whatwg-url: 15.1.0
+
+  dateformat@4.6.3: {}
 
   dax-sh@0.43.2:
     dependencies:
@@ -7763,6 +7853,10 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
       whatwg-encoding: 3.1.1
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   entities@4.5.0: {}
 
@@ -7912,6 +8006,8 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  fast-copy@4.0.2: {}
+
   fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
@@ -7921,6 +8017,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-sha256@1.3.0: {}
 
@@ -8009,15 +8107,9 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
-
-  glob@13.0.3:
-    dependencies:
-      minimatch: 10.2.0
-      minipass: 7.1.2
-      path-scurry: 2.0.1
 
   glob@13.0.6:
     dependencies:
@@ -8096,6 +8188,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  help-me@5.0.0: {}
 
   hookable@5.5.3: {}
 
@@ -8273,6 +8367,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@6.1.3: {}
+
+  joycon@3.1.1: {}
 
   js-base64@3.7.8: {}
 
@@ -8521,13 +8617,11 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@7.1.2: {}
-
   minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   mlly@1.8.0:
     dependencies:
@@ -8756,9 +8850,15 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@6.0.0:
     dependencies:
@@ -8884,12 +8984,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
-
-  path-scurry@2.0.1:
-    dependencies:
-      lru-cache: 11.2.6
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -8925,6 +9020,42 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.3
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
 
   pkg-types@1.3.1:
     dependencies:
@@ -8978,6 +9109,8 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process-warning@5.0.0: {}
+
   process@0.11.10: {}
 
   progress@2.0.3: {}
@@ -8990,11 +9123,18 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   quickselect@3.0.0: {}
 
@@ -9042,6 +9182,8 @@ snapshots:
   readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
+
+  real-require@0.2.0: {}
 
   recast@0.23.11:
     dependencies:
@@ -9159,6 +9301,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -9166,6 +9310,8 @@ snapshots:
       xmlchars: 2.2.0
 
   scule@1.3.0: {}
+
+  secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
 
@@ -9285,6 +9431,10 @@ snapshots:
     dependencies:
       solid-js: 1.9.11
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -9297,6 +9447,8 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  split2@4.2.0: {}
 
   srvx@0.10.1: {}
 
@@ -9371,6 +9523,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-json-comments@5.0.3: {}
+
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
@@ -9407,7 +9561,7 @@ snapshots:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
 
@@ -9428,6 +9582,10 @@ snapshots:
       b4a: 1.7.4
     transitivePeerDependencies:
       - react-native-b4a
+
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
 
   tiny-invariant@1.3.3: {}
 
@@ -9888,6 +10046,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.1.2
+
+  wrappy@1.0.2: {}
 
   ws@8.19.0: {}
 


### PR DESCRIPTION
## Summary

- Add `src/lib/logger.server.ts`: Pino singleton (`name: 'pickmyfruit'`);
  `pino-pretty` in `NODE_ENV=development` only, JSON in production/test
- Replace all `console.log`/`console.error` in `auth.ts`,
  `email-templates.ts`, and `seed.ts` with structured logger calls
- Centralized redaction via Pino's `redact` option — credentials, PII,
  and geo fields scrubbed at the logger level so call sites never need to
  sanitize manually:
  - **Production**: URL query params stripped, email local-parts masked
    (`xxx@domain`), everything else replaced with `[Redacted]`
  - **Development**: matched fields wrapped with `[[…]]` markers (values
    visible, redaction intent signaled)
- `auth.ts` console email provider logs `{ email, token, url }` — all
  three fields are safe because the logger's redaction handles them in prod
- `sentry.ts`: add explanatory comment for its intentional `console.error`
  (runs on client + server; cannot depend on Pino)
- `AGENTS.md`: document `@/lib/logger.server` guidance, `sentry.ts`
  exception, CLI and test-infra carve-outs

Intentionally unchanged: `sentry.ts`'s own `console.error` and
`tests/vitest-global-setup.ts` (test infrastructure).

### Redacted fields

| Category | Fields |
|---|---|
| Auth credentials | `**.token`, `**.accessToken`, `**.refreshToken`, `**.password`, `**.secret`, `**.key`, `**.apiKey` |
| PII | `**.email`, `**.name`, `**.phone`, `**.address` |
| Geo / location | `**.lat`, `**.lng`, `**.h3_index` |
| URLs | `**.url` (query params stripped in prod; `[[full url]]` in dev) |
| HTTP headers | `req.headers.authorization`, `req.headers.cookie`, `res.headers["set-cookie"]` |

## Test Plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:run` passes
- [x] `pnpm dev` — magic link with `EMAIL_PROVIDER=console` shows
  `[[token]]`, `[[url]]`, `[[email]]` in pino-pretty output
- [ ] `pnpm db:seed` — seed progress logs appear structured
- [ ] `NODE_ENV=production pnpm build` — server starts without errors;
  `pino-pretty` never loaded

## Review Notes

5-reviewer parallel review (Architect, User-Advocate, Adversary,
Standards, Operator) before first commit. All CRITICAL/HIGH findings
addressed:

- Magic link `token` field re-added after redaction confirmed to handle
  it centrally (initial review had removed it pre-redaction)
- `isDev` guard changed to `=== 'development'` — pino-pretty stays out
  of Vitest (`NODE_ENV=test`)
- `logger.ts` → `logger.server.ts` (server-only boundary per project
  convention)
- HTML body dropped from inquiry email log (PII + HMAC-signed URL)

Deferred: #138 — `process.exit(0)` before pino flush may drop final
seed log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)