### PR TITLE
Clamp listing card notes to two lines

### DIFF
--- a/apps/www/src/components/ListingCard.css
+++ b/apps/www/src/components/ListingCard.css
@@ -111,5 +111,10 @@
 		margin: 12px 0 0;
 		padding-top: 12px;
 		border-top: 1px solid oklch(from var(--color-quiet) l calc(c * 0.2) h);
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 2;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- clamp `.listing-card-notes` to two lines with `-webkit-line-clamp: 2`
- hide overflow and render an ellipsis to keep listing card heights consistent in the grid

## Visual verification
Before (overflowing notes with uneven card heights):
[Listing card notes before clamp with uneven lengths](https://cursor.com/agents/bc-f80a5179-8a2a-4731-a541-e5778da1deea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flisting-card-notes-before-uneven.webp)

After (two-line clamp with ellipsis):
[Listing card notes after clamp](https://cursor.com/agents/bc-f80a5179-8a2a-4731-a541-e5778da1deea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flisting-card-notes-after.webp)

Demo video:
[listing-card-notes-line-clamp-demo.mp4](https://cursor.com/agents/bc-f80a5179-8a2a-4731-a541-e5778da1deea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flisting-card-notes-line-clamp-demo.mp4)

## Testing
- `pnpm lint`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f80a5179-8a2a-4731-a541-e5778da1deea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f80a5179-8a2a-4731-a541-e5778da1deea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

