### PR TITLE
fix(ci): prevent destroy-preview from cancelling deploy on PR merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,9 +7,10 @@ on:
     types: [closed]
   workflow_dispatch:
 
-# Prevent concurrent runs on the same ref
+# Prevent concurrent runs on the same ref+event (include event_name so that a
+# pull_request closed event on main doesn't cancel a concurrent push-to-main run)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- Adds `github.event_name` to the concurrency group key so `pull_request closed` and `push` events never share a group
- Fixes the race where merging a PR caused the destroy-preview workflow to cancel the main deploy

## Root cause

When a PR is merged to `main`, GitHub fires two events nearly simultaneously: `push` (to deploy) and `pull_request closed` (to destroy the preview). Both resolved to the same concurrency group `CI/CD Pipeline-refs/heads/main`, so with `cancel-in-progress: true` the destroy run was cancelling the deploy run.

## Test plan

- [ ] Merge a PR and confirm both the destroy-preview job and the deploy-to-production job complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)