### PR TITLE
Add Syntaqlite SQL validation to quality gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install syntaqlite CLI
+        run: ./bin/install-syntaqlite.sh
+
       - name: Run format check
         run: pnpm format:check
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Run typecheck
         run: pnpm typecheck
 
+      - name: Validate SQL migrations
+        run: pnpm db:validate:sql
+
       - name: Run tests
         run: pnpm test:ci
 

--- a/bin/install-syntaqlite.sh
+++ b/bin/install-syntaqlite.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Install the syntaqlite CLI from a pinned GitHub release.
+# This avoids `curl | sh` and validates the asset checksum.
+
+set -euo pipefail
+
+VERSION="v0.3.1"
+DEST_DIR="${HOME}/.local/bin"
+TARGET_OS="$(uname -s)"
+TARGET_ARCH="$(uname -m)"
+
+case "$TARGET_OS" in
+Linux) PLATFORM_OS="linux" ;;
+Darwin) PLATFORM_OS="macos" ;;
+*)
+	echo "Unsupported OS for syntaqlite install: $TARGET_OS" >&2
+	exit 2
+	;;
+esac
+
+case "$TARGET_ARCH" in
+x86_64|amd64) PLATFORM_ARCH="x64" ;;
+aarch64|arm64) PLATFORM_ARCH="arm64" ;;
+*)
+	echo "Unsupported architecture for syntaqlite install: $TARGET_ARCH" >&2
+	exit 2
+	;;
+esac
+
+ASSET_NAME="syntaqlite-${PLATFORM_OS}-${PLATFORM_ARCH}.tar.gz"
+ASSET_URL="https://github.com/LalitMaganti/syntaqlite/releases/download/${VERSION}/${ASSET_NAME}"
+
+case "${PLATFORM_OS}-${PLATFORM_ARCH}" in
+linux-x64) EXPECTED_SHA256="2224df27bf2d9361a4cb890979c313299794ed0e4f2d8a06fbdad329db58100d" ;;
+linux-arm64) EXPECTED_SHA256="e271d984e8f51b7902fb35a93eac0dc5f148ea095cf38fb33a2d8edb11302cab" ;;
+macos-x64) EXPECTED_SHA256="618e82b59154d5ee05fc9fd3c2791145bff4b4a2acea58e4ead5f7bd1b57c23f" ;;
+macos-arm64) EXPECTED_SHA256="d4d6d761efd2de3e1c4caa3cd2c2f7531cb01f908587fd3cfb370d4519306bcc" ;;
+*)
+	echo "No checksum configured for ${PLATFORM_OS}-${PLATFORM_ARCH}" >&2
+	exit 2
+	;;
+esac
+
+TMP_DIR="$(mktemp -d)"
+ARCHIVE_PATH="${TMP_DIR}/${ASSET_NAME}"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+echo "[install-syntaqlite] Downloading ${ASSET_NAME}..."
+curl --fail --location --silent --show-error "$ASSET_URL" -o "$ARCHIVE_PATH"
+
+ACTUAL_SHA256="$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')"
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+	echo "[install-syntaqlite] Checksum mismatch for ${ASSET_NAME}" >&2
+	echo "Expected: $EXPECTED_SHA256" >&2
+	echo "Actual:   $ACTUAL_SHA256" >&2
+	exit 2
+fi
+
+mkdir -p "$DEST_DIR"
+tar -xzf "$ARCHIVE_PATH" -C "$TMP_DIR"
+
+if [ ! -f "${TMP_DIR}/syntaqlite" ]; then
+	echo "[install-syntaqlite] Extracted archive does not contain syntaqlite binary" >&2
+	exit 2
+fi
+
+install -m 0755 "${TMP_DIR}/syntaqlite" "${DEST_DIR}/syntaqlite"
+echo "[install-syntaqlite] Installed syntaqlite to ${DEST_DIR}/syntaqlite"

--- a/bin/quality-gate.sh
+++ b/bin/quality-gate.sh
@@ -30,6 +30,17 @@ if [ $exit_code -ne 0 ]; then
 	exit 2
 fi
 
