### PR TITLE
fix(data): avoid truncating photo lookups after 100 listing IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,12 @@ The only service is the **Solid JS web application** in `apps/www`. It uses an e
 | DB schema sync (dev) | `pnpm db:push` (from `apps/www`) |
 | Quality gate (all checks) | `bash bin/quality-gate.sh` |
 
+### Commit gate (required)
+
+- Before every commit, run `bash bin/code-quality.sh` from the repo root.
+- Do not commit unless `bash bin/code-quality.sh` passes.
+- If it fails, fix the reported formatting, linting, or test issue, then rerun `bash bin/code-quality.sh` until it passes.
+
 ### Gotchas
 
 - **Node version**: `.npmrc` sets `use-node-version=24.9.0` — pnpm scripts automatically use Node 24.9.0 regardless of the system Node version. Ensure Node 24 is installed via nvm.

--- a/apps/www/src/api/listings.ts
+++ b/apps/www/src/api/listings.ts
@@ -2,6 +2,7 @@ import { createServerFn } from '@tanstack/solid-start'
 import { getRequestHeaders } from '@tanstack/solid-start/server'
 import { z } from 'zod'
 import { errorMiddleware } from '@/lib/server-error-middleware'
+import { Sentry } from '@/lib/sentry'
 import type { AddressFields } from '@/data/schema'
 import type { OwnerListingView } from '@/data/listing'
 
@@ -17,7 +18,17 @@ export const getMyListings = createServerFn({ method: 'GET' })
 		}
 
 		const { getUserListings } = await import('@/data/queries.server')
-		return getUserListings(session.user.id)
+		const listings = await getUserListings(session.user.id)
+		if (listings.length > 15) {
+			Sentry.captureMessage('User has more than 15 listings', {
+				level: 'warning',
+				extra: {
+					userId: session.user.id,
+					listingCount: listings.length,
+				},
+			})
+		}
+		return listings
 	})
 
 /** Returns the current user's most recent address, or undefined. */

--- a/apps/www/src/data/queries.server.ts
+++ b/apps/www/src/data/queries.server.ts
@@ -41,13 +41,22 @@ function reportH3Error(listingId: number, error: unknown) {
 /**
  * Fetches non-deleted photos for a set of listing IDs in a single query and
  * groups them by listing ID, ordered by `order` ascending.
- * Capped at 100 IDs to stay within SQLite's variable limit.
+ * Throws when more than 100 IDs are requested so call sites fail fast instead
+ * of silently dropping photos.
  */
+const MAX_PHOTO_LOOKUP_LISTING_IDS = 100
+
 async function fetchPhotosByListingIds(
 	listingIds: number[]
 ): Promise<Map<number, PublicPhoto[]>> {
 	if (listingIds.length === 0) return new Map()
-	const ids = listingIds.slice(0, 100)
+	if (listingIds.length > MAX_PHOTO_LOOKUP_LISTING_IDS) {
+		throw new DataInvariantError(
+			`fetchPhotosByListingIds: expected at most ${MAX_PHOTO_LOOKUP_LISTING_IDS} listing IDs, received ${listingIds.length}`
+		)
+	}
+
+	const uniqueIds = [...new Set(listingIds)]
 	const rows = await db
 		.select({
 			id: listingPhotos.id,
@@ -56,7 +65,7 @@ async function fetchPhotosByListingIds(
 			order: listingPhotos.order,
 		})
 		.from(listingPhotos)
-		.where(inArray(listingPhotos.listingId, ids))
+		.where(inArray(listingPhotos.listingId, uniqueIds))
 		.orderBy(listingPhotos.order)
 
 	const map = new Map<number, PublicPhoto[]>()

--- a/apps/www/tests/listing-photo-fetch-limit.server.test.ts
+++ b/apps/www/tests/listing-photo-fetch-limit.server.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSelect = vi.fn()
+
+let listingRows: Array<Record<string, unknown>> = []
+let photoRows: Array<{
+	id: string
+	listingId: number
+	ext: string
+	order: number
+}> = []
+let selectInvocationCount = 0
+
+vi.mock('../src/lib/storage.server', () => ({
+	storage: {
+		publicUrl: (path: string) => `https://cdn.example.com/${path}`,
+	},
+}))
+
+vi.mock('../src/lib/sentry', () => ({
+	Sentry: {
+		captureException: vi.fn(),
+		startSpan: vi.fn((_, fn: (span: { setAttribute: () => void }) => unknown) =>
+			fn({ setAttribute: vi.fn() })
+		),
+	},
+}))
+
+vi.mock('../src/data/db.server', () => ({
+	db: {
+		select: (...args: unknown[]) => mockSelect(...args),
+	},
+}))
+
+vi.mock('drizzle-orm', async () => {
+	const actual =
+		await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm')
+	return {
+		...actual,
+		inArray: vi.fn((_: unknown, values: number[]) => ({
+			kind: 'inArray',
+			values,
+		})),
+	}
+})
+
+const { getUserListings } = await import('../src/data/queries.server')
+
+function makeListingRow(id: number) {
+	return {
+		id,
+		name: `Listing ${id}`,
+		type: 'apple',
+		variety: null,
+		status: 'available',
+		quantity: 'some',
+		harvestWindow: null,
+		address: null,
+		city: 'Napa',
+		state: 'CA',
+		zip: null,
+		lat: 0,
+		lng: 0,
+		h3Index: '8928308280fffff',
+		userId: 'owner-1',
+		notes: null,
+		accessInstructions: null,
+		deletedAt: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	}
+}
+
+describe('getUserListings photo fetch limit guard', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		selectInvocationCount = 0
+
+		mockSelect.mockImplementation(() => {
+			selectInvocationCount += 1
+
+			if (selectInvocationCount === 1) {
+				return {
+					from: () => ({
+						where: () => ({
+							orderBy: () => Promise.resolve(listingRows),
+						}),
+					}),
+				}
+			}
+
+			return {
+				from: () => ({
+					where: (whereExpression: { kind?: string; values?: number[] }) => ({
+						orderBy: () => {
+							const requestedIds =
+								whereExpression.kind === 'inArray' ? (whereExpression.values ?? []) : []
+							return Promise.resolve(
+								photoRows.filter((row) => requestedIds.includes(row.listingId))
+							)
+						},
+					}),
+				}),
+			}
+		})
+	})
+
+	it('throws when photo lookup is asked to handle more than 100 listing IDs', async () => {
+		listingRows = Array.from({ length: 101 }, (_, index) =>
+			makeListingRow(index + 1)
+		)
+		photoRows = [{ id: 'photo-101', listingId: 101, ext: '.jpg', order: 0 }]
+
+		await expect(getUserListings('owner-1')).rejects.toThrow(
+			/fetchPhotosByListingIds: expected at most 100 listing IDs, received 101/
+		)
+	})
+})

