### PR TITLE
feat(www): add contact, About, Privacy, Terms

### DIFF
--- a/apps/www/src/components/PageFooter.css
+++ b/apps/www/src/components/PageFooter.css
@@ -1,0 +1,56 @@
+@layer components {
+	footer.page-footer {
+		background: var(--color-background);
+		padding: 40px 0;
+		border-top: 1px solid oklch(from var(--color-quiet) l calc(c * 0.2) h);
+
+		.container {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+		}
+
+		.footer-left {
+			display: flex;
+			align-items: center;
+			gap: 12px;
+			font-size: 14px;
+			color: var(--color-quiet);
+
+			a {
+				color: var(--color-primary);
+				text-decoration: none;
+
+				&:hover {
+					text-decoration: underline;
+				}
+			}
+		}
+
+		.footer-avatar {
+			width: 32px;
+			height: 32px;
+			border-radius: 50%;
+			background: var(--color-secondary);
+			color: var(--color-background);
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			font-weight: 600;
+			font-size: 12px;
+		}
+
+		.footer-nav {
+			display: flex;
+			font-size: 0.85rem;
+			gap: 24px;
+
+			a::after {
+				content: '.';
+				color: var(--color-accent);
+				text-decoration: none;
+				text-decoration-color: var(--color-background);
+			}
+		}
+	}
+}

--- a/apps/www/src/components/PageFooter.tsx
+++ b/apps/www/src/components/PageFooter.tsx
@@ -1,0 +1,27 @@
+import { Link } from '@tanstack/solid-router'
+import './PageFooter.css'
+import { SupportEmail } from './SupportEmail'
+
+export function PageFooter() {
+	return (
+		<footer class="page-footer">
+			<div class="container">
+				<div class="footer-left">
+					<span class="footer-avatar">JAR</span>
+					<span>
+						Built by <a href="https://jamesarosen.com">James A Rosen</a>
+					</span>
+					<span>|</span>
+					<span>
+						Email <SupportEmail class="text-accent" />
+					</span>
+				</div>
+				<nav class="footer-nav">
+					<Link to="/about">About</Link>
+					<Link to="/privacy">Privacy</Link>
+					<Link to="/terms">Terms</Link>
+				</nav>
+			</div>
+		</footer>
+	)
+}

--- a/apps/www/src/components/SupportEmail.css
+++ b/apps/www/src/components/SupportEmail.css
@@ -1,0 +1,8 @@
+@layer components {
+	kbd.m29cxk1Fm9W {
+		span:nth-of-type(3n + 1) {
+			color: purple;
+			display: none;
+		}
+	}
+}

--- a/apps/www/src/components/SupportEmail.tsx
+++ b/apps/www/src/components/SupportEmail.tsx
@@ -1,0 +1,21 @@
+import { type JSX } from 'solid-js'
+import './SupportEmail.css'
+
+/**
+ * Renders the support email with some obfuscation
+ * @see https://spencermortensen.com/articles/email-obfuscation/
+ * @see https://stackoverflow.com/questions/18749591/encode-html-entities-in-javascript
+ */
+export function SupportEmail(
+	props: JSX.HTMLAttributes<HTMLSpanElement>
+): JSX.Element {
+	return (
+		<kbd {...props} class={`m29cxk1Fm9W ${props.class}`}>
+			<span>&#104;&#101;&#108;&#112;</span>&#106;<span>&#97;</span>
+			&#109;&#101;&#115;&#64;&#112;&#105;&#99;&#107;
+			<span>&#109;&#121;&#102;</span>&#114;&#117;&#105;&#116;&#46;
+			<span>&#99;&#111;</span>
+			<span>&#99;&#111;&#109;</span>
+		</kbd>
+	)
+}

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -9,8 +9,12 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TermsRouteImport } from './routes/terms'
+import { Route as PrivacyPolicyRouteImport } from './routes/privacy-policy'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as CssTestRouteImport } from './routes/css-test'
+import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ListingsNewRouteImport } from './routes/listings/new'
 import { Route as ListingsMineRouteImport } from './routes/listings/mine'
