### PR TITLE
feat(www): complete Sentry sourcemap upload pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,6 +106,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build image
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
           docker build -t pickmyfruit-web -f apps/www/Dockerfile . \
             --build-arg VITE_SENTRY_DSN=https://test@test.ingest.sentry.io/123
@@ -155,10 +157,13 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to Fly.io
-        run: |
-          flyctl deploy --remote-only \
-            --build-arg VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }} \
-            --build-arg VITE_SENTRY_ERROR_SAMPLE_RATE=${{ vars.VITE_SENTRY_ERROR_SAMPLE_RATE }} \
-            --build-arg VITE_SENTRY_TRACES_SAMPLE_RATE=${{ vars.VITE_SENTRY_TRACES_SAMPLE_RATE }}
+        run: ./bin/deploy.sh
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+          SENTRY_RELEASE: ${{ github.sha }}
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_SENTRY_ERROR_SAMPLE_RATE: ${{ vars.VITE_SENTRY_ERROR_SAMPLE_RATE }}
+          VITE_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.VITE_SENTRY_TRACES_SAMPLE_RATE }}

--- a/apps/www/Dockerfile
+++ b/apps/www/Dockerfile
@@ -1,8 +1,18 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM node:24-slim AS builder
 
-# Install pnpm
+# Install CA certificates (required by sentry-cli to make TLS connections)
+# and pnpm. node:24-slim omits the system CA bundle by default.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN corepack enable && corepack prepare pnpm@10.22.0 --activate
+
+# Install sentry-cli for the sourcemap upload step below.
+# Pin to a specific version to prevent unplanned breakage on future builds.
+# Bump this intentionally when upgrading; changelog: https://github.com/getsentry/sentry-cli/releases
+RUN npm install -g @sentry/cli@3.3.2
 
 WORKDIR /app
 
@@ -32,9 +42,35 @@ ARG VITE_SENTRY_DSN
 ARG VITE_SENTRY_ENABLED
 ARG VITE_SENTRY_ERROR_SAMPLE_RATE
 ARG VITE_SENTRY_TRACES_SAMPLE_RATE
+# Non-sensitive Sentry identifiers needed by sentry-cli at upload time.
+ARG SENTRY_ORG
+ARG SENTRY_PROJECT
+# SENTRY_RELEASE is the canonical release name (git SHA) used by sentry-cli.
+# VITE_SENTRY_RELEASE defaults to it so both consumers always reference the same
+# release — only pass SENTRY_RELEASE at build time; VITE_SENTRY_RELEASE is derived.
+ARG SENTRY_RELEASE
+ARG VITE_SENTRY_RELEASE=${SENTRY_RELEASE}
 
-# Build the www application
+# Build the www application.
 RUN cd apps/www && pnpm build
+
+# Upload sourcemaps to Sentry and delete them so they are absent from the
+# final image. Runs after the full build so both client (.output/public/)
+# and server (.output/server/) maps exist. If SENTRY_AUTH_TOKEN is absent
+# (e.g. CI smoke tests), the step is a no-op.
+# SENTRY_ORG, SENTRY_PROJECT, and SENTRY_RELEASE are available from the
+# ARG declarations above; sentry-cli reads them from the environment.
+RUN --mount=type=secret,id=sentry_auth_token \
+    export SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token 2>/dev/null || true) && \
+    if [ -n "$SENTRY_AUTH_TOKEN" ]; then \
+        sentry-cli sourcemaps upload \
+            --release "$SENTRY_RELEASE" \
+            apps/www/.output/public \
+            apps/www/.output/server; \
+    else \
+        echo "INFO: SENTRY_AUTH_TOKEN absent — skipping sourcemap upload"; \
+    fi; \
+    find apps/www/.output -name '*.map' -delete
 
 # traceDeps traces only the builder's native @libsql binary. Copy all Linux
 # variants directly from pnpm's virtual store so the image runs on both x64

--- a/apps/www/src/lib/env.client.ts
+++ b/apps/www/src/lib/env.client.ts
@@ -15,6 +15,7 @@ const schema = z
 			.optional(),
 		VITE_SENTRY_ERROR_SAMPLE_RATE: z.coerce.number().min(0).max(1).optional(),
 		VITE_SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).optional(),