--- a/apps/www/tests/listings-api.server.test.ts
+++ b/apps/www/tests/listings-api.server.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OwnerListingView } from '../src/data/listing'
+
+const mockGetSession = vi.fn()
+const mockGetUserListings = vi.fn()
+const mockCaptureMessage = vi.fn()
+
+vi.mock('../src/lib/auth.server', () => ({
+	auth: {
+		api: {
+			getSession: mockGetSession,
+		},
+	},
+}))
+
+vi.mock('../src/data/queries.server', () => ({
+	getUserListings: (...args: unknown[]) => mockGetUserListings(...args),
+}))
+
+vi.mock('../src/lib/sentry', () => ({
+	Sentry: {
+		captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+	},
+}))
+
+const { getMyListings } = await import('../src/api/listings')
+
+function makeListing(id: number): OwnerListingView {
+	return {
+		id,
+		name: `Listing ${id}`,
+		type: 'apple',
+		variety: null,
+		status: 'available',
+		quantity: 'some',
+		harvestWindow: null,
+		address: `123${id} Main St`,
+		city: 'Napa',
+		state: 'CA',
+		zip: null,
+		lat: 0,
+		lng: 0,
+		h3Index: '8928308280fffff',
+		userId: 'user-123',
+		notes: null,
+		accessInstructions: null,
+		deletedAt: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		photos: [],
+	}
+}
+
+describe('getMyListings Sentry threshold signal', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns empty array without signaling when unauthenticated', async () => {
+		mockGetSession.mockResolvedValue(null)
+
+		const result = await getMyListings()
+
+		expect(result).toEqual([])
+		expect(mockCaptureMessage).not.toHaveBeenCalled()
+	})
+
+	it('does not signal when listing count is 15', async () => {
+		mockGetSession.mockResolvedValue({ user: { id: 'user-123' } })
+		mockGetUserListings.mockResolvedValue(
+			Array.from({ length: 15 }, (_, index) => makeListing(index + 1))
+		)
+
+		const result = await getMyListings()
+
+		expect(result).toHaveLength(15)
+		expect(mockCaptureMessage).not.toHaveBeenCalled()
+	})
+
+	it('signals with structured metadata when listing count exceeds 15', async () => {
+		mockGetSession.mockResolvedValue({ user: { id: 'user-123' } })
+		mockGetUserListings.mockResolvedValue(
+			Array.from({ length: 16 }, (_, index) => makeListing(index + 1))
+		)
+
+		const result = await getMyListings()
+
+		expect(result).toHaveLength(16)
+		expect(mockCaptureMessage).toHaveBeenCalledWith(
+			'User has more than 15 listings',
+			expect.objectContaining({
+				level: 'warning',
+				extra: { userId: 'user-123', listingCount: 16 },
+			})
+		)
+	})
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Enforces a hard 100-ID bound in `fetchPhotosByListingIds` and throws `DataInvariantError` when exceeded, making overflow explicit instead of silent truncation.
- Adds focused regression coverage for the >100 photo lookup guard.
- Replaces the `getMyListings` scale TODO with a Sentry warning signal when listings exceed 15, including structured metadata (`userId`, `listingCount`).
- Adds focused server tests for the `getMyListings` threshold behavior.
- Updates `AGENTS.md` Cursor Cloud commit gate guidance to require `bash bin/code-quality.sh` before every commit.

## Validation
- `bash bin/code-quality.sh` passes.
- `pnpm test:run tests/listings-api.server.test.ts tests/listing-photo-fetch-limit.server.test.ts tests/listingPhotos.server.test.ts` passes.

## Notes
- Branch rebased onto latest `main` and force-pushed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c398f22d-b93c-4b3d-8c0b-554b18a95331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c398f22d-b93c-4b3d-8c0b-554b18a95331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

