### PR TITLE
feat(www): add Sentry tracing for DB queries, client nav (#82)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,7 +106,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build image
-        run: docker build -t pickmyfruit-web -f apps/www/Dockerfile .
+        run: |
+          docker build -t pickmyfruit-web -f apps/www/Dockerfile . \
+            --build-arg VITE_SENTRY_DSN=https://test@test.ingest.sentry.io/123
 
       - name: Start container
         run: |
@@ -153,6 +155,10 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to Fly.io
-        run: flyctl deploy --remote-only
+        run: |
+          flyctl deploy --remote-only \
+            --build-arg VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }} \
+            --build-arg VITE_SENTRY_ERROR_SAMPLE_RATE=${{ vars.VITE_SENTRY_ERROR_SAMPLE_RATE }} \
+            --build-arg VITE_SENTRY_TRACES_SAMPLE_RATE=${{ vars.VITE_SENTRY_TRACES_SAMPLE_RATE }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/apps/www/Dockerfile
+++ b/apps/www/Dockerfile
@@ -30,6 +30,8 @@ COPY . .
 # See env.client.ts
 ARG VITE_SENTRY_DSN
 ARG VITE_SENTRY_ENABLED
+ARG VITE_SENTRY_ERROR_SAMPLE_RATE
+ARG VITE_SENTRY_TRACES_SAMPLE_RATE
 
 # Build the www application
 RUN cd apps/www && pnpm build

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -35,6 +35,7 @@
 	"dependencies": {
 		"@kobalte/core": "^0.13.11",
 		"@libsql/client": "^0.17.0",
+		"@sentry/solid": "^10.40.0",
 		"@sentry/solidstart": "^10.40.0",
 		"@tanstack/solid-router": "^1.160.0",
 		"@tanstack/solid-start": "^1.160.0",

--- a/apps/www/src/data/queries.ts
+++ b/apps/www/src/data/queries.ts
@@ -25,18 +25,28 @@ function reportH3Error(listingId: number, error: unknown) {
 export async function getAvailableListings(
 	limit: number = 10
 ): Promise<PublicListing[]> {
-	const rows = await db
-		.select()
-		.from(listings)
-		.where(
-			and(eq(listings.status, ListingStatus.available), isNull(listings.deletedAt))
-		)
-		.orderBy(desc(listings.createdAt))
-		.limit(limit)
-	return rows.flatMap((row) => {
-		const pub = toPublicListing(row, reportH3Error)
-		return pub ? [pub] : []
-	})
+	return Sentry.startSpan(
+		{ name: 'getAvailableListings', op: 'db.query', attributes: { limit } },
+		async (span) => {
+			const rows = await db
+				.select()
+				.from(listings)
+				.where(
+					and(
+						eq(listings.status, ListingStatus.available),
+						isNull(listings.deletedAt)
+					)
+				)
+				.orderBy(desc(listings.createdAt))
+				.limit(limit)
+			const results = rows.flatMap((row) => {
+				const pub = toPublicListing(row, reportH3Error)
+				return pub ? [pub] : []
+			})
+			span.setAttribute('listing_count', results.length)
+			return results
+		}
+	)
 }
 
 /** Fetches available listings ordered by proximity to a point. */
@@ -45,62 +55,94 @@ export async function getNearbyListings(
 	lng: number,
 	limit: number = 12
 ): Promise<PublicListing[]> {
-	const rows = await db
-		.select()
-		.from(listings)
-		.where(
-			and(eq(listings.status, ListingStatus.available), isNull(listings.deletedAt))
-		)
-		.orderBy(
-			sql`(${listings.lat} - ${lat}) * (${listings.lat} - ${lat}) + (${listings.lng} - ${lng}) * (${listings.lng} - ${lng})`
-		)
-		.limit(limit)
-	return rows.flatMap((row) => {
-		const pub = toPublicListing(row, reportH3Error)
-		return pub ? [pub] : []
-	})
+	return Sentry.startSpan(
+		{ name: 'getNearbyListings', op: 'db.query', attributes: { limit } },
+		async (span) => {
+			const rows = await db
+				.select()
+				.from(listings)
+				.where(
+					and(
+						eq(listings.status, ListingStatus.available),
+						isNull(listings.deletedAt)
+					)
+				)
+				.orderBy(
+					sql`(${listings.lat} - ${lat}) * (${listings.lat} - ${lat}) + (${listings.lng} - ${lng}) * (${listings.lng} - ${lng})`
+				)
+				.limit(limit)
+			const results = rows.flatMap((row) => {
+				const pub = toPublicListing(row, reportH3Error)
+				return pub ? [pub] : []
+			})
+			span.setAttribute('listing_count', results.length)
+			return results
+		}
+	)
 }
 
 export async function createListing(data: NewListing): Promise<Listing> {
-	const result = await db.insert(listings).values(data).returning()
-	return result[0]
+	return Sentry.startSpan(
+		{ name: 'createListing', op: 'db.query' },
+		async () => {
+			const result = await db.insert(listings).values(data).returning()
+			return result[0]
+		}
+	)
 }
 
 export async function getUserListings(userId: string): Promise<Listing[]> {
-	return await db
-		.select()
-		.from(listings)
-		.where(and(eq(listings.userId, userId), isNull(listings.deletedAt)))
-		.orderBy(desc(listings.createdAt))
+	return Sentry.startSpan(
+		{ name: 'getUserListings', op: 'db.query' },
+		async (span) => {
+			const results = await db
+				.select()
+				.from(listings)
+				.where(and(eq(listings.userId, userId), isNull(listings.deletedAt)))
+				.orderBy(desc(listings.createdAt))
+			span.setAttribute('listing_count', results.length)
+			return results
+		}
+	)
 }
 
 export async function getListingById(id: number): Promise<Listing | undefined> {
-	const result = await db
-		.select()
-		.from(listings)
-		.where(and(eq(listings.id, id), isNull(listings.deletedAt)))
-		.limit(1)
-	return result[0]
+	return Sentry.startSpan(
+		{ name: 'getListingById', op: 'db.query', attributes: { id } },
+		async () => {
+			const result = await db
+				.select()
+				.from(listings)
+				.where(and(eq(listings.id, id), isNull(listings.deletedAt)))
+				.limit(1)
+			return result[0]
+		}
+	)
 }
 
 /** Fetches a listing by ID, returning only public-safe fields. Excludes private and deleted listings. */
 export async function getPublicListingById(
 	id: number
 ): Promise<PublicListing | undefined> {
-	const result = await db
-		.select()
-		.from(listings)
-		.where(
-			and(
-				eq(listings.id, id),
-				ne(listings.status, ListingStatus.private),
-				isNull(listings.deletedAt)
-			)
-		)
-		.limit(1)
-	return result[0]
-		? (toPublicListing(result[0], reportH3Error) ?? undefined)
-		: undefined
+	return Sentry.startSpan(
+		{ name: 'getPublicListingById', op: 'db.query', attributes: { id } },
+		async () => {
+			const result = await db
+				.select()
+				.from(listings)
+				.where(
+					and(
+						eq(listings.id, id),
+						ne(listings.status, ListingStatus.private),
+						isNull(listings.deletedAt)
+					)
+				)
+				.limit(1)
+			return result[0]
+				? (toPublicListing(result[0], reportH3Error) ?? undefined)
+				: undefined
+		}
+	)
 }
 
 /** Soft-deletes a listing by setting its deletedAt timestamp and removes related inquiries. */
@@ -108,23 +150,28 @@ export async function deleteListingById(
 	id: number,
 	userId: string
 ): Promise<boolean> {
-	const result = await db
-		.update(listings)
-		.set({ deletedAt: new Date() })
-		.where(
-			and(
-				eq(listings.id, id),
-				eq(listings.userId, userId),
-				isNull(listings.deletedAt)
-			)
-		)
-		.returning({ id: listings.id })
+	return Sentry.startSpan(
+		{ name: 'deleteListingById', op: 'db.query', attributes: { id } },
+		async () => {
+			const result = await db
+				.update(listings)
+				.set({ deletedAt: new Date() })
+				.where(
+					and(
+						eq(listings.id, id),
+						eq(listings.userId, userId),
+						isNull(listings.deletedAt)
+					)
+				)
+				.returning({ id: listings.id })
 
-	if (result.length > 0) {
-		await db.delete(inquiries).where(eq(inquiries.listingId, id))
-	}
+			if (result.length > 0) {
+				await db.delete(inquiries).where(eq(inquiries.listingId, id))
+			}
 
-	return result.length > 0
+			return result.length > 0
+		}
+	)
 }
 
 // ============================================================================
@@ -132,27 +179,37 @@ export async function deleteListingById(
 // ============================================================================
 
 export async function createInquiry(data: NewInquiry): Promise<Inquiry> {
-	const result = await db.insert(inquiries).values(data).returning()
-	return result[0]
+	return Sentry.startSpan(
+		{ name: 'createInquiry', op: 'db.query' },
+		async () => {
+			const result = await db.insert(inquiries).values(data).returning()
+			return result[0]
+		}
+	)
 }
 
 export async function hasRecentInquiry(
 	gleanerId: string,
 	listingId: number
 ): Promise<boolean> {
-	const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
-	const result = await db
-		.select({ id: inquiries.id })
-		.from(inquiries)
-		.where(
-			and(
-				eq(inquiries.gleanerId, gleanerId),
-				eq(inquiries.listingId, listingId),
-				gt(inquiries.createdAt, twentyFourHoursAgo)
-			)
-		)
-		.limit(1)
-	return result.length > 0
+	return Sentry.startSpan(
+		{ name: 'hasRecentInquiry', op: 'db.query', attributes: { listingId } },
+		async () => {
+			const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
+			const result = await db
+				.select({ id: inquiries.id })
+				.from(inquiries)
+				.where(
+					and(
+						eq(inquiries.gleanerId, gleanerId),
+						eq(inquiries.listingId, listingId),
+						gt(inquiries.createdAt, twentyFourHoursAgo)
+					)
+				)
+				.limit(1)
+			return result.length > 0
+		}
+	)
 }
 
 export async function getListingWithOwner(id: number): Promise<
@@ -162,38 +219,48 @@ export async function getListingWithOwner(id: number): Promise<
 	  }
 	| undefined
 > {
-	const result = await db
-		.select({
-			listing: listings,
-			owner: {
-				id: user.id,
-				name: user.name,
-				email: user.email,
-			},
-		})
-		.from(listings)
-		.innerJoin(user, eq(listings.userId, user.id))
-		.where(and(eq(listings.id, id), isNull(listings.deletedAt)))
-		.limit(1)
+	return Sentry.startSpan(
+		{ name: 'getListingWithOwner', op: 'db.query', attributes: { id } },
+		async () => {
+			const result = await db
+				.select({
+					listing: listings,
+					owner: {
+						id: user.id,
+						name: user.name,
+						email: user.email,
+					},
+				})
+				.from(listings)
+				.innerJoin(user, eq(listings.userId, user.id))
+				.where(and(eq(listings.id, id), isNull(listings.deletedAt)))
+				.limit(1)
 
-	return result[0]
+			return result[0]
+		}
+	)
 }
 
 export async function getListingForInquiry(
 	id: number
 ): Promise<Listing | undefined> {
-	const result = await db
-		.select()
-		.from(listings)
-		.where(
-			and(
-				eq(listings.id, id),
-				isNull(listings.deletedAt)
-				// Status validation (available or private) done at API layer
-			)
-		)
-		.limit(1)
-	return result[0]
+	return Sentry.startSpan(
+		{ name: 'getListingForInquiry', op: 'db.query', attributes: { id } },
+		async () => {
+			const result = await db
+				.select()
+				.from(listings)
+				.where(
+					and(
+						eq(listings.id, id),
+						isNull(listings.deletedAt)
+						// Status validation (available or private) done at API layer
+					)
+				)
+				.limit(1)
+			return result[0]
+		}
+	)
 }
 
 /** Updates a listing's status, scoped to the owning user. */
@@ -202,55 +269,72 @@ export async function updateListingStatus(
 	userId: string,
 	status: ListingStatusValue
 ): Promise<boolean> {
-	const result = await db
-		.update(listings)
-		.set({ status, updatedAt: new Date() })
-		.where(
-			and(
-				eq(listings.id, id),
-				eq(listings.userId, userId),
-				isNull(listings.deletedAt)
-			)
-		)
-		.returning({ id: listings.id })
-	return result.length > 0
+	return Sentry.startSpan(
+		{ name: 'updateListingStatus', op: 'db.query', attributes: { id, status } },
+		async () => {
+			const result = await db
+				.update(listings)
+				.set({ status, updatedAt: new Date() })
+				.where(
+					and(
+						eq(listings.id, id),
+						eq(listings.userId, userId),
+						isNull(listings.deletedAt)
+					)
+				)
+				.returning({ id: listings.id })
+			return result.length > 0
+		}
+	)
 }
 
 export async function getUserById(
 	id: string
 ): Promise<{ name: string; email: string } | undefined> {
-	const result = await db
-		.select({ name: user.name, email: user.email })
-		.from(user)
-		.where(eq(user.id, id))
-		.limit(1)
-	return result[0]
+	return Sentry.startSpan({ name: 'getUserById', op: 'db.query' }, async () => {
+		const result = await db
+			.select({ name: user.name, email: user.email })
+			.from(user)
+			.where(eq(user.id, id))
+			.limit(1)
+		return result[0]
+	})
 }
 
 /** Returns address fields from the user's most recent non-deleted listing. */
 export async function getUserLastAddress(
 	userId: string
 ): Promise<AddressFields | undefined> {
-	const result = await db
-		.select({
-			address: listings.address,
-			city: listings.city,
-			state: listings.state,
-			zip: listings.zip,
-		})
-		.from(listings)
-		.where(and(eq(listings.userId, userId), isNull(listings.deletedAt)))
-		.orderBy(desc(listings.createdAt))
-		.limit(1)
-	return result[0]
+	return Sentry.startSpan(
+		{ name: 'getUserLastAddress', op: 'db.query' },
+		async () => {
+			const result = await db
+				.select({
+					address: listings.address,
+					city: listings.city,
+					state: listings.state,
+					zip: listings.zip,
+				})
+				.from(listings)
+				.where(and(eq(listings.userId, userId), isNull(listings.deletedAt)))
+				.orderBy(desc(listings.createdAt))
+				.limit(1)
+			return result[0]
+		}
+	)
 }
 
 /** Mark a listing as unavailable (used by HMAC-signed one-click URL). */
 export async function markListingUnavailable(id: number): Promise<boolean> {
-	const result = await db
-		.update(listings)
-		.set({ status: ListingStatus.unavailable, updatedAt: new Date() })
-		.where(and(eq(listings.id, id), isNull(listings.deletedAt)))
-		.returning({ id: listings.id })
-	return result.length > 0
+	return Sentry.startSpan(
+		{ name: 'markListingUnavailable', op: 'db.query', attributes: { id } },
+		async () => {
+			const result = await db
+				.update(listings)
+				.set({ status: ListingStatus.unavailable, updatedAt: new Date() })
+				.where(and(eq(listings.id, id), isNull(listings.deletedAt)))
+				.returning({ id: listings.id })
+			return result.length > 0
+		}
+	)
 }

--- a/apps/www/src/lib/env.client.ts
+++ b/apps/www/src/lib/env.client.ts
@@ -13,6 +13,8 @@ const schema = z
 			.enum(['true', 'false'])
 			.transform((v) => v === 'true')
 			.optional(),
+		VITE_SENTRY_ERROR_SAMPLE_RATE: z.coerce.number().min(0).max(1).optional(),
+		VITE_SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).optional(),
 	})
 	.transform((data) => ({
 		sentryDsn: data.VITE_SENTRY_DSN,
@@ -20,6 +22,10 @@ const schema = z
 		// In other envs: default to false (reporting off, opt-in for testing)
 		sentryEnabled:
 			data.VITE_SENTRY_ENABLED ?? (isProd && Boolean(data.VITE_SENTRY_DSN)),
+		// In prod: default to 1.0 (100%); in other envs default to 0 (off)
+		sentrySampleRate: data.VITE_SENTRY_ERROR_SAMPLE_RATE ?? (isProd ? 1.0 : 0),
+		sentryTracesSampleRate:
+			data.VITE_SENTRY_TRACES_SAMPLE_RATE ?? (isProd ? 1.0 : 0),
 		mode: import.meta.env.MODE as string,
 		prod: isProd,
 	}))
