### PR TITLE
fix(map): use Noto Sans for group labels

### DIFF
--- a/apps/www/src/components/ListingsMap.tsx
+++ b/apps/www/src/components/ListingsMap.tsx
@@ -192,7 +192,7 @@ export default function ListingsMap(props: Props) {
 			layout: {
 				'text-field': ['get', 'label'],
 				'text-size': 13,
-				'text-font': ['Open Sans Bold'],
+				'text-font': ['Noto Sans Bold'],
 				'text-allow-overlap': true,
 			},
 			paint: {


### PR DESCRIPTION
The `<ListingsMap>` adds a custom `listing-groups-label` layer. The initial implementation used `Open Sans Bold`. This is incompatible with the MapLibre `liberty` style config,[^1] which defines

```
"glyphs": "https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf
```

That server doesn't have `Open Sans Bold`.

This commit changes the layer to use `Noto Sans Bold`, which the `liberty` style already uses and the server provides.

[^1]: https://tiles.openfreemap.org/styles/liberty