### PR TITLE
test(migrations): add migration smoke test and execution logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ We use a monorepo structure
 - `db:push` for local dev — diffs `schema.ts` against the live DB
 - `db:migrate` for E2E tests and production — runs migration files tracked by a journal
 - Do not mix: a DB created with `push` can't switch to `migrate` (and vice versa)
+- When writing a migration by hand, set `when` in `drizzle/meta/_journal.json` to `Date.now()` at the time of writing (milliseconds since epoch). Values must be strictly increasing; entries with a `when` below the current `MAX(created_at)` in `__drizzle_migrations` are silently skipped by the migrator.
 - Use Solid JS for reactive UI components
 - Routes are defined using TanStack Router's file-based routing
 - Route loaders that fetch data must use `createServerFn` (not `createIsomorphicFn` with `.client(() => undefined)`) so client-side navigation triggers an RPC call

--- a/apps/www/src/lib/migrations.server.ts
+++ b/apps/www/src/lib/migrations.server.ts
@@ -1,6 +1,7 @@
 import { migrate } from 'drizzle-orm/libsql/migrator'
 import { db } from '@/data/db.server'
 import { Sentry } from '@/lib/sentry'
+import { logger } from '@/lib/logger.server'
 import { serverEnv } from '@/lib/env.server'
 
 let pending: Promise<void> | undefined
@@ -23,7 +24,12 @@ export function runMigrations(): Promise<void> {
 		)
 	}
 
-	pending ??= migrate(db, { migrationsFolder: './drizzle' }).catch((err) => {
+	pending ??= (async () => {
+		const start = Date.now()
+		logger.info('Running database migrations')
+		await migrate(db, { migrationsFolder: './drizzle' })
+		logger.info({ elapsed: Date.now() - start }, 'Database migrations complete')
+	})().catch((err) => {
 		Sentry.captureException(err)
 		failureCount++
 		pending = undefined

--- a/apps/www/tests/migrations.server.test.ts
+++ b/apps/www/tests/migrations.server.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { GOLDEN_DB_PATH } from './helpers/test-db-setup'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const wwwRoot = resolve(__dirname, '..')
+
+/**
+ * All application tables that must exist after every migration has run.
+ * Keep this list in sync with schema.ts. The query uses ORDER BY name, so
+ * this list must also be sorted alphabetically for the equality check.
+ */
+const EXPECTED_TABLES = [
+	'account',
+	'inquiries',
+	'listing_photos',
+	'listings',
+	'session',
+	'user',
+	'verification',
+]
+
+/**
+ * Query sqlite_master in a child process to work around the ESM/CJS conflict
+ * between @libsql/client and the `ws` package inside vitest's module system.
+ */
+function queryTables(dbPath: string): string[] {
+	const script = `
+		import { createClient } from '@libsql/client'
+		const client = createClient({ url: process.env.CHECK_DB_URL })
+		const result = await client.execute(
+			"SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT GLOB 'sqlite_*' AND name NOT GLOB '__*' ORDER BY name"
+		)
+		process.stdout.write(JSON.stringify(result.rows.map(r => String(r[0]))))
+		client.close()
+	`
+	const output = execSync('node --input-type=module', {
+		cwd: wwwRoot,
+		input: script,
+		env: { ...process.env, CHECK_DB_URL: `file:${dbPath}` },
+		encoding: 'utf8',
+		timeout: 15_000,
+	})
+	return JSON.parse(output) as string[]
+}
+
+describe('database migrations', () => {
+	it('golden database has all expected tables after migrations run', () => {
+		// The golden DB is created by vitest globalSetup (createGoldenDatabase) before
+		// any test runs. Querying it here asserts that the migration outcome is correct —
+		// something globalSetup does not check — without paying the cost of a second
+		// migration run.
+		const tables = queryTables(GOLDEN_DB_PATH)
+		expect(tables).toEqual(EXPECTED_TABLES)
+	})
+
+	it('journal when values are strictly increasing by idx', () => {
+		const journalPath = resolve(wwwRoot, 'drizzle', 'meta', '_journal.json')
+		const journal = JSON.parse(readFileSync(journalPath, 'utf8'))
+		const entries: Array<{ idx: number; when: number; tag: string }> =
+			journal.entries
+
+		for (let i = 1; i < entries.length; i++) {
+			const prev = entries[i - 1]
+			const curr = entries[i]
+			expect(
+				curr.when,
+				`${curr.tag} (idx ${curr.idx}, when=${curr.when}) must be > ${prev.tag} (idx ${prev.idx}, when=${prev.when})`
+			).toBeGreaterThan(prev.when)
+		}
+	})
+})


### PR DESCRIPTION
## Summary

Implements four High/Medium recommendations from the RCA in #195:

- **Migration smoke test** — verifies all expected application tables exist after every migration runs against the golden DB (globalSetup already creates it; this adds the assertion)
- **Journal monotonicity check** — Vitest asserts `when` values in `_journal.json` are strictly increasing by `idx`, catching the exact class of timestamp bug that caused the #195 incident before merge
- **Migration execution logging** — `runMigrations()` now logs start and completion with elapsed ms via `logger.info`; silent success/failure is no longer possible
- **CLAUDE.md convention** — documents that hand-written migration `when` values must be set to `Date.now()` at time of writing

## Test Plan

- [x] `pnpm test:run` passes (158 tests, including 2 new migration tests)
- [x] Confirm `pnpm test:run` passes in CI

## Review Notes

Self-reviewed via deliver skill. One LOW finding rebutted: the `__drizzle_migrations` internal table reference in CLAUDE.md was flagged for lacking a drizzle-orm version caveat — the note is a usage convention, not an internals reference, so adding version numbers would be noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)