### PR TITLE
fix(ci): run e2e tests on all branch pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request'
     defaults:
       run:
         working-directory: apps/www


### PR DESCRIPTION
## Summary

- E2E job was gated on `github.ref == 'refs/heads/main'`, so it never ran on PR branches
- Changed condition to `github.event_name != 'pull_request'` (matching the `test` job) so E2E runs on every branch push

## Test plan

- [x] Verify E2E job appears in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)