+		VITE_SENTRY_RELEASE: z.string().optional(),
 	})
 	.transform((data) => ({
 		sentryDsn: data.VITE_SENTRY_DSN,
@@ -26,6 +27,7 @@ const schema = z
 		sentrySampleRate: data.VITE_SENTRY_ERROR_SAMPLE_RATE ?? (isProd ? 1.0 : 0),
 		sentryTracesSampleRate:
 			data.VITE_SENTRY_TRACES_SAMPLE_RATE ?? (isProd ? 1.0 : 0),
+		sentryRelease: data.VITE_SENTRY_RELEASE,
 		mode: import.meta.env.MODE as string,
 		prod: isProd,
 	}))
@@ -38,6 +40,7 @@ const result = schema.safeParse({
 	VITE_SENTRY_ENABLED: import.meta.env.VITE_SENTRY_ENABLED,
 	VITE_SENTRY_ERROR_SAMPLE_RATE: import.meta.env.VITE_SENTRY_ERROR_SAMPLE_RATE,
 	VITE_SENTRY_TRACES_SAMPLE_RATE: import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE,
+	VITE_SENTRY_RELEASE: import.meta.env.VITE_SENTRY_RELEASE,
 })
 if (!result.success) {
 	const issues = result.error.issues.map(

--- a/apps/www/src/lib/sentry.ts
+++ b/apps/www/src/lib/sentry.ts
@@ -32,6 +32,7 @@ if (clientEnv.sentryDsn) {
 		dsn: clientEnv.sentryDsn,
 		enabled: clientEnv.sentryEnabled,
 		environment: clientEnv.mode,
+		release: clientEnv.sentryRelease,
 		sampleRate: clientEnv.sentrySampleRate,
 		tracesSampleRate: clientEnv.sentryTracesSampleRate,
 		beforeSend(event, hint) {

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -33,13 +33,29 @@ export default defineConfig(({ command, mode }) => {
 	}
 
 	return {
+		build: {
+			// 'hidden' generates .map files but omits the //# sourceMappingURL= comment,
+			// so browsers do not auto-fetch them. sentry-cli (run in the Dockerfile
+			// build step after pnpm build) can still locate and upload them by path.
+			sourcemap: 'hidden',
+		},
+		// Enable sourcemaps in the SSR Vite environment so Nitro has source-mapped
+		// input when it builds the final server bundle. Without this, server-side
+		// error stack traces in Sentry cannot be mapped back to original TypeScript.
+		environments: {
+			ssr: {
+				build: { sourcemap: 'hidden' },
+			},
+		},
 		server: {},
 		plugins: [
 			tsconfigPaths(),
 			tanstackStart(),
 			// traceDeps copies @libsql's native binaries into .output/server/node_modules/
 			// so the production bundle can resolve them without a full node_modules install.
-			nitro({ traceDeps: ['libsql'] }),
+			// sourcemap: true makes Nitro's Rollup pass emit .map files for the final
+			// .output/server bundle and chain them through the SSR sourcemaps above.
+			nitro({ sourcemap: true, traceDeps: ['libsql'] }),
 			h3jsDirnamePolyfill,
 			solid({ ssr: true }),
 		],

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Deploy PickMyFruit to Fly.io with Sentry sourcemap upload.
+#
+# The vite build runs inside the Docker build on Fly's remote builder.
+# SENTRY_AUTH_TOKEN is passed as a BuildKit secret so it is never stored in an
+# image layer. sentry-cli uploads sourcemaps and deletes the .map files from
+# the output directory during the build.
+#
+# One-time GitHub repository setup (Settings → Secrets and variables):
+#   Secrets:  SENTRY_AUTH_TOKEN   Create at https://sentry.io/settings/auth-tokens/
+#             VITE_SENTRY_DSN     Found in Sentry project → Settings → Client Keys
+#             FLY_API_TOKEN       Create at https://fly.io/user/personal_access_tokens
+#   Variables: SENTRY_ORG         Your Sentry organization slug
+#              SENTRY_PROJECT     Your Sentry project slug
+#   Note: VITE_SENTRY_ENABLED is already set to "true" via fly.toml [build.args]
+#         and does not need to be a GitHub variable.
+#
+# Required env vars for manual deploys:
+#   SENTRY_AUTH_TOKEN   Sentry authentication token
+#   SENTRY_ORG          Sentry organization slug
+#   SENTRY_PROJECT      Sentry project slug
+#   VITE_SENTRY_DSN     Sentry DSN (baked into the JS bundle at build time)
+#
+# Optional env vars:
+#   SENTRY_RELEASE               Git SHA to use as the release name.
+#                                Defaults to: git rev-parse HEAD
+#                                VITE_SENTRY_RELEASE is derived from this automatically.
+#   VITE_SENTRY_ERROR_SAMPLE_RATE    Error sample rate (default: 1.0 in prod)
+#   VITE_SENTRY_TRACES_SAMPLE_RATE   Traces sample rate (default: 1.0 in prod)
+
+set -euo pipefail
+
+: "${SENTRY_AUTH_TOKEN:?Required: SENTRY_AUTH_TOKEN}"
+: "${SENTRY_ORG:?Required: SENTRY_ORG}"
+: "${SENTRY_PROJECT:?Required: SENTRY_PROJECT}"
+: "${VITE_SENTRY_DSN:?Required: VITE_SENTRY_DSN}"
+
+RELEASE="${SENTRY_RELEASE:-$(git rev-parse HEAD)}"
+SHORT="${RELEASE:0:8}"
+
+echo "=== Deploying PickMyFruit (release: $SHORT) ==="
+
+DEPLOY_ARGS=(
+	--remote-only
+	--build-secret "sentry_auth_token=$SENTRY_AUTH_TOKEN"
+	--build-arg "VITE_SENTRY_DSN=$VITE_SENTRY_DSN"
+	--build-arg "SENTRY_RELEASE=$RELEASE"
+	--build-arg "SENTRY_ORG=$SENTRY_ORG"
+	--build-arg "SENTRY_PROJECT=$SENTRY_PROJECT"
+)
+
+[[ -n "${VITE_SENTRY_ERROR_SAMPLE_RATE:-}" ]] &&
+	DEPLOY_ARGS+=(--build-arg "VITE_SENTRY_ERROR_SAMPLE_RATE=$VITE_SENTRY_ERROR_SAMPLE_RATE")
+
+[[ -n "${VITE_SENTRY_TRACES_SAMPLE_RATE:-}" ]] &&
+	DEPLOY_ARGS+=(--build-arg "VITE_SENTRY_TRACES_SAMPLE_RATE=$VITE_SENTRY_TRACES_SAMPLE_RATE")
+
+flyctl deploy "${DEPLOY_ARGS[@]}"


### PR DESCRIPTION
## Summary

- Replace `@sentry/vite-plugin` with an explicit `sentry-cli` step in
  the Dockerfile builder stage — the vite plugin fired mid-build before
  Nitro's server maps existed, producing 0 uploads with no error
- Install `ca-certificates` in the builder stage (`node:24-slim` omits
  the system CA bundle, which was the root cause of all silent failures)
- Pin `sentry-cli` to `3.3.2`
- Add `bin/deploy.sh` to encapsulate `flyctl` invocation; CI now calls it
- Derive `VITE_SENTRY_RELEASE` from `SENTRY_RELEASE` via ARG default so
  only one value is passed at deploy time
- Use `sourcemap: 'hidden'` for both client and SSR environments
- Pass release name through `env.client.ts` schema into `Sentry.init`
- Document required GitHub secrets/variables in `bin/deploy.sh` header

## Root Cause Analysis

The root cause was present from the very first deploy. Every detour —
BuildKit secrets, `release_command`, symlink copying — was chasing a
symptom, not the cause.

**Missed assumption checks:**

1. **"Can this container reach the upload endpoint?"** was never tested.
   A single `RUN curl` line would have found it immediately. For any new
   outbound call from a container: check connectivity before debugging
   application logic.

2. **`node:X-slim` needs `ca-certificates` for TLS.** Slim images strip
   the system CA bundle. We should have suspected this when we first added
   any HTTPS upload to a slim builder stage.

3. **The vite plugin's silence was misleading.** `0 artifacts` with no
   error looks like a logic problem. It was a hard TLS failure being
   swallowed. When a tool produces zero output with no error, the first
   hypothesis should be "is it failing silently?" not "is it
   misconfigured?"

**Diagnostic order for "tool won't upload" from a container:**
1. Does the auth token arrive? (test it explicitly)
2. Can the container reach the endpoint? (curl it)
3. Does the tool produce output when run directly? (bypass the wrapper)
4. Then check configuration, timing, and logic

## Test plan

- [x] `bin/deploy.sh` completes and Sentry release shows > 0 artifacts
- [x] Server-side error in Sentry resolves to original TypeScript source
- [ ] CI smoke-test Docker build passes without `SENTRY_AUTH_TOKEN`
- [x] `.map` files are absent from the production image (`docker run --rm ... find .output -name '*.map'`)

## Deferred

- #162 — Make `SENTRY_AUTH_TOKEN` optional to allow deploys during Sentry outages

🤖 Generated with [Claude Code](https://claude.com/claude-code)