### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,31 @@ We use a monorepo structure
 ## Future Plans
 
 (none yet)
+
+## Cursor Cloud specific instructions
+
+### Services
+
+The only service is the **Solid JS web application** in `apps/www`. It uses an embedded SQLite database (no external DB process required). All env defaults for dev and test are committed in `.env.development` and `.env.test`.
+
+### Common commands (run from repo root)
+
+| Task | Command |
+|---|---|
+| Dev server (port 5173) | `pnpm dev` (from `apps/www`) |
+| Lint | `pnpm lint` |
+| Typecheck | `pnpm typecheck` |
+| Unit tests | `pnpm test:run` |
+| E2E tests | `pnpm test:e2e` (from `apps/www`) |
+| Format check | `pnpm format:check` |
+| DB schema sync (dev) | `pnpm db:push` (from `apps/www`) |
+| Quality gate (all checks) | `bash bin/quality-gate.sh` |
+
+### Gotchas
+
+- **Node version**: `.npmrc` sets `use-node-version=24.9.0` — pnpm scripts automatically use Node 24.9.0 regardless of the system Node version. Ensure Node 24 is installed via nvm.
+- **DB push vs migrate**: Dev uses `db:push`; E2E tests and production use `db:migrate`. A DB created with one method cannot switch to the other — delete the `.db` file to start fresh if needed.
+- **Magic link auth in dev**: `EMAIL_PROVIDER=console` (default) logs the magic link token to the Vite dev server stdout. Look for the Pino log line with `token:` to extract it for manual testing.
+- **E2E test server**: Playwright starts its own Vite dev server on port 5174 with test-specific env vars (`reuseExistingServer: false`). The port-5173 dev server does not interfere.
+- **pnpm build script warnings**: `pnpm install` may show "Ignored build scripts" for `esbuild`, `sharp`, `@parcel/watcher`, `@sentry/cli`. The platform-specific binaries are still installed correctly via optional dependencies; these warnings are safe to ignore.
+- **`pnpm db:seed` script reference**: The `package.json` `db:seed` script references `src/data/seed.ts` but the actual file is `src/data/seed.server.ts`. The seed script will fail; this is a known discrepancy in the repo.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable development environment context for future cloud agents.

### What's included

- Service overview (single Solid JS app with embedded SQLite)
- Common commands table (dev, lint, typecheck, test, format, db sync)
- Non-obvious gotchas discovered during setup:
  - Node version management (`.npmrc` `use-node-version` behavior)
  - `db:push` vs `db:migrate` incompatibility
  - Magic link token extraction from dev server logs
  - E2E test server isolation (port 5174)
  - pnpm build script warnings (safe to ignore)
  - `db:seed` script path discrepancy

### Demo

[demo_pick_my_fruit_hello_world.mp4](https://cursor.com/agents/bc-987c0069-cb28-4950-be1a-eb3601f2ef2a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_pick_my_fruit_hello_world.mp4)

Full end-to-end demo: homepage load, magic link auth, and creating a new produce listing.

[Homepage](https://cursor.com/agents/bc-987c0069-cb28-4950-be1a-eb3601f2ef2a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Listing created successfully](https://cursor.com/agents/bc-987c0069-cb28-4950-be1a-eb3601f2ef2a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flisting_created.webp)

### Verification

- **Lint**: 0 errors (166 warnings, all pre-existing)
- **Typecheck**: passes
- **Unit tests**: 177/177 pass
- **E2E tests**: 30/31 pass (1 pre-existing flaky test in `auth.test.ts` — sign-out menu timing)
- **Dev server**: runs on port 5173, health endpoint returns `{"status":"ok"}`
- **Hello world**: authenticated via magic link, created a Lemon listing with geocoded address

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-987c0069-cb28-4950-be1a-eb3601f2ef2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-987c0069-cb28-4950-be1a-eb3601f2ef2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

