### PR TITLE
fix(docker): pass VITE_* build args for docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to .env and populate as needed.
+# This .env file is used for all sub-projects.
+# docker-compose reads build-time environment variables from this file, but not
+# from the sub-project .env files like apps/www/.env.
+# VITE_* environment variables must be defined in this file to be available
+# as ARG.
+# @see docker-compose.yml
+
+# Enable Sentry error capturing in local dev. Mostly useful for testing the
+# Sentry integration.
+VITE_SENTRY_ENABLED=false
+VITE_SENTRY_DSN=https://1234567890abcdef@o111111111.ingest.sentry.io/222334456

--- a/apps/www/.env.example
+++ b/apps/www/.env.example
@@ -1,7 +1,0 @@
-# Email sending via Resend. The default email provider is console,
-# which doesn't require this.
-# RESEND_API_KEY=re_xxxxx
-
-# Enable Sentry error capturing in local dev. Mostly useful for testing the
-# Sentry integration.
-# VITE_SENTRY_ENABLED=true

--- a/apps/www/README.md
+++ b/apps/www/README.md
@@ -55,14 +55,20 @@ All commands are run from the root of the project, from a terminal:
 Test the production build locally using Docker Compose:
 
 ```bash
+# Change to the workspace directory
+$ cd path/to/PickMyFruit
+
+# Create a .env file in the workspace
+$ cp -n .env.example .env
+
 # Build and start the container
-pnpm docker:up
+$ pnpm docker:up
 
 # View logs
-pnpm docker:logs
+$ pnpm docker:logs
 
 # Stop the container
-pnpm docker:down
+$ pnpm docker:down
 ```
 
 The application will be available at `http://localhost:3000`. The SQLite database will be persisted in `./data/` directory.

--- a/apps/www/src/lib/env.client.ts
+++ b/apps/www/src/lib/env.client.ts
@@ -18,7 +18,8 @@ const schema = z
 		sentryDsn: data.VITE_SENTRY_DSN,
 		// In prod: default to true if DSN is available
 		// In other envs: default to false (reporting off, opt-in for testing)
-		sentryEnabled: data.VITE_SENTRY_ENABLED ?? (isProd && !!data.VITE_SENTRY_DSN),
+		sentryEnabled:
+			data.VITE_SENTRY_ENABLED ?? (isProd && Boolean(data.VITE_SENTRY_DSN)),
 		mode: import.meta.env.MODE as string,
 		prod: isProd,
 	}))
@@ -35,7 +36,7 @@ if (!result.success) {
 		(i) => `  ${i.path.join('.')}: ${i.message}`
 	)
 	throw new Error(
-		`Client environment validation failed. Check fly.toml [build.args] and Dockerfile ARGs:\n${issues.join('\n')}`
+		`Client environment validation failed. Check fly.toml [build.args], .env, and Dockerfile ARGs:\n${issues.join('\n')}`
 	)
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: .
       dockerfile: apps/www/Dockerfile
+      args:
+        VITE_SENTRY_DSN: ${VITE_SENTRY_DSN}
+        VITE_SENTRY_ENABLED: ${VITE_SENTRY_ENABLED}
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
VITE_* variables are replaced at Vite build time and cannot be injected at runtime. Add explicit build.args to docker-compose.yml so Docker Compose forwards them from the root .env file to the Dockerfile ARGs.

Move .env.example to the workspace root (where Docker Compose reads variable interpolation), and update the README with a prerequisite step to copy it before running docker:up. Improve the env.client.ts error message to mention .env alongside fly.toml.