### PR TITLE
fix(e2e): make auth tests resilient to Vite dev-mode reloads

### DIFF
--- a/apps/www/tests/e2e/auth.test.ts
+++ b/apps/www/tests/e2e/auth.test.ts
@@ -63,18 +63,23 @@ test.describe('Authentication', () => {
 		await loginViaUI(page, testUser)
 
 		const nav = pageHeader(page)
-		expect(await nav.isSignedIn()).toBeTruthy()
+		// Vite dev mode may reload the page when loading new modules on first visit.
+		// Poll until the session is established rather than asserting immediately.
+		await expect.poll(() => nav.isSignedIn(), { timeout: 10000 }).toBeTruthy()
 
 		await page.reload()
+		await page.waitForLoadState('networkidle')
 
 		await expect(page).toHaveURL('/listings/mine')
-		expect(await nav.isSignedIn()).toBeTruthy()
+		await expect.poll(() => nav.isSignedIn(), { timeout: 5000 }).toBeTruthy()
 	})
 
 	test('sign-out redirects from protected page', async ({ page, testUser }) => {
 		await loginViaUI(page, testUser)
 
 		const nav = pageHeader(page)
+		// Wait for page to settle (Vite may reload on first visit to mine page)
+		await expect.poll(() => nav.isSignedIn(), { timeout: 10000 }).toBeTruthy()
 		await nav.signOut()
 
 		await expect(page).toHaveURL('/')


### PR DESCRIPTION
## Summary

- `session survives page refresh` and `sign-out redirects from protected page` would fail when run against a cold Vite dev server
- Root cause: on first visit to `/listings/mine`, Vite discovers new modules and may trigger a module-graph update, briefly aborting the TanStack Router loader fetch and rolling the navigation back to `/login`
- Fix: replace immediate `expect(await nav.isSignedIn()).toBeTruthy()` assertions (which fire while the page is mid-flight) with `expect.poll()` so the tests wait out any Vite-triggered reload before asserting

The `sign-out redirects from protected page` test had the same latent bug but was never reached because the serial suite stopped at the preceding failure.

## Test plan

- [x] `pnpm exec playwright test auth` → all 5 pass
- [x] Run twice in a row (second run = warm Vite cache) → still all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)