### PR TITLE
fix(e2e): add hydration guard to inquiry tests 1 and 3

### DIFF
--- a/apps/www/tests/e2e/inquiry.test.ts
+++ b/apps/www/tests/e2e/inquiry.test.ts
@@ -24,6 +24,7 @@ test.describe('Inquiry Flow', () => {
 		try {
 			await loginViaUI(page, gleaner)
 			await page.goto(`/listings/${listing.id}`)
+			await page.waitForLoadState('networkidle')
 
 			// Verify the inquiry form is visible
 			await expect(
@@ -97,6 +98,7 @@ test.describe('Inquiry Flow', () => {
 	}) => {
 		await loginViaUI(page, testUser)
 		await page.goto(`/listings/${testListing.id}`)
+		await page.waitForLoadState('networkidle')
 
 		// Owner sees "This is your listing" instead of the inquiry form
 		await expect(page.getByText('This is your listing.')).toBeVisible()


### PR DESCRIPTION
## Summary

- Two inquiry E2E tests were missing `waitForLoadState('networkidle')` after `page.goto`
- On slower CI hardware, SolidJS hasn't hydrated when the button is clicked — `isAuthenticated()` returns false and the form starts a magic-link flow instead of submitting directly
- Test 2 already had this guard with a comment; tests 1 and 3 now match

## Test Plan

- [x] CI E2E run passes (was failing deterministically in jamesarosen/PickMyFruit#24225358333 and jamesarosen/PickMyFruit#24224981987)

## Review Notes

Self-reviewed via deliver skill (adversary agent).

- `networkidle` as a hydration proxy: rebutted — consistent with test 2's existing pattern
- Commented-out textarea locator on line 37: deferred (separate concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)