+echo "[quality-gate] Validating SQL migrations..."
+errors=$(pnpm db:validate:sql 2>&1)
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+	echo "[quality-gate] SQL validation failed" >&2
+	echo "$errors" >&2
+	echo "" >&2
+	echo "Review and fix these SQL errors before proceeding." >&2
+	exit 2
+fi
+
 echo "[quality-gate] Running tests..."
 errors=$(pnpm test:run 2>&1)
 exit_code=$?

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"scripts": {
 		"clean": "pnpm -r --if-present clean",
 		"build": "pnpm -r build",
-		"db:validate:sql": "syntaqlite validate \"apps/www/drizzle/*.sql\"",
+		"db:validate:sql": "pnpm exec syntaqlite validate \"apps/www/drizzle/*.sql\"",
 		"format": "pnpm -r format",
 		"format:check": "pnpm -r format:check",
 		"format:write": "pnpm -r format:write",
@@ -40,5 +40,8 @@
 				"arm64"
 			]
 		}
+	},
+	"devDependencies": {
+		"syntaqlite": "^0.3.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"scripts": {
 		"clean": "pnpm -r --if-present clean",
 		"build": "pnpm -r build",
-		"db:validate:sql": "pnpm exec syntaqlite validate \"apps/www/drizzle/*.sql\"",
+		"db:validate:sql": "SYNTAQLITE_BIN=${SYNTAQLITE_BIN:-syntaqlite}; \"$SYNTAQLITE_BIN\" validate \"apps/www/drizzle/*.sql\"",
 		"format": "pnpm -r format",
 		"format:check": "pnpm -r format:check",
 		"format:write": "pnpm -r format:write",
@@ -40,8 +40,5 @@
 				"arm64"
 			]
 		}
-	},
-	"devDependencies": {
-		"syntaqlite": "^0.3.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	"scripts": {
 		"clean": "pnpm -r --if-present clean",
 		"build": "pnpm -r build",
+		"db:validate:sql": "syntaqlite validate \"apps/www/drizzle/*.sql\"",
 		"format": "pnpm -r format",
 		"format:check": "pnpm -r format:check",
 		"format:write": "pnpm -r format:write",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,7 @@ settings:
 
 importers:
 
-  .:
-    devDependencies:
-      syntaqlite:
-        specifier: ^0.3.0
-        version: 0.3.0
+  .: {}
 
   apps/www:
     dependencies:
@@ -5234,9 +5230,6 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-
-  syntaqlite@0.3.0:
-    resolution: {integrity: sha512-EysvTR4h96B+CC9g7T+/83JfmZopFqjIPVnKKGhrAblrciMZ9lSkJEnRbMbDvjMQJQW/KltWR952elhI7724ZA==}
 
   system-architecture@0.1.0:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
@@ -11321,8 +11314,6 @@ snapshots:
       uuid: 10.0.0
 
   symbol-tree@3.2.4: {}
-
-  syntaqlite@0.3.0: {}
 
   system-architecture@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      syntaqlite:
+        specifier: ^0.3.0
+        version: 0.3.0
 
   apps/www:
     dependencies:
@@ -5230,6 +5234,9 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  syntaqlite@0.3.0:
+    resolution: {integrity: sha512-EysvTR4h96B+CC9g7T+/83JfmZopFqjIPVnKKGhrAblrciMZ9lSkJEnRbMbDvjMQJQW/KltWR952elhI7724ZA==}
 
   system-architecture@0.1.0:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
@@ -11314,6 +11321,8 @@ snapshots:
       uuid: 10.0.0
 
   symbol-tree@3.2.4: {}
+
+  syntaqlite@0.3.0: {}
 
   system-architecture@0.1.0: {}
 

--- a/syntaqlite.toml
+++ b/syntaqlite.toml
@@ -1,0 +1,2 @@
+[schemas]
+"apps/www/drizzle/*.sql" = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a root `db:validate:sql` script that runs the `syntaqlite` CLI binary (`SYNTAQLITE_BIN` override supported)
- add `bin/install-syntaqlite.sh` to install the pinned `v0.3.1` release binary with SHA-256 verification (no `curl | sh`)
- add `syntaqlite.toml` with repo-local schema routing for `apps/www/drizzle/*.sql`
- run SQL validation in CI and install syntaqlite first in the test job
- run SQL validation as part of `bin/quality-gate.sh` with clear failure messaging

## Testing
- `bash bin/install-syntaqlite.sh`
- `pnpm db:validate:sql`
- `bash bin/quality-gate.sh`
- `bash bin/code-quality.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cbb75f6-6066-4673-b842-fc916ed993ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cbb75f6-6066-4673-b842-fc916ed993ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