@@ -30,6 +36,8 @@ const schema = z
 const result = schema.safeParse({
 	VITE_SENTRY_DSN: import.meta.env.VITE_SENTRY_DSN,
 	VITE_SENTRY_ENABLED: import.meta.env.VITE_SENTRY_ENABLED,
+	VITE_SENTRY_ERROR_SAMPLE_RATE: import.meta.env.VITE_SENTRY_ERROR_SAMPLE_RATE,
+	VITE_SENTRY_TRACES_SAMPLE_RATE: import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE,
 })
 if (!result.success) {
 	const issues = result.error.issues.map(

--- a/apps/www/src/lib/sentry.ts
+++ b/apps/www/src/lib/sentry.ts
@@ -32,7 +32,8 @@ if (clientEnv.sentryDsn) {
 		dsn: clientEnv.sentryDsn,
 		enabled: clientEnv.sentryEnabled,
 		environment: clientEnv.mode,
-		tracesSampleRate: 1.0,
+		sampleRate: clientEnv.sentrySampleRate,
+		tracesSampleRate: clientEnv.sentryTracesSampleRate,
 		beforeSend(event, hint) {
 			const err = hint.originalException
 			if (isControlFlow(err)) return null

--- a/apps/www/src/router.tsx
+++ b/apps/www/src/router.tsx
@@ -1,4 +1,6 @@
 import { createRouter } from '@tanstack/solid-router'
+import { tanstackRouterBrowserTracingIntegration } from '@sentry/solid/tanstackrouter'
+import { Sentry } from '@/lib/sentry'
 import { routeTree } from './routeTree.gen'
 
 export function getRouter() {
@@ -6,6 +8,12 @@ export function getRouter() {
 		routeTree,
 		scrollRestoration: true,
 	})
+
+	// Client-only: replace the default browserTracingIntegration with the
+	// TanStack Router-aware version so navigation spans use route patterns.
+	if (!import.meta.env.SSR) {
+		Sentry.addIntegration(tanstackRouterBrowserTracingIntegration(router))
+	}
 
 	return router
 }

--- a/apps/www/tests/soft-delete.test.ts
+++ b/apps/www/tests/soft-delete.test.ts
@@ -23,7 +23,12 @@ vi.mock('../src/data/db', () => ({
 }))
 
 vi.mock('../src/lib/sentry', () => ({
-	Sentry: { captureException: vi.fn() },
+	Sentry: {
+		captureException: vi.fn(),
+		startSpan: vi.fn((_, fn: (span: { setAttribute: () => void }) => unknown) =>
+			fn({ setAttribute: vi.fn() })
+		),
+	},
 }))
 
 // Must import after mocking

--- a/fly.toml
+++ b/fly.toml
@@ -16,6 +16,8 @@ primary_region = 'sjc'
   # Fly secrets are runtime-only, so they can't be used for build-time vars.
   # See Dockerfile ARGs and apps/www/src/lib/env.client.ts.
   # Pass VITE_SENTRY_DSN via: flyctl deploy --build-arg VITE_SENTRY_DSN=...
+  # Pass VITE_SENTRY_ERROR_SAMPLE_RATE and VITE_SENTRY_TRACES_SAMPLE_RATE
+  # similarly to tune sampling without changing defaults in env.client.ts.
   [build.args]
     VITE_SENTRY_ENABLED = "true"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@libsql/client':
         specifier: ^0.17.0
         version: 0.17.0
+      '@sentry/solid':
+        specifier: ^10.40.0
+        version: 10.40.0(@tanstack/solid-router@1.160.0(solid-js@1.9.11))(solid-js@1.9.11)
       '@sentry/solidstart':
         specifier: ^10.40.0
         version: 10.40.0(@solidjs/start@1.2.1(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vinxi@0.5.10(@libsql/client@0.17.0)(@types/node@25.2.3)(db0@0.3.4(@libsql/client@0.17.0)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11))(ioredis@5.9.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(@tanstack/solid-router@1.160.0(solid-js@1.9.11))(rollup@4.57.1)(solid-js@1.9.11)


### PR DESCRIPTION
## Summary

Wire up OpenTelemetry-style tracing via Sentry across the app:

- Wrap all 15 query functions in `queries.ts` with `Sentry.startSpan` (`op: 'db.query'`) so every DB call produces a span; result counts are set as span attributes where useful. lat/lng coordinates are deliberately omitted from span attributes to avoid leaking PII in violation of the app's H3 coarsening model.
- Add `tanstackRouterBrowserTracingIntegration` in `router.tsx` (client-only guard) so navigation spans use route patterns instead of raw URLs.
- Introduce `VITE_SENTRY_ERROR_SAMPLE_RATE` and `VITE_SENTRY_TRACES_SAMPLE_RATE` build args with prod defaults of 1.0 and dev defaults of 0; validated in `env.client.ts` and plumbed through to `sentry.ts`.
- Declare new build args in `Dockerfile` and document them in `fly.toml`.
- Add `@sentry/solid` as an explicit dependency (pinned to `^10.40.0`) alongside `@sentry/solidstart`.
- Update `soft-delete.test.ts` Sentry mock to include `startSpan`.

Partially addresses #111 (production readiness checklist).

## Review

- lat/lng removed from getNearbyListings span attributes to prevent PII exposure — addressed.
- `VITE_SENTRY_SAMPLE_RATE` renamed to `VITE_SENTRY_ERROR_SAMPLE_RATE` before first deploy to avoid an ops breaking change — addressed.
- `@sentry/solid` pin changed from exact to `^10.40.0` to track the `@sentry/solidstart` range — addressed.
- Sentry mock in `soft-delete.test.ts` was missing `startSpan` — addressed.
- `Dockerfile` and `fly.toml` were missing ARG declarations for the new sample-rate build args — addressed.
- `addIntegration` called without an init guard: Sentry v8 is designed to be a no-op before init, so no guard is needed — rebutted, no action.
- `getRouter()` singleton concern: TanStack Start calls it once per client lifecycle and Sentry deduplicates by integration name — rebutted, no action.
- Span coverage was initially limited to `getNearbyListings`; extended to all 15 query functions — addressed.

## Conversation

Session completed issue #82 (OpenTelemetry/Sentry tracing) and made progress on #111 (production readiness). Key work included the initial getNearbyListings span, wiring up the TanStack Router browser-tracing integration, adding configurable sample rates via two new VITE_ build args, and expanding span coverage to all 15 query functions after a parallel two-agent review (User Advocate + Lead Engineer) flagged the inconsistency. All pre-merge findings were addressed or rebutted before staging. ~15 turns,
~3 permission prompts.