@@ -22,6 +26,21 @@ import { Route as ApiListingsIdRouteImport } from './routes/api/listings.$id'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as ApiListingsIdUnavailableRouteImport } from './routes/api/listings.$id.unavailable'
 
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyPolicyRoute = PrivacyPolicyRouteImport.update({
+  id: '/privacy-policy',
+  path: '/privacy-policy',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
@@ -30,6 +49,11 @@ const LoginRoute = LoginRouteImport.update({
 const CssTestRoute = CssTestRouteImport.update({
   id: '/css-test',
   path: '/css-test',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AboutRoute = AboutRouteImport.update({
+  id: '/about',
+  path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -86,8 +110,12 @@ const ApiListingsIdUnavailableRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
   '/css-test': typeof CssTestRoute
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
+  '/privacy-policy': typeof PrivacyPolicyRoute
+  '/terms': typeof TermsRoute
   '/api/health': typeof ApiHealthRoute
   '/api/inquiries': typeof ApiInquiriesRoute
   '/api/listings': typeof ApiListingsRouteWithChildren
@@ -100,8 +128,12 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
   '/css-test': typeof CssTestRoute
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
+  '/privacy-policy': typeof PrivacyPolicyRoute
+  '/terms': typeof TermsRoute
   '/api/health': typeof ApiHealthRoute
   '/api/inquiries': typeof ApiInquiriesRoute
   '/api/listings': typeof ApiListingsRouteWithChildren
@@ -115,8 +147,12 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
   '/css-test': typeof CssTestRoute
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
+  '/privacy-policy': typeof PrivacyPolicyRoute
+  '/terms': typeof TermsRoute
   '/api/health': typeof ApiHealthRoute
   '/api/inquiries': typeof ApiInquiriesRoute
   '/api/listings': typeof ApiListingsRouteWithChildren
@@ -131,8 +167,12 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/about'
     | '/css-test'
     | '/login'
+    | '/privacy'
+    | '/privacy-policy'
+    | '/terms'
     | '/api/health'
     | '/api/inquiries'
     | '/api/listings'
@@ -145,8 +185,12 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/about'
     | '/css-test'
     | '/login'
+    | '/privacy'
+    | '/privacy-policy'
+    | '/terms'
     | '/api/health'
     | '/api/inquiries'
     | '/api/listings'
@@ -159,8 +203,12 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/about'
     | '/css-test'
     | '/login'
+    | '/privacy'
+    | '/privacy-policy'
+    | '/terms'
     | '/api/health'
     | '/api/inquiries'
     | '/api/listings'
@@ -174,8 +222,12 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AboutRoute: typeof AboutRoute
   CssTestRoute: typeof CssTestRoute
   LoginRoute: typeof LoginRoute
+  PrivacyRoute: typeof PrivacyRoute
+  PrivacyPolicyRoute: typeof PrivacyPolicyRoute
+  TermsRoute: typeof TermsRoute
   ApiHealthRoute: typeof ApiHealthRoute
   ApiInquiriesRoute: typeof ApiInquiriesRoute
   ApiListingsRoute: typeof ApiListingsRouteWithChildren
@@ -187,6 +239,27 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/solid-router' {
   interface FileRoutesByPath {
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy-policy': {
+      id: '/privacy-policy'
+      path: '/privacy-policy'
+      fullPath: '/privacy-policy'
+      preLoaderRoute: typeof PrivacyPolicyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login': {
       id: '/login'
       path: '/login'
@@ -199,6 +272,13 @@ declare module '@tanstack/solid-router' {
       path: '/css-test'
       fullPath: '/css-test'
       preLoaderRoute: typeof CssTestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -300,8 +380,12 @@ const ApiListingsRouteWithChildren = ApiListingsRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AboutRoute: AboutRoute,
   CssTestRoute: CssTestRoute,
   LoginRoute: LoginRoute,
+  PrivacyRoute: PrivacyRoute,
+  PrivacyPolicyRoute: PrivacyPolicyRoute,
+  TermsRoute: TermsRoute,
   ApiHealthRoute: ApiHealthRoute,
   ApiInquiriesRoute: ApiInquiriesRoute,
   ApiListingsRoute: ApiListingsRouteWithChildren,

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -1,4 +1,15 @@
 /// <reference types="vite/client" />
+/*
+ * At minimum, base.css must be before any components so we define the
+ * layers in the correct order.
+ * The rest are "site-wide defaults", which are also good to have before the
+ * things that override them so we don't use over-strong selectors to
+ * compensate.
+ */
+import '../styles/base.css'
+import '../styles/colors.css'
+import '../styles/focus.css'
+import '../styles/surfaces.css'
 import * as Solid from 'solid-js'
 import {
 	Outlet,
@@ -9,12 +20,9 @@ import {
 	type ErrorComponentProps,
 } from '@tanstack/solid-router'
 import { HydrationScript } from 'solid-js/web'
+import { PageFooter } from '@/components/PageFooter'
 import { getSession } from '@/lib/session'
 import { Sentry } from '@/lib/sentry'
-import '../styles/base.css'
-import '../styles/colors.css'
-import '../styles/focus.css'
-import '../styles/surfaces.css'
 
 export const Route = createRootRoute({
 	beforeLoad: async () => {
@@ -57,7 +65,12 @@ function RootShell(props: { children: Solid.JSX.Element }) {
 }
 
 function RootComponent() {
-	return <Outlet />
+	return (
+		<>
+			<Outlet />
+			<PageFooter />
+		</>
+	)
 }
 
 function RootError({ error, reset }: ErrorComponentProps) {

--- a/apps/www/src/routes/about.css
+++ b/apps/www/src/routes/about.css
@@ -1,0 +1,67 @@
+@layer page {
+	.about-page {
+		padding: 48px 0 80px;
+
+		.container {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+
+		h1 {
+			font-size: 2rem;
+			margin-bottom: 24px;
+		}
+
+		section {
+			margin-top: 40px;
+
+			h2 {
+				font-size: 1.25rem;
+				margin-bottom: 12px;
+			}
+
+			p,
+			li {
+				line-height: 1.6;
+				color: var(--color-text);
+			}
+
+			ul {
+				padding-left: 1.25em;
+				display: flex;
+				flex-direction: column;
+				gap: 12px;
+			}
+		}
+
+		.motto {
+			font-style: italic;
+			color: var(--color-quiet);
+			border-left: 3px solid var(--color-accent);
+			padding-left: 16px;
+			margin: 0 0 8px;
+		}
+
+		.about-ctas {
+			display: flex;
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 16px;
+
+			.contact-cta {
+				font-size: 0.9rem;
+				color: var(--color-quiet);
+
+				a {
+					color: var(--color-primary);
+					text-decoration: none;
+
+					&:hover {
+						text-decoration: underline;
+					}
+				}
+			}
+		}
+	}
+}

--- a/apps/www/src/routes/about.tsx
+++ b/apps/www/src/routes/about.tsx
@@ -1,0 +1,81 @@
+import { createFileRoute, Link } from '@tanstack/solid-router'
+import Layout from '@/components/Layout'
+import SiteHeader from '@/components/SiteHeader'
+import './about.css'
+import { SupportEmail } from '@/components/SupportEmail'
+
+export const Route = createFileRoute('/about')({
+	component: AboutPage,
+})
+
+function AboutPage() {
+	return (
+		<Layout title="About - Pick My Fruit">
+			<SiteHeader breadcrumbs={[{ label: 'About' }]} />
+			<main class="about-page">
+				<div class="container">
+					<h1>About Pick My Fruit</h1>
+
+					<blockquote class="motto">
+						Blessed are those who plant trees under which they will never sit.
+					</blockquote>
+
+					<section>
+						<h2>The Problem</h2>
+						<p>
+							Food waste exists alongside hunger because of broken connections, not
+							scarcity. Every season, fruit falls to the ground while families go
+							without. Pick My Fruit reconnects that abundance to need.
+						</p>
+					</section>
+
+					<section>
+						<h2>Who It's For</h2>
+						<ul>
+							<li>
+								<strong>Growers</strong> — You have a lemon tree loaded with more fruit
+								than you can use. We find someone who wants it.
+							</li>
+							<li>
+								<strong>Gleaners</strong> — You're looking for fresh, local produce. We
+								show you what's available nearby.
+							</li>
+							<li>
+								<strong>Gleaning groups</strong> — You organize regular harvests for
+								food banks and community organizations. We help you find trees and
+								coordinate pickups.
+							</li>
+						</ul>
+					</section>
+
+					<section>
+						<h2>Where We Operate</h2>
+						<p>
+							We're currently serving Napa and surrounding areas, with plans to expand
+							to more communities.
+						</p>
+					</section>
+
+					<section>
+						<h2>Our Mission</h2>
+						<p>Rescue the most food. Feed the most people.</p>
+						<p>
+							We think in decades, not quarters. Every fruit tree, every volunteer
+							connection, every process we build should leave things better than we
+							found them.
+						</p>
+					</section>
+
+					<section class="about-ctas">
+						<Link to="/listings/new" class="cta-button">
+							List My Fruit Tree
+						</Link>
+						<p class="contact-cta">
+							Questions or ideas? Email us: <SupportEmail class="text-accent" />.
+						</p>
+					</section>
+				</div>
+			</main>
+		</Layout>
+	)
+}

--- a/apps/www/src/routes/index.css
+++ b/apps/www/src/routes/index.css
@@ -170,68 +170,6 @@
 		text-decoration: underline;
 	}
 
-	/* Footer */
-	footer {
-		background: var(--color-background);
-		padding: 40px 0;
-		border-top: 1px solid oklch(from var(--color-quiet) l calc(c * 0.2) h);
-	}
-
-	footer .container {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-	}
-
-	.footer-left {
-		display: flex;
-		align-items: center;
-		gap: 12px;
-		font-size: 14px;
-		color: var(--color-quiet);
-	}
-
-	.footer-avatar {
-		width: 32px;
-		height: 32px;
-		border-radius: 50%;
-		background: var(--color-secondary);
-		color: var(--color-background);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-weight: 600;
-		font-size: 12px;
-	}
-
-	.footer-left a {
-		color: var(--color-primary);
-		text-decoration: none;
-	}
-
-	.footer-left a:hover {
-		text-decoration: underline;
-	}
-
-	.footer-nav {
-		display: flex;
-		gap: 24px;
-	}
-
-	.footer-nav button {
-		color: var(--color-quiet);
-		text-decoration: none;
-		font-size: 14px;
-		background: none;
-		border: none;
-		padding: 0;
-		cursor: pointer;
-	}
-
-	.footer-nav button:hover {
-		color: var(--color-foreground);
-	}
-
 	/* Available Listings Section */
 	.available-listings {
 		padding: 80px 0;

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -177,31 +177,7 @@ function HomePage() {
 						</Show>
 					</div>
 				</section>
-
-				<section class="contact-info surface-subtle">
-					<div class="container">
-						<p>
-							Questions? Text me at <a href="tel:+15551234567">(555) 123-4567</a>
-						</p>
-					</div>
-				</section>
 			</main>
-
-			<footer>
-				<div class="container">
-					<div class="footer-left">
-						<span class="footer-avatar">JD</span>
-						<span>
-							Built by <span>Your Name</span>
-						</span>
-					</div>
-					<nav class="footer-nav">
-						<button type="button">About</button>
-						<button type="button">Contact</button>
-						<button type="button">Privacy</button>
-					</nav>
-				</div>
-			</footer>
 		</Layout>
 	)
 }

--- a/apps/www/src/routes/privacy-policy.tsx
+++ b/apps/www/src/routes/privacy-policy.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, redirect } from '@tanstack/solid-router'
+
+export const Route = createFileRoute('/privacy-policy')({
+	beforeLoad: () => {
+		throw redirect({ to: '/privacy', statusCode: 301 })
+	},
+})

--- a/apps/www/src/routes/privacy.css
+++ b/apps/www/src/routes/privacy.css
@@ -1,0 +1,42 @@
+@layer page {
+	.privacy-policy {
+		max-width: 72ch;
+		padding-block: 2rem 4rem;
+
+		h1 {
+			margin-block-end: 0.25rem;
+		}
+
+		.effective-date {
+			color: var(--color-quiet);
+			font-size: 0.875rem;
+			margin-block-end: 1.5rem;
+		}
+
+		& > p {
+			margin-block-end: 1.5rem;
+		}
+
+		section {
+			margin-block-start: 2rem;
+
+			h2 {
+				margin-block-end: 0.75rem;
+			}
+
+			p + p,
+			ul + p {
+				margin-block-start: 0.75rem;
+			}
+
+			ul {
+				padding-inline-start: 1.5rem;
+				margin-block: 0.5rem;
+
+				li {
+					margin-block-end: 0.4rem;
+				}
+			}
+		}
+	}
+}

--- a/apps/www/src/routes/privacy.tsx
+++ b/apps/www/src/routes/privacy.tsx
@@ -1,0 +1,181 @@
+import { createFileRoute } from '@tanstack/solid-router'
+import Layout from '@/components/Layout'
+import SiteHeader from '@/components/SiteHeader'
+import './privacy.css'
+import { SupportEmail } from '@/components/SupportEmail'
+
+export const Route = createFileRoute('/privacy')({
+	component: PrivacyPage,
+})
+
+function PrivacyPage() {
+	return (
+		<Layout title="Privacy Policy - Pick My Fruit">
+			<SiteHeader breadcrumbs={[{ label: 'Privacy Policy' }]} />
+			<main>
+				<div class="container privacy-policy">
+					<h1>Privacy Policy</h1>
+					<p class="effective-date">Effective date: March 7, 2026</p>
+
+					<p>
+						Pick My Fruit ("we", "us", or "our") operates pickmyfruit.com. This policy
+						explains what information we collect, how we use it, and what choices you
+						have.
+					</p>
+
+					<section>
+						<h2>What we collect</h2>
+						<ul>
+							<li>
+								<strong>Email address</strong> — when you create an account or send a
+								magic-link sign-in request.
+							</li>
+							<li>
+								<strong>Produce listings</strong> — the type and quantity of produce you
+								offer, plus the address you provide (see below).
+							</li>
+							<li>
+								<strong>Messages</strong> — inquiries you send to or receive from other
+								gardeners.
+							</li>
+							<li>
+								<strong>Technical data</strong> — browser type, IP address, and error
+								reports collected automatically to keep the site running reliably.
+							</li>
+						</ul>
+						<p>We do not collect payment information or run advertising.</p>
+					</section>
+
+					<section>
+						<h2>Location data</h2>
+						<p>
+							When you create a listing, you provide an exact address.
+							<strong>
+								We display only the approximate location publicly — never your exact
+								address.
+							</strong>
+						</p>
+						<p>
+							Your precise address is shared with another user only if you explicitly
+							choose to share it — for example, when you agree to a pick-up and decide
+							to reveal your door-step location. We will always ask for your permission
+							before disclosing anything more specific than your approximate area.
+						</p>
+					</section>
+
+					<section>
+						<h2>How we use your information</h2>
+						<ul>
+							<li>Match gardeners with surplus produce to people who want it.</li>
+							<li>
+								Send transactional emails (magic-link sign-ins, inquiry notifications)
+								via Resend.
+							</li>
+							<li>
+								Detect and fix bugs using Sentry error monitoring, which may capture
+								limited contextual data when errors occur.
+							</li>
+							<li>Understand how the site is used so we can improve it.</li>
+						</ul>
+						<p>We do not sell or rent your information to third parties.</p>
+					</section>
+
+					<section>
+						<h2>Who we share information with</h2>
+						<p>
+							We use a small number of trusted services to operate the site. Each
+							receives only the minimum data needed for their function:
+						</p>
+						<ul>
+							<li>
+								<strong>
+									<a href="https://resend.com/privacy">Resend</a>
+								</strong>{' '}
+								— email delivery (your email address and message content for
+								transactional emails).
+							</li>
+							<li>
+								<strong>
+									<a href="https://sentry.io/privacy/">Sentry</a>
+								</strong>{' '}
+								— error monitoring (technical context when an error occurs; we configure
+								Sentry to minimize personal data capture).
+							</li>
+							<li>
+								<strong>
+									<a href="https://fly.io/legal/privacy-policy">Fly.io</a>
+								</strong>{' '}
+								— hosting and infrastructure (your data is stored in a SQLite database
+								on Fly.io servers in the United States).
+							</li>
+						</ul>
+						<p>
+							We do not share your information with any other parties unless required
+							by law.
+						</p>
+					</section>
+
+					<section>
+						<h2>Data retention</h2>
+						<p>
+							We keep your account data for as long as your account is active. Listings
+							and messages are retained to support ongoing exchanges. If you delete
+							your account, we will remove your personal information within 30 days,
+							except where retention is required by law.
+						</p>
+					</section>
+
+					<section>
+						<h2>Your rights</h2>
+						<p>You can:</p>
+						<ul>
+							<li>Request a copy of the data we hold about you.</li>
+							<li>Ask us to correct inaccurate information.</li>
+							<li>Ask us to delete your account and personal data.</li>
+						</ul>
+						<p>
+							To exercise any of these rights, email us at <SupportEmail />.
+						</p>
+						<p>
+							<strong>California residents (CCPA):</strong> We do not sell your
+							personal information. You have the right to know what data we collect and
+							to request its deletion.
+						</p>
+					</section>
+
+					<section>
+						<h2>Cookies and local storage</h2>
+						<p>
+							We use a session cookie to keep you signed in. We do not use tracking or
+							advertising cookies.
+						</p>
+					</section>
+
+					<section>
+						<h2>Children's privacy</h2>
+						<p>
+							Pick My Fruit is not directed at children under 13. We do not knowingly
+							collect personal information from children.
+						</p>
+					</section>
+
+					<section>
+						<h2>Changes to this policy</h2>
+						<p>
+							We may update this policy from time to time. When we do, we will update
+							the effective date at the top of the page. Continued use of the site
+							after changes constitutes acceptance of the updated policy.
+						</p>
+					</section>
+
+					<section>
+						<h2>Contact</h2>
+						<p>
+							Questions or concerns? Email <SupportEmail />.
+						</p>
+					</section>
+				</div>
+			</main>
+		</Layout>
+	)
+}

--- a/apps/www/src/routes/terms.css
+++ b/apps/www/src/routes/terms.css
@@ -1,0 +1,42 @@
+@layer page {
+	.terms-of-service {
+		max-width: 72ch;
+		padding-block: 2rem 4rem;
+
+		h1 {
+			margin-block-end: 0.25rem;
+		}
+
+		.effective-date {
+			color: var(--color-quiet);
+			font-size: 0.875rem;
+			margin-block-end: 1.5rem;
+		}
+
+		& > p {
+			margin-block-end: 1.5rem;
+		}
+
+		section {
+			margin-block-start: 2rem;
+
+			h2 {
+				margin-block-end: 0.75rem;
+			}
+
+			p + p,
+			ul + p {
+				margin-block-start: 0.75rem;
+			}
+
+			ul {
+				padding-inline-start: 1.5rem;
+				margin-block: 0.5rem;
+
+				li {
+					margin-block-end: 0.4rem;
+				}
+			}
+		}
+	}
+}

--- a/apps/www/src/routes/terms.tsx
+++ b/apps/www/src/routes/terms.tsx
@@ -1,0 +1,198 @@
+import { createFileRoute } from '@tanstack/solid-router'
+import Layout from '@/components/Layout'
+import SiteHeader from '@/components/SiteHeader'
+import './terms.css'
+import { SupportEmail } from '@/components/SupportEmail'
+
+export const Route = createFileRoute('/terms')({
+	component: TermsPage,
+})
+
+function TermsPage() {
+	return (
+		<Layout title="Terms of Service - Pick My Fruit">
+			<SiteHeader breadcrumbs={[{ label: 'Terms of Service' }]} />
+			<main>
+				<div class="container terms-of-service">
+					<h1>Terms of Service</h1>
+					<p class="effective-date">Effective date: March 8, 2026</p>
+
+					<p>
+						Welcome to Pick My Fruit ("we", "us", or "our"). By using pickmyfruit.com
+						(the "Site"), you agree to these Terms of Service. If you do not agree,
+						please do not use the Site.
+					</p>
+
+					<section>
+						<h2>What Pick My Fruit is</h2>
+						<p>
+							Pick My Fruit is a platform that connects gardeners who have surplus
+							produce with community members who would like it. We facilitate
+							introductions — we do not grow, handle, inspect, or deliver any produce.
+						</p>
+					</section>
+
+					<section>
+						<h2>No warranty on produce quality or safety</h2>
+						<p>
+							<strong>
+								We make no representations or warranties, express or implied, about the
+								quality, safety, fitness for consumption, or condition of any produce
+								listed on the Site.
+							</strong>{' '}
+							All produce is shared between private individuals. We do not inspect,
+							test, certify, or verify any produce offered through the Site.
+						</p>
+						<p>
+							You are solely responsible for evaluating whether any produce you receive
+							is safe and suitable for your intended use. When in doubt, discard it.
+							Pick My Fruit is not liable for any illness, injury, loss, or damage
+							arising from consuming or using produce obtained through the Site.
+						</p>
+					</section>
+
+					<section>
+						<h2>Harvesting safety</h2>
+						<p>
+							<strong>
+								Harvesting produce — climbing trees, using ladders, working on
+								unfamiliar property, and handling tools — carries inherent physical
+								risks. You assume all risk associated with the harvesting process.
+							</strong>
+						</p>
+						<p>
+							Pick My Fruit is not liable for any injury, accident, property damage, or
+							other harm that occurs during or in connection with harvesting activities
+							arranged through the Site. Neither the property owner's listing nor our
+							platform constitutes an assurance that any property is safe for entry,
+							harvesting, or any other activity.
+						</p>
+						<p>
+							Before entering someone's property or beginning to harvest, take
+							reasonable precautions: assess the site, use appropriate equipment, and
+							do not proceed if conditions seem unsafe.
+						</p>
+					</section>
+
+					<section>
+						<h2>Acceptable use</h2>
+						<p>You agree not to:</p>
+						<ul>
+							<li>Post false, misleading, or fraudulent listings.</li>
+							<li>
+								Use the Site for commercial resale of produce without the explicit
+								permission of the listing gardener.
+							</li>
+							<li>
+								Harass, threaten, or harm other users in any way, whether through the
+								Site or during in-person exchanges.
+							</li>
+							<li>
+								Attempt to gain unauthorized access to the Site or another user's
+								account.
+							</li>
+							<li>
+								Use automated tools to scrape, index, or interact with the Site without
+								our written consent.
+							</li>
+						</ul>
+					</section>
+
+					<section>
+						<h2>User accounts</h2>
+						<p>
+							You must provide a valid email address and keep your account information
+							accurate. You are responsible for all activity that occurs under your
+							account. Notify us immediately at <SupportEmail /> if you believe your
+							account has been compromised.
+						</p>
+					</section>
+
+					<section>
+						<h2>Listings and content</h2>
+						<p>
+							You are responsible for the accuracy and legality of any content you
+							post. By submitting a listing or message, you grant us a limited,
+							non-exclusive license to display and transmit that content as necessary
+							to operate the Site. We reserve the right to remove any content that
+							violates these Terms or that we deem harmful to the community.
+						</p>
+					</section>
+
+					<section>
+						<h2>Disclaimer of warranties</h2>
+						<p>
+							The Site is provided "as is" and "as available" without warranty of any
+							kind. To the fullest extent permitted by law, we disclaim all warranties,
+							express or implied, including merchantability, fitness for a particular
+							purpose, and non-infringement.
+						</p>
+					</section>
+
+					<section>
+						<h2>Limitation of liability</h2>
+						<p>
+							To the fullest extent permitted by applicable law, Pick My Fruit and its
+							operators shall not be liable for any indirect, incidental, special,
+							consequential, or punitive damages arising out of your use of (or
+							inability to use) the Site or any produce or interactions facilitated
+							through it, even if we have been advised of the possibility of such
+							damages.
+						</p>
+						<p>
+							Our total liability to you for any claim arising from these Terms or your
+							use of the Site shall not exceed the amount you paid us in the twelve
+							months preceding the claim (which, given that the Site is currently free,
+							is zero).
+						</p>
+					</section>
+
+					<section>
+						<h2>Indemnification</h2>
+						<p>
+							You agree to indemnify and hold harmless Pick My Fruit and its operators
+							from any claims, damages, or expenses (including reasonable attorneys'
+							fees) arising from your use of the Site, your listings or messages, your
+							harvesting activities, or your violation of these Terms.
+						</p>
+					</section>
+
+					<section>
+						<h2>Third-party interactions</h2>
+						<p>
+							Exchanges arranged through the Site take place between private
+							individuals. We are not a party to those exchanges and have no control
+							over the conduct of any user. Always exercise common sense and personal
+							judgment when meeting strangers or entering unfamiliar properties.
+						</p>
+					</section>
+
+					<section>
+						<h2>Changes to these Terms</h2>
+						<p>
+							We may update these Terms from time to time. When we do, we will update
+							the effective date at the top of this page. Continued use of the Site
+							after changes constitutes acceptance of the updated Terms.
+						</p>
+					</section>
+
+					<section>
+						<h2>Governing law</h2>
+						<p>
+							These Terms are governed by the laws of the State of California, without
+							regard to its conflict-of-law provisions. Any disputes shall be resolved
+							in the courts of San Francisco County, California.
+						</p>
+					</section>
+
+					<section>
+						<h2>Contact</h2>
+						<p>
+							Questions about these Terms? Email <SupportEmail />.
+						</p>
+					</section>
+				</div>
+			</main>
+		</Layout>
+	)
+}


### PR DESCRIPTION
- Move footer from `index` route to `__root` layout so it appears on
  every page.
- Replace the stub name and phone number with a real name and email
  address. Adds `<SupportEmail>` to obfuscate the address to reduce
  spam.
  See https://spencermortensen.com/articles/email-obfuscation/
- Remove "Contact" button since we don't have a Contact page
- Add a new `/about` page and replace "About" button with link to it
- Add a new `/privacy` page and replace "Privacy" button with link to it
- Redirect `/privacy-policy` to `/privacy`
- Add a new `/terms` page and add "Terms" link in footer