### PR TITLE
Implement notifications create and list flow with TDD

### DIFF
--- a/apps/www/drizzle/0007_add_notification_subscriptions.sql
+++ b/apps/www/drizzle/0007_add_notification_subscriptions.sql
@@ -1,0 +1,29 @@
+CREATE TABLE `notification_subscriptions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` text NOT NULL REFERENCES `user`(`id`) ON DELETE CASCADE,
+	`label` text,
+	`center_h3` text NOT NULL,
+	`resolution` integer NOT NULL,
+	`ring_size` integer NOT NULL,
+	`place_name` text NOT NULL,
+	`produce_types` text,
+	`throttle_period` text NOT NULL CHECK (`throttle_period` IN ('immediately', 'weekly')),
+	`last_notified_at` integer,
+	`enabled` integer NOT NULL DEFAULT 1,
+	`created_at` integer NOT NULL DEFAULT (unixepoch()),
+	`updated_at` integer NOT NULL DEFAULT (unixepoch()),
+	`deleted_at` integer
+);
+--> statement-breakpoint
+CREATE INDEX `notification_subscriptions_user_id_idx` ON `notification_subscriptions`(`user_id`);
+--> statement-breakpoint
+CREATE INDEX `notification_subscriptions_throttle_notified_idx` ON `notification_subscriptions`(`throttle_period`, `last_notified_at`)
+WHERE `deleted_at` IS NULL AND `enabled` = 1;
+--> statement-breakpoint
+CREATE TRIGGER `enforce_subscription_limit`
+BEFORE INSERT ON `notification_subscriptions`
+BEGIN
+  SELECT RAISE(ABORT, 'subscription_limit_exceeded')
+  WHERE (SELECT COUNT(*) FROM `notification_subscriptions`
+         WHERE `user_id` = NEW.`user_id` AND `deleted_at` IS NULL) >= 10;
+END;

--- a/apps/www/drizzle/meta/_journal.json
+++ b/apps/www/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
 			"when": 1775007518000,
 			"tag": "0006_add_listing_photos",
 			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "6",
+			"when": 1775865600000,
+			"tag": "0007_add_notification_subscriptions",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/www/src/api/notifications.ts
+++ b/apps/www/src/api/notifications.ts
@@ -46,8 +46,11 @@ export const getMySubscriptions = createServerFn({ method: 'GET' })
 		const headers = getRequestHeaders()
 		const { auth } = await import('@/lib/auth.server')
 		const session = await auth.api.getSession({ headers })
-		if (!session?.user) return []
-		const { getUserNotificationSubscriptions } = await import('@/data/queries.server')
+		if (!session?.user) {
+			return []
+		}
+		const { getUserNotificationSubscriptions } =
+			await import('@/data/queries.server')
 		return getUserNotificationSubscriptions(session.user.id)
 	})
 
@@ -62,7 +65,8 @@ export const getMySubscription = createServerFn({ method: 'GET' })
 		if (!session?.user) {
 			throw new UserError('UNAUTHORIZED', 'Authentication required.')
 		}
-		const { getUserNotificationSubscription } = await import('@/data/queries.server')
+		const { getUserNotificationSubscription } =
+			await import('@/data/queries.server')
 		const sub = await getUserNotificationSubscription(session.user.id, id)
 		if (!sub) {
 			throw new UserError('NOT_FOUND', 'Subscription not found.')
@@ -83,7 +87,8 @@ export const createMySubscription = createServerFn({ method: 'POST' })
 		if (!session?.user) {
 			throw new UserError('UNAUTHORIZED', 'Authentication required.')
 		}
-		const { createNotificationSubscription } = await import('@/data/queries.server')
+		const { createNotificationSubscription } =
+			await import('@/data/queries.server')
 		return createNotificationSubscription({
 			userId: session.user.id,
 			label: data.label ?? null,
@@ -110,11 +115,22 @@ export const updateMySubscription = createServerFn({ method: 'POST' })
 		if (!session?.user) {
 			throw new UserError('UNAUTHORIZED', 'Authentication required.')
 		}
-		const { updateNotificationSubscription } = await import('@/data/queries.server')
+		const { updateNotificationSubscription } =
+			await import('@/data/queries.server')
 
-		const updates: Partial<Pick<NotificationSubscription,
-			'label' | 'centerH3' | 'resolution' | 'ringSize' | 'placeName' | 'produceTypes' | 'throttlePeriod' | 'enabled'
-		>> = {}
+		const updates: Partial<
+			Pick<
+				NotificationSubscription,
+				| 'label'
+				| 'centerH3'
+				| 'resolution'
+				| 'ringSize'
+				| 'placeName'
+				| 'produceTypes'
+				| 'throttlePeriod'
+				| 'enabled'
+			>
+		> = {}
 		if (input.data.label !== undefined) updates.label = input.data.label ?? null
 		if (input.data.centerH3 !== undefined) updates.centerH3 = input.data.centerH3
 		if (input.data.resolution !== undefined)
@@ -154,6 +170,7 @@ export const deleteMySubscription = createServerFn({ method: 'POST' })
 		if (!session?.user) {
 			throw new UserError('UNAUTHORIZED', 'Authentication required.')
 		}
-		const { deleteNotificationSubscription } = await import('@/data/queries.server')
+		const { deleteNotificationSubscription } =
+			await import('@/data/queries.server')
 		await deleteNotificationSubscription(session.user.id, id)
 	})

--- a/apps/www/src/api/notifications.ts
+++ b/apps/www/src/api/notifications.ts
@@ -1,0 +1,159 @@
+import { createServerFn } from '@tanstack/solid-start'
+import { getRequestHeaders } from '@tanstack/solid-start/server'
+import { z } from 'zod'
+import { errorMiddleware, UserError } from '@/lib/server-error-middleware'
+import type { NotificationSubscription } from '@/data/schema'
+import {
+	createSubscriptionSchema,
+	updateSubscriptionSchema,
+	type CreateSubscriptionData,
+	type UpdateSubscriptionData,
+} from '@/lib/validation'
+
+const subscriptionIdValidator = z.coerce.number().int().positive()
+
+/** Geocodes a plain string address query for the subscription form. */
+export const geocodeForSubscription = createServerFn({ method: 'GET' })
+	.middleware([errorMiddleware])
+	.inputValidator((query: string) => z.string().min(1).parse(query))
+	.handler(
+		async ({
+			data: query,
+		}): Promise<{ lat: number; lng: number; displayName: string } | null> => {
+			const { geocodeAddress, GeocodingError } = await import('@/lib/geocoding')
+			const { Sentry } = await import('@/lib/sentry')
+			try {
+				const result = await geocodeAddress(query)
+				if (!result) return null
+				return { lat: result.lat, lng: result.lng, displayName: result.displayName }
+			} catch (error) {
+				if (error instanceof GeocodingError) {
+					Sentry.captureException(error, { extra: { query } })
+					throw new UserError(
+						'GEOCODING_ERROR',
+						'Location search is temporarily unavailable — try again in a moment.'
+					)
+				}
+				throw error
+			}
+		}
+	)
+
+/** Returns all non-deleted subscriptions for the authenticated user. */
+export const getMySubscriptions = createServerFn({ method: 'GET' })
+	.middleware([errorMiddleware])
+	.handler(async (): Promise<NotificationSubscription[]> => {
+		const headers = getRequestHeaders()
+		const { auth } = await import('@/lib/auth.server')
+		const session = await auth.api.getSession({ headers })
+		if (!session?.user) return []
+		const { getUserNotificationSubscriptions } = await import('@/data/queries.server')
+		return getUserNotificationSubscriptions(session.user.id)
+	})
+
+/** Returns a single subscription owned by the authenticated user. Throws if not found. */
+export const getMySubscription = createServerFn({ method: 'GET' })
+	.middleware([errorMiddleware])
+	.inputValidator((id: number) => subscriptionIdValidator.parse(id))
+	.handler(async ({ data: id }): Promise<NotificationSubscription> => {
+		const headers = getRequestHeaders()
+		const { auth } = await import('@/lib/auth.server')
+		const session = await auth.api.getSession({ headers })
+		if (!session?.user) {
+			throw new UserError('UNAUTHORIZED', 'Authentication required.')
+		}
+		const { getUserNotificationSubscription } = await import('@/data/queries.server')
+		const sub = await getUserNotificationSubscription(session.user.id, id)
+		if (!sub) {
+			throw new UserError('NOT_FOUND', 'Subscription not found.')
+		}
+		return sub
+	})
+
+/** Creates a subscription for the authenticated user. */
+export const createMySubscription = createServerFn({ method: 'POST' })
+	.middleware([errorMiddleware])
+	.inputValidator((data: CreateSubscriptionData) =>
+		createSubscriptionSchema.parse(data)
+	)
+	.handler(async ({ data }): Promise<NotificationSubscription> => {
+		const headers = getRequestHeaders()
+		const { auth } = await import('@/lib/auth.server')
+		const session = await auth.api.getSession({ headers })
+		if (!session?.user) {
+			throw new UserError('UNAUTHORIZED', 'Authentication required.')
+		}
+		const { createNotificationSubscription } = await import('@/data/queries.server')
+		return createNotificationSubscription({
+			userId: session.user.id,
+			label: data.label ?? null,
+			centerH3: data.centerH3,
+			resolution: data.resolution,
+			ringSize: data.ringSize,
+			placeName: data.placeName,
+			produceTypes: data.produceTypes ? JSON.stringify(data.produceTypes) : null,
+			throttlePeriod: data.throttlePeriod,
+		})
+	})
+
+/** Updates a subscription owned by the authenticated user. */
+export const updateMySubscription = createServerFn({ method: 'POST' })
+	.middleware([errorMiddleware])
+	.inputValidator((input: { id: number; data: UpdateSubscriptionData }) => ({
+		id: subscriptionIdValidator.parse(input.id),
+		data: updateSubscriptionSchema.parse(input.data),
+	}))
+	.handler(async ({ data: input }): Promise<NotificationSubscription> => {
+		const headers = getRequestHeaders()
+		const { auth } = await import('@/lib/auth.server')
+		const session = await auth.api.getSession({ headers })
+		if (!session?.user) {
+			throw new UserError('UNAUTHORIZED', 'Authentication required.')
+		}
+		const { updateNotificationSubscription } = await import('@/data/queries.server')
+
+		const updates: Partial<Pick<NotificationSubscription,
+			'label' | 'centerH3' | 'resolution' | 'ringSize' | 'placeName' | 'produceTypes' | 'throttlePeriod' | 'enabled'
+		>> = {}
+		if (input.data.label !== undefined) updates.label = input.data.label ?? null
+		if (input.data.centerH3 !== undefined) updates.centerH3 = input.data.centerH3
+		if (input.data.resolution !== undefined)
+			updates.resolution = input.data.resolution
+		if (input.data.ringSize !== undefined) updates.ringSize = input.data.ringSize
+		if (input.data.placeName !== undefined)
+			updates.placeName = input.data.placeName
+		if (input.data.produceTypes !== undefined) {
+			updates.produceTypes = input.data.produceTypes
+				? JSON.stringify(input.data.produceTypes)
+				: null
+		}
+		if (input.data.throttlePeriod !== undefined) {
+			updates.throttlePeriod = input.data.throttlePeriod
+		}
+		if (input.data.enabled !== undefined) updates.enabled = input.data.enabled
+
+		const updated = await updateNotificationSubscription(
+			session.user.id,
+			input.id,
+			updates
+		)
+		if (!updated) {
+			throw new UserError('NOT_FOUND', 'Subscription not found.')
+		}
+		return updated
+	})
+
+/** Soft-deletes a subscription owned by the authenticated user. */
+export const deleteMySubscription = createServerFn({ method: 'POST' })
+	.middleware([errorMiddleware])
+	.inputValidator((id: number) => subscriptionIdValidator.parse(id))
+	.handler(async ({ data: id }): Promise<void> => {
+		const headers = getRequestHeaders()
+		const { auth } = await import('@/lib/auth.server')
+		const session = await auth.api.getSession({ headers })
+		if (!session?.user) {
+			throw new UserError('UNAUTHORIZED', 'Authentication required.')
+		}
+		const { deleteNotificationSubscription } = await import('@/data/queries.server')
+		await deleteNotificationSubscription(session.user.id, id)
+	})

--- a/apps/www/src/components/PageHeader.tsx
+++ b/apps/www/src/components/PageHeader.tsx
@@ -126,6 +126,7 @@ export default function PageHeader(props: PageHeaderProps) {
 							<DropdownMenu.Content class="page-header__menu-content">
 								<Show when={user()}>
 									<DropdownMenuLink to="/listings/mine">My Garden</DropdownMenuLink>
+									<DropdownMenuLink to="/notifications">Notifications</DropdownMenuLink>
 									<DropdownMenuLink to="/profile">Profile</DropdownMenuLink>
 									<DropdownMenu.Separator class="page-header__menu-separator" />
 									<DropdownMenu.Item

--- a/apps/www/src/components/SubscriptionForm.css
+++ b/apps/www/src/components/SubscriptionForm.css
@@ -1,0 +1,50 @@
+@layer components {
+	.subscription-form {
+		display: grid;
+		gap: 20px;
+	}
+
+	.subscription-form__search {
+		display: grid;
+		gap: 12px;
+	}
+
+	.subscription-form__create {
+		display: grid;
+		gap: 16px;
+	}
+
+	.subscription-form__search-button,
+	.subscription-form__submit-button {
+		justify-self: start;
+		background: var(--color-primary);
+		color: var(--color-background);
+		padding: 10px 18px;
+		border-radius: 8px;
+		border: none;
+		font-weight: 600;
+		cursor: pointer;
+	}
+
+	.subscription-form__search-button:disabled,
+	.subscription-form__submit-button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.subscription-form__confirmation {
+		margin: 0;
+		color: var(--color-foreground);
+		font-weight: 500;
+	}
+
+	.subscription-form__summary {
+		margin: 0;
+		color: var(--color-quiet);
+		font-size: 14px;
+	}
+
+	.subscription-form__message {
+		margin: 0;
+	}
+}

--- a/apps/www/src/components/SubscriptionForm.tsx
+++ b/apps/www/src/components/SubscriptionForm.tsx
@@ -1,0 +1,180 @@
+import { createMemo, createSignal, For, Show } from 'solid-js'
+import { useNavigate } from '@tanstack/solid-router'
+import { Input } from '@/components/FormField'
+import { createErrorSignal, ErrorMessage } from '@/components/ErrorMessage'
+import {
+	createMySubscription,
+	geocodeForSubscription,
+} from '@/api/notifications'
+import {
+	buildCreateSubscriptionData,
+	buildLocationConfirmationText,
+	type GeocodedSubscriptionLocation,
+} from '@/lib/subscription-draft'
+import { produceTypes } from '@/lib/produce-types'
+import { UserError } from '@/lib/user-error'
+import '@/components/ListingForm.css'
+import '@/components/SubscriptionForm.css'
+
+type FormState = 'idle' | 'searching' | 'submitting'
+
+export default function SubscriptionForm() {
+	const navigate = useNavigate()
+	const [formState, setFormState] = createSignal<FormState>('idle')
+	const [address, setAddress] = createSignal('')
+	const [label, setLabel] = createSignal('')
+	const [selectedType, setSelectedType] = createSignal('')
+	const [location, setLocation] =
+		createSignal<GeocodedSubscriptionLocation | null>(null)
+	const [searchError, setSearchError] = createErrorSignal()
+	const [submitError, setSubmitError] = createErrorSignal()
+
+	const isSearching = () => formState() === 'searching'
+	const isSubmitting = () => formState() === 'submitting'
+	const canSubmit = () =>
+		Boolean(location()) && !isSubmitting() && !isSearching()
+	const confirmationText = createMemo(() => {
+		const found = location()
+		return found ? buildLocationConfirmationText(found.displayName, 1) : ''
+	})
+
+	async function handleSearch(event: SubmitEvent) {
+		event.preventDefault()
+		if (isSearching() || isSubmitting()) return
+
+		setSearchError(null)
+		setSubmitError(null)
+		setLocation(null)
+		setFormState('searching')
+
+		try {
+			const query = address().trim()
+			const found = await geocodeForSubscription({ data: query })
+			if (!found) {
+				setSearchError('Could not find that address — try a nearby city.')
+				return
+			}
+			setLocation({
+				lat: found.lat,
+				lng: found.lng,
+				displayName: found.displayName,
+			})
+		} catch (error) {
+			if (error instanceof UserError && error.code === 'GEOCODING_ERROR') {
+				setSearchError(error.message)
+			} else {
+				setSearchError(
+					'Location search is temporarily unavailable — try again in a moment.'
+				)
+			}
+		} finally {
+			if (!isSubmitting()) {
+				setFormState('idle')
+			}
+		}
+	}
+
+	async function handleCreateSubscription(event: SubmitEvent) {
+		event.preventDefault()
+		if (!canSubmit()) return
+		const found = location()
+		if (!found) return
+
+		setSubmitError(null)
+		setFormState('submitting')
+
+		try {
+			const payload = buildCreateSubscriptionData({
+				label: label(),
+				location: found,
+				produceTypes: selectedType() ? [selectedType()] : null,
+				ringSize: 1,
+				throttlePeriod: 'immediately',
+			})
+			await createMySubscription({ data: payload })
+			await navigate({ to: '/notifications' })
+		} catch (error) {
+			setSubmitError(error)
+			setFormState('idle')
+		}
+	}
+
+	return (
+		<div class="subscription-form">
+			<form class="subscription-form__search" onSubmit={handleSearch}>
+				<Input
+					label="Address"
+					name="address"
+					value={address()}
+					onChange={(value) => {
+						setAddress(value)
+						setLocation(null)
+						setSearchError(null)
+					}}
+					placeholder="City, state, or ZIP"
+					required
+					disabled={isSearching() || isSubmitting()}
+				/>
+				<button
+					type="submit"
+					class="subscription-form__search-button"
+					disabled={isSearching() || isSubmitting() || !address().trim()}
+				>
+					{isSearching() ? 'Searching…' : 'Search'}
+				</button>
+			</form>
+
+			<ErrorMessage class="subscription-form__message" error={searchError()} />
+
+			<Show when={location()}>
+				<p class="subscription-form__confirmation">{confirmationText()}</p>
+			</Show>
+
+			<form class="subscription-form__create" onSubmit={handleCreateSubscription}>
+				<Input
+					label="Label (optional)"
+					name="label"
+					value={label()}
+					onChange={setLabel}
+					placeholder="Backyard produce alerts"
+					disabled={isSubmitting()}
+				/>
+
+				<div class="form-field">
+					<label class="form-field__label" for="subscription-produce-type">
+						Produce type (optional)
+					</label>
+					<select
+						id="subscription-produce-type"
+						class="form-field__control"
+						name="produceType"
+						value={selectedType()}
+						onInput={(event) => setSelectedType(event.currentTarget.value)}
+						disabled={isSubmitting()}
+					>
+						<option value="">All produce types</option>
+						<For each={produceTypes}>
+							{(type) => (
+								<option value={type.slug}>{type.nameSingularTitleCase}</option>
+							)}
+						</For>
+					</select>
+				</div>
+
+				<p class="subscription-form__summary">
+					Delivery: Immediately (within ~1 hour)
+				</p>
+
+				<ErrorMessage class="subscription-form__message" error={submitError()} />
+
+				<button
+					type="submit"
+					class="subscription-form__submit-button"
+					disabled={!canSubmit()}
+				>
+					{isSubmitting() ? 'Creating…' : 'Create subscription'}
+				</button>
+			</form>
+		</div>
+	)
+}

--- a/apps/www/src/data/queries.server.ts
+++ b/apps/www/src/data/queries.server.ts
@@ -4,14 +4,16 @@ import {
 	inquiries,
 	listingPhotos,
 	user,
+	notificationSubscriptions,
 	type Listing,
 	type NewListing,
 	type Inquiry,
 	type NewInquiry,
 	type AddressFields,
 	type ListingPhoto,
+	type NotificationSubscription,
 } from './schema'
-import { eq, desc, and, ne, isNull, gt, inArray, sql } from 'drizzle-orm'
+import { eq, desc, and, ne, isNull, gt, lt, or, inArray, sql } from 'drizzle-orm'
 import { ListingStatus, type ListingStatusValue } from '@/lib/validation'
 import { Sentry } from '@/lib/sentry'
 import { storage } from '@/lib/storage.server'
@@ -527,6 +529,271 @@ export async function markListingUnavailable(id: number): Promise<boolean> {
 				.where(and(eq(listings.id, id), isNull(listings.deletedAt)))
 				.returning({ id: listings.id })
 			return result.length > 0
+		}
+	)
+}
+
+/** Returns all available listings with full fields (for notification matching). */
+export async function getAvailableListingsForNotifications(
+	limit: number = 500
+): Promise<Listing[]> {
+	return Sentry.startSpan(
+		{
+			name: 'getAvailableListingsForNotifications',
+			op: 'db.query',
+			attributes: { limit },
+		},
+		async (span) => {
+			const rows = await db
+				.select()
+				.from(listings)
+				.where(
+					and(eq(listings.status, ListingStatus.available), isNull(listings.deletedAt))
+				)
+				.orderBy(desc(listings.createdAt))
+				.limit(limit)
+			if (rows.length === limit) {
+				const { logger } = await import('@/lib/logger.server')
+				logger.warn({ limit }, 'getAvailableListingsForNotifications hit limit')
+			}
+			span.setAttribute('listing_count', rows.length)
+			return rows
+		}
+	)
+}
+
+// ============================================================================
+// Notification Subscription Functions
+// ============================================================================
+
+/** Creates a subscription. Throws UserError('subscription_limit_exceeded') if at limit. */
+export async function createNotificationSubscription(
+	data: Omit<
+		NotificationSubscription,
+		'id' | 'lastNotifiedAt' | 'enabled' | 'createdAt' | 'updatedAt' | 'deletedAt'
+	>
+): Promise<NotificationSubscription> {
+	return Sentry.startSpan(
+		{ name: 'createNotificationSubscription', op: 'db.query' },
+		async () => {
+			const { UserError } = await import('@/lib/user-error')
+
+			// Application-layer limit check (works with db:push that lacks the trigger)
+			const count = await db
+				.select({ n: sql<number>`count(*)` })
+				.from(notificationSubscriptions)
+				.where(
+					and(
+						eq(notificationSubscriptions.userId, data.userId),
+						isNull(notificationSubscriptions.deletedAt)
+					)
+				)
+			if (Number(count[0].n) >= 10) {
+				throw new UserError(
+					'subscription_limit_exceeded',
+					'You have reached the limit of 10 subscriptions.'
+				)
+			}
+
+			try {
+				const result = await db
+					.insert(notificationSubscriptions)
+					.values({
+						...data,
+						createdAt: new Date(),
+						updatedAt: new Date(),
+					})
+					.returning()
+				return result[0]
+			} catch (error) {
+				if (
+					error instanceof Error &&
+					error.message.includes('subscription_limit_exceeded')
+				) {
+					throw new UserError(
+						'subscription_limit_exceeded',
+						'You have reached the limit of 10 subscriptions.'
+					)
+				}
+				throw error
+			}
+		}
+	)
+}
+
+/** Returns all non-deleted subscriptions for a user, newest first. */
+export async function getUserNotificationSubscriptions(
+	userId: string
+): Promise<NotificationSubscription[]> {
+	return Sentry.startSpan(
+		{ name: 'getUserNotificationSubscriptions', op: 'db.query' },
+		async () => {
+			return db
+				.select()
+				.from(notificationSubscriptions)
+				.where(
+					and(
+						eq(notificationSubscriptions.userId, userId),
+						isNull(notificationSubscriptions.deletedAt)
+					)
+				)
+				.orderBy(desc(notificationSubscriptions.createdAt))
+		}
+	)
+}
+
+/** Returns a single non-deleted subscription owned by the user, or undefined. */
+export async function getUserNotificationSubscription(
+	userId: string,
+	id: number
+): Promise<NotificationSubscription | undefined> {
+	return Sentry.startSpan(
+		{ name: 'getUserNotificationSubscription', op: 'db.query', attributes: { id } },
+		async () => {
+			const result = await db
+				.select()
+				.from(notificationSubscriptions)
+				.where(
+					and(
+						eq(notificationSubscriptions.id, id),
+						eq(notificationSubscriptions.userId, userId),
+						isNull(notificationSubscriptions.deletedAt)
+					)
+				)
+				.limit(1)
+			return result[0]
+		}
+	)
+}
+
+/** Updates a subscription owned by the user. Returns updated row or undefined if not found. */
+export async function updateNotificationSubscription(
+	userId: string,
+	id: number,
+	updates: Partial<
+		Pick<
+			NotificationSubscription,
+			| 'label'
+			| 'centerH3'
+			| 'resolution'
+			| 'ringSize'
+			| 'placeName'
+			| 'produceTypes'
+			| 'throttlePeriod'
+			| 'enabled'
+		>
+	>
+): Promise<NotificationSubscription | undefined> {
+	return Sentry.startSpan(
+		{ name: 'updateNotificationSubscription', op: 'db.query', attributes: { id } },
+		async () => {
+			const result = await db
+				.update(notificationSubscriptions)
+				.set({ ...updates, updatedAt: new Date() })
+				.where(
+					and(
+						eq(notificationSubscriptions.id, id),
+						eq(notificationSubscriptions.userId, userId),
+						isNull(notificationSubscriptions.deletedAt)
+					)
+				)
+				.returning()
+			return result[0]
+		}
+	)
+}
+
+/** Soft-deletes a subscription owned by the user. No-op if already deleted. */
+export async function deleteNotificationSubscription(
+	userId: string,
+	id: number
+): Promise<void> {
+	return Sentry.startSpan(
+		{ name: 'deleteNotificationSubscription', op: 'db.query', attributes: { id } },
+		async () => {
+			await db
+				.update(notificationSubscriptions)
+				.set({ deletedAt: new Date() })
+				.where(
+					and(
+						eq(notificationSubscriptions.id, id),
+						eq(notificationSubscriptions.userId, userId),
+						isNull(notificationSubscriptions.deletedAt)
+					)
+				)
+		}
+	)
+}
+
+/** Soft-deletes a subscription by ID (no ownership check — for HMAC-authenticated unsubscribe). */
+export async function deleteNotificationSubscriptionById(id: number): Promise<void> {
+	return Sentry.startSpan(
+		{
+			name: 'deleteNotificationSubscriptionById',
+			op: 'db.query',
+			attributes: { id },
+		},
+		async () => {
+			await db
+				.update(notificationSubscriptions)
+				.set({ deletedAt: new Date() })
+				.where(
+					and(
+						eq(notificationSubscriptions.id, id),
+						isNull(notificationSubscriptions.deletedAt)
+					)
+				)
+		}
+	)
+}
+
+/**
+ * Returns active subscriptions due for notification for the given throttle period.
+ * A subscription is due when it has never been notified or was last notified
+ * before the cutoff.
+ */
+export async function getNotificationSubscriptionsDue(
+	throttlePeriod: 'immediately' | 'weekly',
+	cutoff: Date
+): Promise<NotificationSubscription[]> {
+	const cutoffSecs = Math.floor(cutoff.getTime() / 1000)
+	return Sentry.startSpan(
+		{
+			name: 'getNotificationSubscriptionsDue',
+			op: 'db.query',
+			attributes: { throttlePeriod },
+		},
+		async () => {
+			return db
+				.select()
+				.from(notificationSubscriptions)
+				.where(
+					and(
+						eq(notificationSubscriptions.throttlePeriod, throttlePeriod),
+						eq(notificationSubscriptions.enabled, true),
+						isNull(notificationSubscriptions.deletedAt),
+						or(
+							isNull(notificationSubscriptions.lastNotifiedAt),
+							lt(
+								sql`cast(strftime('%s', ${notificationSubscriptions.lastNotifiedAt}) as integer)`,
+								cutoffSecs
+							)
+						)
+					)
+				)
+		}
+	)
+}
+
+/** Updates last_notified_at to now for a subscription. */
+export async function markSubscriptionNotified(id: number): Promise<void> {
+	return Sentry.startSpan(
+		{ name: 'markSubscriptionNotified', op: 'db.query', attributes: { id } },
+		async () => {
+			await db
+				.update(notificationSubscriptions)
+				.set({ lastNotifiedAt: new Date() })
+				.where(eq(notificationSubscriptions.id, id))
 		}
 	)
 }

--- a/apps/www/src/data/queries.server.ts
+++ b/apps/www/src/data/queries.server.ts
@@ -13,7 +13,18 @@ import {
 	type ListingPhoto,
 	type NotificationSubscription,
 } from './schema'
-import { eq, desc, and, ne, isNull, gt, lt, or, inArray, sql } from 'drizzle-orm'
+import {
+	eq,
+	desc,
+	and,
+	ne,
+	isNull,
+	gt,
+	lt,
+	or,
+	inArray,
+	sql,
+} from 'drizzle-orm'
 import { ListingStatus, type ListingStatusValue } from '@/lib/validation'
 import { Sentry } from '@/lib/sentry'
 import { storage } from '@/lib/storage.server'
@@ -548,7 +559,10 @@ export async function getAvailableListingsForNotifications(
 				.select()
 				.from(listings)
 				.where(
-					and(eq(listings.status, ListingStatus.available), isNull(listings.deletedAt))
+					and(
+						eq(listings.status, ListingStatus.available),
+						isNull(listings.deletedAt)
+					)
 				)
 				.orderBy(desc(listings.createdAt))
 				.limit(limit)
@@ -648,7 +662,11 @@ export async function getUserNotificationSubscription(
 	id: number
 ): Promise<NotificationSubscription | undefined> {
 	return Sentry.startSpan(
-		{ name: 'getUserNotificationSubscription', op: 'db.query', attributes: { id } },
+		{
+			name: 'getUserNotificationSubscription',
+			op: 'db.query',
+			attributes: { id },
+		},
 		async () => {
 			const result = await db
 				.select()
@@ -685,7 +703,11 @@ export async function updateNotificationSubscription(
 	>
 ): Promise<NotificationSubscription | undefined> {
 	return Sentry.startSpan(
-		{ name: 'updateNotificationSubscription', op: 'db.query', attributes: { id } },
+		{
+			name: 'updateNotificationSubscription',
+			op: 'db.query',
+			attributes: { id },
+		},
 		async () => {
 			const result = await db
 				.update(notificationSubscriptions)
@@ -709,7 +731,11 @@ export async function deleteNotificationSubscription(
 	id: number
 ): Promise<void> {
 	return Sentry.startSpan(
-		{ name: 'deleteNotificationSubscription', op: 'db.query', attributes: { id } },
+		{
+			name: 'deleteNotificationSubscription',
+			op: 'db.query',
+			attributes: { id },
+		},
 		async () => {
 			await db
 				.update(notificationSubscriptions)
@@ -726,7 +752,9 @@ export async function deleteNotificationSubscription(
 }
 
 /** Soft-deletes a subscription by ID (no ownership check — for HMAC-authenticated unsubscribe). */
-export async function deleteNotificationSubscriptionById(id: number): Promise<void> {
+export async function deleteNotificationSubscriptionById(
+	id: number
+): Promise<void> {
 	return Sentry.startSpan(
 		{
 			name: 'deleteNotificationSubscriptionById',

--- a/apps/www/src/data/schema.ts
+++ b/apps/www/src/data/schema.ts
@@ -202,3 +202,46 @@ export const listingPhotos = sqliteTable(
 
 export type ListingPhoto = typeof listingPhotos.$inferSelect
 export type NewListingPhoto = typeof listingPhotos.$inferInsert
+
+// ============================================================================
+// Notification Subscriptions Table
+// ============================================================================
+
+export const notificationSubscriptions = sqliteTable(
+	'notification_subscriptions',
+	{
+		id: integer('id').primaryKey({ autoIncrement: true }),
+		userId: text('user_id')
+			.notNull()
+			.references(() => user.id, { onDelete: 'cascade' }),
+		label: text('label'),
+		centerH3: text('center_h3').notNull(),
+		resolution: integer('resolution').notNull(),
+		ringSize: integer('ring_size').notNull(),
+		placeName: text('place_name').notNull(),
+		/** JSON array of produce-type slugs; NULL means all types. */
+		produceTypes: text('produce_types'),
+		throttlePeriod: text('throttle_period').notNull(),
+		lastNotifiedAt: integer('last_notified_at', { mode: 'timestamp' }),
+		enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+		createdAt: integer('created_at', { mode: 'timestamp' })
+			.notNull()
+			.default(sql`(unixepoch())`),
+		updatedAt: integer('updated_at', { mode: 'timestamp' })
+			.notNull()
+			.default(sql`(unixepoch())`),
+		deletedAt: integer('deleted_at', { mode: 'timestamp' }),
+	},
+	(table) => [
+		index('notification_subscriptions_user_id_idx').on(table.userId),
+		index('notification_subscriptions_throttle_notified_idx').on(
+			table.throttlePeriod,
+			table.lastNotifiedAt
+		),
+	]
+)
+
+export type NotificationSubscription =
+	typeof notificationSubscriptions.$inferSelect
+export type NewNotificationSubscription =
+	typeof notificationSubscriptions.$inferInsert

--- a/apps/www/src/lib/email-templates.server.ts
+++ b/apps/www/src/lib/email-templates.server.ts
@@ -81,6 +81,127 @@ export function buildInquiryEmailHtml(data: InquiryEmailData): string {
 </html>`
 }
 
+interface NotificationEmailData {
+	to: string
+	subscription: {
+		id: number
+		placeName: string
+		throttlePeriod: 'immediately' | 'weekly'
+	}
+	listings: Array<{
+		id: number
+		name: string
+		type: string
+		city: string
+		state: string
+	}>
+	unsubscribeUrl: string
+	baseUrl: string
+}
+
+/** Subject line for a subscription notification email. */
+export function buildNotificationEmailSubject(
+	data: NotificationEmailData
+): string {
+	const n = data.listings.length
+	const noun = n === 1 ? 'produce listing' : 'produce listings'
+	if (data.subscription.throttlePeriod === 'weekly') {
+		return `${n} ${noun} near you this week`
+	}
+	return `${n} new ${noun} near you`
+}
+
+/** HTML body for a subscription notification email. */
+export function buildNotificationEmailHtml(
+	data: NotificationEmailData
+): string {
+	const listingItems = data.listings
+		.map(
+			(listing) => `
+  <li style="margin: 0 0 12px 0;">
+    <a href="${data.baseUrl}/listings/${listing.id}" style="color: #4a7c23; font-weight: bold;">
+      ${escapeHtml(listing.name)}
+    </a>
+    <span style="color: #666; margin-left: 4px;">— ${escapeHtml(listing.city)}, ${escapeHtml(listing.state)}</span>
+  </li>`
+		)
+		.join('')
+
+	return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h1 style="color: #2d5016; margin-bottom: 16px;">${escapeHtml(buildNotificationEmailSubject(data))}</h1>
+
+  <p>New produce is available near ${escapeHtml(data.subscription.placeName)}:</p>
+
+  <ul style="padding-left: 20px;">
+    ${listingItems}
+  </ul>
+
+  <p>
+    <a href="${data.baseUrl}/listings" style="color: #4a7c23;">Browse all listings</a>
+  </p>
+
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 32px 0;">
+
+  <p style="color: #666; font-size: 14px;">
+    <a href="${data.baseUrl}/notifications" style="color: #4a7c23;">Manage your notification subscriptions</a>
+    &nbsp;·&nbsp;
+    <a href="${escapeHtml(data.unsubscribeUrl)}" style="color: #4a7c23;">Unsubscribe from this subscription</a>
+  </p>
+</body>
+</html>`
+}
+
+/** Sends a notification email for a subscription. Throws on failure. */
+export async function sendNotificationEmail(
+	input: NotificationEmailData
+): Promise<void> {
+	if (serverEnv.EMAIL_PROVIDER === 'silent') return
+
+	if (serverEnv.EMAIL_PROVIDER === 'console') {
+		logger.info(
+			{
+				to: input.to,
+				subscriptionId: input.subscription.id,
+				listingCount: input.listings.length,
+				unsubscribeUrl: input.unsubscribeUrl,
+			},
+			'Notification email (EMAIL_PROVIDER=console)'
+		)
+		return
+	}
+
+	if (serverEnv.EMAIL_PROVIDER === 'resend') {
+		const { Resend } = await import('resend')
+		const resend = new Resend(serverEnv.RESEND_API_KEY)
+
+		const { error } = await resend.emails.send({
+			from: serverEnv.EMAIL_FROM,
+			to: input.to,
+			subject: buildNotificationEmailSubject(input),
+			html: buildNotificationEmailHtml(input),
+			headers: {
+				'List-Unsubscribe': `<${input.unsubscribeUrl}>`,
+				'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+			},
+		})
+
+		if (error) {
+			throw new Error(`Notification email send failed: ${error.name} — ${error.message}`)
+		}
+		return
+	}
+
+	throw new Error(
+		`Unhandled EMAIL_PROVIDER: ${(serverEnv as { EMAIL_PROVIDER: string }).EMAIL_PROVIDER}`
+	)
+}
+
 function escapeHtml(text: string): string {
 	return text
 		.replace(/&/g, '&amp;')

--- a/apps/www/src/lib/email-templates.server.ts
+++ b/apps/www/src/lib/email-templates.server.ts
@@ -161,7 +161,9 @@ export function buildNotificationEmailHtml(
 export async function sendNotificationEmail(
 	input: NotificationEmailData
 ): Promise<void> {
-	if (serverEnv.email.PROVIDER === 'silent') return
+	if (serverEnv.email.PROVIDER === 'silent') {
+		return
+	}
 
 	if (serverEnv.email.PROVIDER === 'console') {
 		logger.info(
@@ -199,9 +201,7 @@ export async function sendNotificationEmail(
 		return
 	}
 
-	throw new Error(
-		`Unhandled EMAIL_PROVIDER: ${serverEnv.email.PROVIDER}`
-	)
+	throw new Error(`Unhandled EMAIL_PROVIDER: ${serverEnv.email.PROVIDER}`)
 }
 
 function escapeHtml(text: string): string {
@@ -222,7 +222,9 @@ export async function sendInquiryEmail(
 		unavailableUrl: buildUnavailableUrl(input.baseUrl, input.listing.id),
 	}
 
-	if (serverEnv.email.PROVIDER === 'silent') return
+	if (serverEnv.email.PROVIDER === 'silent') {
+		return
+	}
 
 	if (serverEnv.email.PROVIDER === 'console') {
 		/**

--- a/apps/www/src/lib/email-templates.server.ts
+++ b/apps/www/src/lib/email-templates.server.ts
@@ -161,9 +161,9 @@ export function buildNotificationEmailHtml(
 export async function sendNotificationEmail(
 	input: NotificationEmailData
 ): Promise<void> {
-	if (serverEnv.EMAIL_PROVIDER === 'silent') return
+	if (serverEnv.email.PROVIDER === 'silent') return
 
-	if (serverEnv.EMAIL_PROVIDER === 'console') {
+	if (serverEnv.email.PROVIDER === 'console') {
 		logger.info(
 			{
 				to: input.to,
@@ -176,9 +176,9 @@ export async function sendNotificationEmail(
 		return
 	}
 
-	if (serverEnv.EMAIL_PROVIDER === 'resend') {
+	if (serverEnv.email.PROVIDER === 'resend') {
 		const { Resend } = await import('resend')
-		const resend = new Resend(serverEnv.RESEND_API_KEY)
+		const resend = new Resend(serverEnv.email.RESEND_API_KEY)
 
 		const { error } = await resend.emails.send({
 			from: serverEnv.EMAIL_FROM,
@@ -192,13 +192,15 @@ export async function sendNotificationEmail(
 		})
 
 		if (error) {
-			throw new Error(`Notification email send failed: ${error.name} — ${error.message}`)
+			throw new Error(
+				`Notification email send failed: ${error.name} — ${error.message}`
+			)
 		}
 		return
 	}
 
 	throw new Error(
-		`Unhandled EMAIL_PROVIDER: ${(serverEnv as { EMAIL_PROVIDER: string }).EMAIL_PROVIDER}`
+		`Unhandled EMAIL_PROVIDER: ${serverEnv.email.PROVIDER}`
 	)
 }
 

--- a/apps/www/src/lib/env.server.ts
+++ b/apps/www/src/lib/env.server.ts
@@ -57,6 +57,7 @@ const outputSchema = z
 	.object({
 		BETTER_AUTH_SECRET: z.string().min(32),
 		BETTER_AUTH_URL: z.string(),
+		CRON_SECRET: z.string().min(32).prefault('dev-cron-secret-not-for-production-use-here'),
 		DATABASE_AUTH_TOKEN: z.string().optional(),
 		DATABASE_URL: z.string().min(1),
 		EMAIL_FROM: z
@@ -65,6 +66,7 @@ const outputSchema = z
 		HMAC_SECRET: z.string().min(32),
 		MIGRATE_ON_REQUEST: z.stringbool().prefault('false'),
 		NODE_ENV: z.string().prefault('development'),
+		NOMINATIM_USER_AGENT: z.string().min(1).prefault('PickMyFruitDev/1.0 (dev@localhost)'),
 		email: emailSchema,
 		storage: storageSchema,
 	})

--- a/apps/www/src/lib/env.server.ts
+++ b/apps/www/src/lib/env.server.ts
@@ -57,7 +57,10 @@ const outputSchema = z
 	.object({
 		BETTER_AUTH_SECRET: z.string().min(32),
 		BETTER_AUTH_URL: z.string(),
-		CRON_SECRET: z.string().min(32).prefault('dev-cron-secret-not-for-production-use-here'),
+		CRON_SECRET: z
+			.string()
+			.min(32)
+			.prefault('dev-cron-secret-not-for-production-use-here'),
 		DATABASE_AUTH_TOKEN: z.string().optional(),
 		DATABASE_URL: z.string().min(1),
 		EMAIL_FROM: z
@@ -66,7 +69,10 @@ const outputSchema = z
 		HMAC_SECRET: z.string().min(32),
 		MIGRATE_ON_REQUEST: z.stringbool().prefault('false'),
 		NODE_ENV: z.string().prefault('development'),
-		NOMINATIM_USER_AGENT: z.string().min(1).prefault('PickMyFruitDev/1.0 (dev@localhost)'),
+		NOMINATIM_USER_AGENT: z
+			.string()
+			.min(1)
+			.prefault('PickMyFruitDev/1.0 (dev@localhost)'),
 		email: emailSchema,
 		storage: storageSchema,
 	})

--- a/apps/www/src/lib/geocoding.ts
+++ b/apps/www/src/lib/geocoding.ts
@@ -1,19 +1,28 @@
 import { latLngToCell } from 'h3-js'
 import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
+import { serverEnv } from '@/lib/env.server'
 
+/** Thrown when Nominatim returns a 429 or 5xx status. */
+export class GeocodingError extends Error {
+	constructor(
+		public readonly status: number,
+		address: string
+	) {
+		super(`Geocoding failed (HTTP ${status}) for: ${address}`)
+		this.name = 'GeocodingError'
+	}
+}
+
+/** Result returned when geocoding succeeds. */
 export interface GeocodingResult {
 	lat: number
 	lng: number
+	/** H3 index at {@link H3_RESOLUTIONS.STORAGE} (resolution 13). */
 	h3Index: string
 	displayName: string
 }
 
-export interface NominatimResponse {
-	lat: string
-	lon: string
-	display_name: string
-}
-
+/** Structured address input, used for listing creation. */
 export interface GeocodingInput {
 	address: string
 	city: string
@@ -21,51 +30,79 @@ export interface GeocodingInput {
 	zip?: string
 }
 
+interface NominatimResponse {
+	lat: string
+	lon: string
+	display_name: string
+}
+
 const GEOCODE_URL =
 	'https://nominatim.openstreetmap.org/search?format=json&limit=1&countrycodes=us'
 
-/**
- * Geocode an address using OpenStreetMap's Nominatim API.
- * Rate limited to 1 request/second - fine for MVP.
- *
- * @throws Error if geocoding fails or no results found
- */
-export async function geocodeAddress(
-	input: GeocodingInput
-): Promise<GeocodingResult> {
-	const { address, city, state, zip } = input
-	const query = [address, city, state, zip].filter(Boolean).join(', ')
+const TIMEOUT_MS = 10_000
+
+async function doGeocode(
+	query: string,
+	signal?: AbortSignal
+): Promise<GeocodingResult | null> {
 	const url = new URL(GEOCODE_URL)
 	url.searchParams.append('q', query)
 
-	const response = await fetch(url, {
-		headers: {
-			'User-Agent': 'PickMyFruit/1.0 (https://pickmyfruit.com)',
-		},
-	})
+	const controller = new AbortController()
+	const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+	signal?.addEventListener('abort', () => controller.abort(), { once: true })
+
+	let response: Response
+	try {
+		response = await fetch(url, {
+			headers: { 'User-Agent': serverEnv.NOMINATIM_USER_AGENT },
+			signal: controller.signal,
+		})
+	} catch (error) {
+		clearTimeout(timer)
+		throw error
+	}
+	clearTimeout(timer)
+
+	if (response.status === 429 || response.status >= 500) {
+		throw new GeocodingError(response.status, query)
+	}
 
 	if (!response.ok) {
-		throw new Error(`Geocoding request failed: ${response.status}`)
+		throw new GeocodingError(response.status, query)
 	}
 
 	const results: NominatimResponse[] = await response.json()
 
 	if (results.length === 0) {
-		throw new Error(
-			'Address not found. Please check the address and try again, or enter coordinates manually.'
-		)
+		return null
 	}
 
 	const [result] = results
 	const lat = parseFloat(result.lat)
 	const lng = parseFloat(result.lon)
-
 	const h3Index = latLngToCell(lat, lng, H3_RESOLUTIONS.STORAGE)
 
-	return {
-		lat,
-		lng,
-		h3Index,
-		displayName: result.display_name,
-	}
+	return { lat, lng, h3Index, displayName: result.display_name }
+}
+
+/**
+ * Geocodes a structured address or a plain string query using Nominatim.
+ *
+ * - Returns `null` when no results are found.
+ * - Throws {@link GeocodingError} on 429 (rate-limited) or 5xx responses.
+ * - Applies a 10-second timeout; an optional `AbortSignal` can cancel earlier.
+ */
+export async function geocodeAddress(
+	input: GeocodingInput | string,
+	options?: { signal?: AbortSignal }
+): Promise<GeocodingResult | null> {
+	const query =
+		typeof input === 'string'
+			? input
+			: [input.address, input.city, input.state, input.zip]
+					.filter(Boolean)
+					.join(', ')
+
+	return doGeocode(query, options?.signal)
 }

--- a/apps/www/src/lib/geocoding.ts
+++ b/apps/www/src/lib/geocoding.ts
@@ -1,6 +1,5 @@
 import { latLngToCell } from 'h3-js'
 import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
-import { serverEnv } from '@/lib/env.server'
 
 /** Thrown when Nominatim returns a 429 or 5xx status. */
 export class GeocodingError extends Error {
@@ -51,6 +50,8 @@ async function doGeocode(
 	const controller = new AbortController()
 	const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
 	signal?.addEventListener('abort', () => controller.abort(), { once: true })
+
+	const { serverEnv } = await import('@/lib/env.server')
 
 	let response: Response
 	try {

--- a/apps/www/src/lib/hmac.server.ts
+++ b/apps/www/src/lib/hmac.server.ts
@@ -49,3 +49,28 @@ export function buildUnavailableUrl(
 	const { nonce, ts, sig } = signUrl(listingId)
 	return `${baseUrl}/api/listings/${listingId}/unavailable?nonce=${nonce}&ts=${ts}&sig=${sig}`
 }
+
+/** Signs a subscription ID for use in one-click unsubscribe URLs. No expiry. */
+export function signUnsubscribeUrl(
+	baseUrl: string,
+	subscriptionId: number
+): string {
+	const message = `unsubscribe:${subscriptionId}`
+	const sig = createHmac('sha256', serverEnv.HMAC_SECRET)
+		.update(message)
+		.digest('hex')
+	return `${baseUrl}/api/notifications/${subscriptionId}/unsubscribe?sig=${sig}`
+}
+
+/** Verifies a subscription unsubscribe HMAC signature. */
+export function verifyUnsubscribeSignature(
+	subscriptionId: number,
+	sig: string
+): boolean {
+	const message = `unsubscribe:${subscriptionId}`
+	const expected = createHmac('sha256', serverEnv.HMAC_SECRET)
+		.update(message)
+		.digest('hex')
+	if (sig.length !== expected.length) return false
+	return timingSafeEqual(Buffer.from(sig), Buffer.from(expected))
+}

--- a/apps/www/src/lib/hmac.server.ts
+++ b/apps/www/src/lib/hmac.server.ts
@@ -22,11 +22,10 @@ export function signUrl(listingId: number): {
 /** Verifies an HMAC signature, rejecting expired or tampered URLs. */
 export function verifySignature(
 	listingId: number,
-	nonce: string,
-	ts: number,
-	sig: string,
+	query: { nonce: string; ts: number; sig: string },
 	now: number = Date.now()
 ): boolean {
+	const { nonce, ts, sig } = query
 	const age = now - ts
 	if (age < 0 || age > SIGNATURE_MAX_AGE_MS) {
 		return false
@@ -71,6 +70,8 @@ export function verifyUnsubscribeSignature(
 	const expected = createHmac('sha256', serverEnv.HMAC_SECRET)
 		.update(message)
 		.digest('hex')
-	if (sig.length !== expected.length) return false
+	if (sig.length !== expected.length) {
+		return false
+	}
 	return timingSafeEqual(Buffer.from(sig), Buffer.from(expected))
 }

--- a/apps/www/src/lib/notification-runner.ts
+++ b/apps/www/src/lib/notification-runner.ts
@@ -1,6 +1,4 @@
 import { Sentry } from '@/lib/sentry'
-import { logger } from '@/lib/logger.server'
-import { serverEnv } from '@/lib/env.server'
 import type { Listing } from '@/data/schema'
 
 /** Summary returned by each run. */
@@ -26,6 +24,8 @@ export async function runForThrottlePeriod(
 	throttlePeriod: 'immediately' | 'weekly',
 	cutoff: Date
 ): Promise<RunSummary> {
+	const { logger } = await import('@/lib/logger.server')
+	const { serverEnv } = await import('@/lib/env.server')
 	const {
 		getNotificationSubscriptionsDue,
 		getAvailableListingsForNotifications,
@@ -45,29 +45,24 @@ export async function runForThrottlePeriod(
 	)
 	const allListings: Listing[] = await getAvailableListingsForNotifications(500)
 
-	const summary: RunSummary = {
-		period: throttlePeriod,
-		sent: 0,
-		skipped: 0,
-		errors: 0,
-	}
+	type SubResult = 'sent' | 'skipped' | { error: unknown }
 
-	for (const sub of subscriptions) {
+	async function processSubscription(
+		sub: (typeof subscriptions)[number]
+	): Promise<SubResult> {
 		try {
 			const matchingListings = allListings.filter((listing) =>
 				subscriptionMatchesListing(sub, listing)
 			)
 
 			if (matchingListings.length === 0) {
-				summary.skipped++
-				continue
+				return 'skipped'
 			}
 
 			const owner = await getUserById(sub.userId)
 			if (!owner) {
 				logger.warn({ subscriptionId: sub.id }, 'Subscription owner not found')
-				summary.skipped++
-				continue
+				return 'skipped'
 			}
 
 			const unsubscribeUrl = signUnsubscribeUrl(baseUrl, sub.id)
@@ -91,9 +86,29 @@ export async function runForThrottlePeriod(
 			})
 
 			await markSubscriptionNotified(sub.id)
-			summary.sent++
+			return 'sent'
 		} catch (error) {
 			Sentry.captureException(error, { extra: { subscriptionId: sub.id } })
+			return { error }
+		}
+	}
+
+	const results = await Promise.all(
+		subscriptions.map((sub) => processSubscription(sub))
+	)
+
+	const summary: RunSummary = {
+		period: throttlePeriod,
+		sent: 0,
+		skipped: 0,
+		errors: 0,
+	}
+	for (const result of results) {
+		if (result === 'sent') {
+			summary.sent++
+		} else if (result === 'skipped') {
+			summary.skipped++
+		} else {
 			summary.errors++
 		}
 	}

--- a/apps/www/src/lib/notification-runner.ts
+++ b/apps/www/src/lib/notification-runner.ts
@@ -1,0 +1,110 @@
+import { Sentry } from '@/lib/sentry'
+import { logger } from '@/lib/logger.server'
+import { serverEnv } from '@/lib/env.server'
+import type { Listing } from '@/data/schema'
+
+/** Summary returned by each run. */
+export interface RunSummary {
+	period: 'immediately' | 'weekly'
+	sent: number
+	skipped: number
+	errors: number
+}
+
+/** Cutoff date for the "immediately" period: 1 hour ago. */
+function immediateCutoff(): Date {
+	return new Date(Date.now() - 60 * 60 * 1000)
+}
+
+/** Cutoff date for the "weekly" period: 7 days ago. */
+function weeklyCutoff(): Date {
+	return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+}
+
+/** Processes notifications for one throttle period. */
+export async function runForThrottlePeriod(
+	throttlePeriod: 'immediately' | 'weekly',
+	cutoff: Date
+): Promise<RunSummary> {
+	const {
+		getNotificationSubscriptionsDue,
+		getAvailableListingsForNotifications,
+		markSubscriptionNotified,
+		getUserById,
+	} = await import('@/data/queries.server')
+	const { subscriptionMatchesListing } =
+		await import('@/lib/subscription-matcher')
+	const { sendNotificationEmail } = await import('@/lib/email-templates.server')
+	const { signUnsubscribeUrl } = await import('@/lib/hmac.server')
+
+	const baseUrl = serverEnv.BETTER_AUTH_URL.replace(/\/$/, '')
+
+	const subscriptions = await getNotificationSubscriptionsDue(
+		throttlePeriod,
+		cutoff
+	)
+	const allListings: Listing[] = await getAvailableListingsForNotifications(500)
+
+	const summary: RunSummary = {
+		period: throttlePeriod,
+		sent: 0,
+		skipped: 0,
+		errors: 0,
+	}
+
+	for (const sub of subscriptions) {
+		try {
+			const matchingListings = allListings.filter((listing) =>
+				subscriptionMatchesListing(sub, listing)
+			)
+
+			if (matchingListings.length === 0) {
+				summary.skipped++
+				continue
+			}
+
+			const owner = await getUserById(sub.userId)
+			if (!owner) {
+				logger.warn({ subscriptionId: sub.id }, 'Subscription owner not found')
+				summary.skipped++
+				continue
+			}
+
+			const unsubscribeUrl = signUnsubscribeUrl(baseUrl, sub.id)
+
+			await sendNotificationEmail({
+				to: owner.email,
+				subscription: {
+					id: sub.id,
+					placeName: sub.placeName,
+					throttlePeriod,
+				},
+				listings: matchingListings.map((l) => ({
+					id: l.id,
+					name: l.name,
+					type: l.type,
+					city: l.city,
+					state: l.state,
+				})),
+				unsubscribeUrl,
+				baseUrl,
+			})
+
+			await markSubscriptionNotified(sub.id)
+			summary.sent++
+		} catch (error) {
+			Sentry.captureException(error, { extra: { subscriptionId: sub.id } })
+			summary.errors++
+		}
+	}
+
+	logger.info(summary, 'Notification run complete')
+	return summary
+}
+
+/** Runs notifications for all throttle periods sequentially. */
+export async function runAll(): Promise<RunSummary[]> {
+	const immediate = await runForThrottlePeriod('immediately', immediateCutoff())
+	const weekly = await runForThrottlePeriod('weekly', weeklyCutoff())
+	return [immediate, weekly]
+}

--- a/apps/www/src/lib/subscription-draft.ts
+++ b/apps/www/src/lib/subscription-draft.ts
@@ -1,0 +1,45 @@
+import { latLngToCell } from 'h3-js'
+import {
+	RING_SIZE_LABELS,
+	resolutionForRingSize,
+} from '@/lib/subscription-labels'
+import type { CreateSubscriptionData } from '@/lib/validation'
+
+/** Geocoded place details used to build a subscription draft. */
+export interface GeocodedSubscriptionLocation {
+	lat: number
+	lng: number
+	displayName: string
+}
+
+interface BuildCreateSubscriptionDataInput {
+	label?: string
+	location: GeocodedSubscriptionLocation
+	produceTypes?: string[] | null
+	ringSize: number
+	throttlePeriod: 'immediately' | 'weekly'
+}
+
+/** Builds a validated create-subscription payload from a geocoded search result. */
+export function buildCreateSubscriptionData(
+	input: BuildCreateSubscriptionDataInput
+): CreateSubscriptionData {
+	const resolution = resolutionForRingSize(input.ringSize)
+	return {
+		label: input.label?.trim() || undefined,
+		centerH3: latLngToCell(input.location.lat, input.location.lng, resolution),
+		resolution,
+		ringSize: input.ringSize,
+		placeName: input.location.displayName,
+		produceTypes: input.produceTypes ?? null,
+		throttlePeriod: input.throttlePeriod,
+	}
+}
+
+/** Builds the post-search confirmation sentence shown below the address field. */
+export function buildLocationConfirmationText(
+	placeName: string,
+	ringSize: number
+): string {
+	return `Searching within ${RING_SIZE_LABELS[ringSize]} of ${placeName}`
+}

--- a/apps/www/src/lib/subscription-labels.ts
+++ b/apps/www/src/lib/subscription-labels.ts
@@ -1,0 +1,30 @@
+/** Maps H3 ring size to a human-readable approximate radius label. */
+export const RING_SIZE_LABELS: Record<number, string> = {
+	0: '~1 mile',
+	1: '~3 miles',
+	2: '~6 miles',
+	3: '~10 miles',
+	4: '~15 miles',
+	5: '~20 miles',
+	6: '~30 miles',
+}
+
+/** Maps throttle period values to display labels. */
+export const THROTTLE_PERIOD_LABELS: Record<string, string> = {
+	immediately: 'Immediately (within ~1 hour)',
+	weekly: 'Weekly digest',
+}
+
+/**
+ * Maps a subscription ring size (0–6) to the H3 resolution appropriate for
+ * its radius. Finer resolution = more cells = more precise location.
+ */
+export function resolutionForRingSize(ringSize: number): number {
+	if (ringSize === 0) {
+		return 8
+	}
+	if (ringSize <= 2) {
+		return 7
+	}
+	return 6
+}

--- a/apps/www/src/lib/subscription-matcher.ts
+++ b/apps/www/src/lib/subscription-matcher.ts
@@ -1,0 +1,52 @@
+import { gridDisk, cellToParent } from 'h3-js'
+import { Sentry } from '@/lib/sentry'
+import type { Listing, NotificationSubscription } from '@/data/schema'
+
+/**
+ * Returns true if a listing falls within a subscription's geographic area
+ * and matches its produce-type filter (if any).
+ *
+ * Malformed `produceTypes` JSON is captured to Sentry and returns false (skip,
+ * not match-all) to avoid flooding subscribers with unintended emails.
+ */
+export function subscriptionMatchesListing(
+	subscription: NotificationSubscription,
+	listing: Listing
+): boolean {
+	// Convert the listing's high-res cell to the subscription's resolution
+	let listingCell: string
+	try {
+		listingCell = cellToParent(listing.h3Index, subscription.resolution)
+	} catch {
+		return false
+	}
+
+	// Check geographic containment
+	const coverageCells = gridDisk(subscription.centerH3, subscription.ringSize)
+	if (!coverageCells.includes(listingCell)) {
+		return false
+	}
+
+	// No produce-type filter → match any type
+	if (!subscription.produceTypes) {
+		return true
+	}
+
+	// Validate and apply produce-type filter
+	let types: string[]
+	try {
+		const parsed = JSON.parse(subscription.produceTypes) as unknown
+		if (!Array.isArray(parsed)) throw new Error('produceTypes is not an array')
+		types = parsed as string[]
+	} catch (error) {
+		Sentry.captureException(error, {
+			extra: {
+				subscriptionId: subscription.id,
+				produceTypes: subscription.produceTypes,
+			},
+		})
+		return false
+	}
+
+	return types.includes(listing.type)
+}

--- a/apps/www/src/lib/validation.ts
+++ b/apps/www/src/lib/validation.ts
@@ -70,6 +70,50 @@ export const profileNameSchema = z
 	.string()
 	.max(100, 'Name must be 100 characters or fewer')
 
+// ============================================================================
+// Subscription Schemas
+// ============================================================================
+
+export const createSubscriptionSchema = z.object({
+	label: z.preprocess(
+		(val) => (val === '' || val === null ? undefined : val),
+		z.string().max(100).optional()
+	),
+	centerH3: z.string().min(1),
+	resolution: z.number().int().min(6).max(8),
+	ringSize: z.number().int().min(0).max(6),
+	placeName: z.string().min(1).max(500),
+	produceTypes: z.array(z.string()).nullable().optional(),
+	throttlePeriod: z.enum(['immediately', 'weekly']),
+})
+
+export type CreateSubscriptionData = z.infer<typeof createSubscriptionSchema>
+
+export const updateSubscriptionSchema = z
+	.object({
+		label: z.preprocess(
+			(val) => (val === '' || val === null ? undefined : val),
+			z.string().max(100).optional()
+		),
+		centerH3: z.string().optional(),
+		resolution: z.number().int().min(6).max(8).optional(),
+		ringSize: z.number().int().min(0).max(6).optional(),
+		placeName: z.string().max(500).optional(),
+		produceTypes: z.array(z.string()).nullable().optional(),
+		throttlePeriod: z.enum(['immediately', 'weekly']).optional(),
+		enabled: z.boolean().optional(),
+	})
+	.refine(
+		(data) => {
+			const hasCenter = data.centerH3 !== undefined
+			const hasResolution = data.resolution !== undefined
+			return hasCenter === hasResolution
+		},
+		{ message: 'centerH3 and resolution must both be provided or both omitted' }
+	)
+
+export type UpdateSubscriptionData = z.infer<typeof updateSubscriptionSchema>
+
 export const ListingStatus = {
 	available: 'available',
 	unavailable: 'unavailable',

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as ApiUploadsSplatRouteImport } from './routes/api/uploads/$'
 import { Route as ApiListingsIdRouteImport } from './routes/api/listings.$id'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as ApiListingsIdUnavailableRouteImport } from './routes/api/listings.$id.unavailable'
+import { Route as ApiCronNotifyRouteImport } from './routes/api/cron.notify'
 
 const TermsRoute = TermsRouteImport.update({
   id: '/terms',
@@ -113,6 +114,11 @@ const ApiListingsIdUnavailableRoute =
     path: '/unavailable',
     getParentRoute: () => ApiListingsIdRoute,
   } as any)
+const ApiCronNotifyRoute = ApiCronNotifyRouteImport.update({
+  id: '/api/cron/notify',
+  path: '/api/cron/notify',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -132,6 +138,7 @@ export interface FileRoutesByFullPath {
   '/api/listings/$id': typeof ApiListingsIdRouteWithChildren
   '/api/uploads/$': typeof ApiUploadsSplatRoute
   '/api/listings/$id/unavailable': typeof ApiListingsIdUnavailableRoute
+  '/api/cron/notify': typeof ApiCronNotifyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -151,6 +158,7 @@ export interface FileRoutesByTo {
   '/api/listings/$id': typeof ApiListingsIdRouteWithChildren
   '/api/uploads/$': typeof ApiUploadsSplatRoute
   '/api/listings/$id/unavailable': typeof ApiListingsIdUnavailableRoute
+  '/api/cron/notify': typeof ApiCronNotifyRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -171,6 +179,7 @@ export interface FileRoutesById {
   '/api/listings/$id': typeof ApiListingsIdRouteWithChildren
   '/api/uploads/$': typeof ApiUploadsSplatRoute
   '/api/listings/$id/unavailable': typeof ApiListingsIdUnavailableRoute
+  '/api/cron/notify': typeof ApiCronNotifyRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -192,6 +201,7 @@ export interface FileRouteTypes {
     | '/api/listings/$id'
     | '/api/uploads/$'
     | '/api/listings/$id/unavailable'
+    | '/api/cron/notify'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -211,6 +221,7 @@ export interface FileRouteTypes {
     | '/api/listings/$id'
     | '/api/uploads/$'
     | '/api/listings/$id/unavailable'
+    | '/api/cron/notify'
   id:
     | '__root__'
     | '/'
@@ -230,6 +241,7 @@ export interface FileRouteTypes {
     | '/api/listings/$id'
     | '/api/uploads/$'
     | '/api/listings/$id/unavailable'
+    | '/api/cron/notify'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -248,6 +260,7 @@ export interface RootRouteChildren {
   ListingsNewRoute: typeof ListingsNewRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiUploadsSplatRoute: typeof ApiUploadsSplatRoute
+  ApiCronNotifyRoute: typeof ApiCronNotifyRoute
 }
 
 declare module '@tanstack/solid-router' {
@@ -371,6 +384,13 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof ApiListingsIdUnavailableRouteImport
       parentRoute: typeof ApiListingsIdRoute
     }
+    '/api/cron/notify': {
+      id: '/api/cron/notify'
+      path: '/api/cron/notify'
+      fullPath: '/api/cron/notify'
+      preLoaderRoute: typeof ApiCronNotifyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -414,6 +434,7 @@ const rootRouteChildren: RootRouteChildren = {
   ListingsNewRoute: ListingsNewRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiUploadsSplatRoute: ApiUploadsSplatRoute,
+  ApiCronNotifyRoute: ApiCronNotifyRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -17,6 +17,8 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as CssTestRouteImport } from './routes/css-test'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as NotificationsIndexRouteImport } from './routes/notifications/index'
+import { Route as NotificationsNewRouteImport } from './routes/notifications/new'
 import { Route as ListingsNewRouteImport } from './routes/listings/new'
 import { Route as ListingsMineRouteImport } from './routes/listings/mine'
 import { Route as ListingsIdRouteImport } from './routes/listings.$id'
@@ -24,9 +26,9 @@ import { Route as ApiListingsRouteImport } from './routes/api/listings'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
 import { Route as ApiUploadsSplatRouteImport } from './routes/api/uploads/$'
 import { Route as ApiListingsIdRouteImport } from './routes/api/listings.$id'
+import { Route as ApiCronNotifyRouteImport } from './routes/api/cron.notify'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as ApiListingsIdUnavailableRouteImport } from './routes/api/listings.$id.unavailable'
-import { Route as ApiCronNotifyRouteImport } from './routes/api/cron.notify'
 
 const TermsRoute = TermsRouteImport.update({
   id: '/terms',
@@ -68,6 +70,16 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const NotificationsIndexRoute = NotificationsIndexRouteImport.update({
+  id: '/notifications/',
+  path: '/notifications/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NotificationsNewRoute = NotificationsNewRouteImport.update({
+  id: '/notifications/new',
+  path: '/notifications/new',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ListingsNewRoute = ListingsNewRouteImport.update({
   id: '/listings/new',
   path: '/listings/new',
@@ -103,6 +115,11 @@ const ApiListingsIdRoute = ApiListingsIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => ApiListingsRoute,
 } as any)
+const ApiCronNotifyRoute = ApiCronNotifyRouteImport.update({
+  id: '/api/cron/notify',
+  path: '/api/cron/notify',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   id: '/api/auth/$',
   path: '/api/auth/$',
@@ -114,11 +131,6 @@ const ApiListingsIdUnavailableRoute =
     path: '/unavailable',
     getParentRoute: () => ApiListingsIdRoute,
   } as any)
-const ApiCronNotifyRoute = ApiCronNotifyRouteImport.update({
-  id: '/api/cron/notify',
-  path: '/api/cron/notify',
-  getParentRoute: () => rootRouteImport,
-} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -134,11 +146,13 @@ export interface FileRoutesByFullPath {
   '/listings/$id': typeof ListingsIdRoute
   '/listings/mine': typeof ListingsMineRoute
   '/listings/new': typeof ListingsNewRoute
+  '/notifications/new': typeof NotificationsNewRoute
+  '/notifications/': typeof NotificationsIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/cron/notify': typeof ApiCronNotifyRoute
   '/api/listings/$id': typeof ApiListingsIdRouteWithChildren
   '/api/uploads/$': typeof ApiUploadsSplatRoute
   '/api/listings/$id/unavailable': typeof ApiListingsIdUnavailableRoute
-  '/api/cron/notify': typeof ApiCronNotifyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -154,11 +168,13 @@ export interface FileRoutesByTo {
   '/listings/$id': typeof ListingsIdRoute
   '/listings/mine': typeof ListingsMineRoute
   '/listings/new': typeof ListingsNewRoute
+  '/notifications/new': typeof NotificationsNewRoute
+  '/notifications': typeof NotificationsIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/cron/notify': typeof ApiCronNotifyRoute
   '/api/listings/$id': typeof ApiListingsIdRouteWithChildren
   '/api/uploads/$': typeof ApiUploadsSplatRoute
   '/api/listings/$id/unavailable': typeof ApiListingsIdUnavailableRoute
-  '/api/cron/notify': typeof ApiCronNotifyRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -175,11 +191,13 @@ export interface FileRoutesById {
   '/listings/$id': typeof ListingsIdRoute
   '/listings/mine': typeof ListingsMineRoute
   '/listings/new': typeof ListingsNewRoute
+  '/notifications/new': typeof NotificationsNewRoute
+  '/notifications/': typeof NotificationsIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/cron/notify': typeof ApiCronNotifyRoute
   '/api/listings/$id': typeof ApiListingsIdRouteWithChildren
   '/api/uploads/$': typeof ApiUploadsSplatRoute
   '/api/listings/$id/unavailable': typeof ApiListingsIdUnavailableRoute
-  '/api/cron/notify': typeof ApiCronNotifyRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -197,11 +215,13 @@ export interface FileRouteTypes {
     | '/listings/$id'
     | '/listings/mine'
     | '/listings/new'
+    | '/notifications/new'
+    | '/notifications/'
     | '/api/auth/$'
+    | '/api/cron/notify'
     | '/api/listings/$id'
     | '/api/uploads/$'
     | '/api/listings/$id/unavailable'
-    | '/api/cron/notify'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -217,11 +237,13 @@ export interface FileRouteTypes {
     | '/listings/$id'
     | '/listings/mine'
     | '/listings/new'
+    | '/notifications/new'
+    | '/notifications'
     | '/api/auth/$'
+    | '/api/cron/notify'
     | '/api/listings/$id'
     | '/api/uploads/$'
     | '/api/listings/$id/unavailable'
-    | '/api/cron/notify'
   id:
     | '__root__'
     | '/'
@@ -237,11 +259,13 @@ export interface FileRouteTypes {
     | '/listings/$id'
     | '/listings/mine'
     | '/listings/new'
+    | '/notifications/new'
+    | '/notifications/'
     | '/api/auth/$'
+    | '/api/cron/notify'
     | '/api/listings/$id'
     | '/api/uploads/$'
     | '/api/listings/$id/unavailable'
-    | '/api/cron/notify'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -258,9 +282,11 @@ export interface RootRouteChildren {
   ListingsIdRoute: typeof ListingsIdRoute
   ListingsMineRoute: typeof ListingsMineRoute
   ListingsNewRoute: typeof ListingsNewRoute
+  NotificationsNewRoute: typeof NotificationsNewRoute
+  NotificationsIndexRoute: typeof NotificationsIndexRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
-  ApiUploadsSplatRoute: typeof ApiUploadsSplatRoute
   ApiCronNotifyRoute: typeof ApiCronNotifyRoute
+  ApiUploadsSplatRoute: typeof ApiUploadsSplatRoute
 }
 
 declare module '@tanstack/solid-router' {
@@ -321,6 +347,20 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/notifications/': {
+      id: '/notifications/'
+      path: '/notifications'
+      fullPath: '/notifications/'
+      preLoaderRoute: typeof NotificationsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/notifications/new': {
+      id: '/notifications/new'
+      path: '/notifications/new'
+      fullPath: '/notifications/new'
+      preLoaderRoute: typeof NotificationsNewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/listings/new': {
       id: '/listings/new'
       path: '/listings/new'
@@ -370,6 +410,13 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof ApiListingsIdRouteImport
       parentRoute: typeof ApiListingsRoute
     }
+    '/api/cron/notify': {
+      id: '/api/cron/notify'
+      path: '/api/cron/notify'
+      fullPath: '/api/cron/notify'
+      preLoaderRoute: typeof ApiCronNotifyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/auth/$': {
       id: '/api/auth/$'
       path: '/api/auth/$'
@@ -383,13 +430,6 @@ declare module '@tanstack/solid-router' {
       fullPath: '/api/listings/$id/unavailable'
       preLoaderRoute: typeof ApiListingsIdUnavailableRouteImport
       parentRoute: typeof ApiListingsIdRoute
-    }
-    '/api/cron/notify': {
-      id: '/api/cron/notify'
-      path: '/api/cron/notify'
-      fullPath: '/api/cron/notify'
-      preLoaderRoute: typeof ApiCronNotifyRouteImport
-      parentRoute: typeof rootRouteImport
     }
   }
 }
@@ -432,9 +472,11 @@ const rootRouteChildren: RootRouteChildren = {
   ListingsIdRoute: ListingsIdRoute,
   ListingsMineRoute: ListingsMineRoute,
   ListingsNewRoute: ListingsNewRoute,
+  NotificationsNewRoute: NotificationsNewRoute,
+  NotificationsIndexRoute: NotificationsIndexRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
-  ApiUploadsSplatRoute: ApiUploadsSplatRoute,
   ApiCronNotifyRoute: ApiCronNotifyRoute,
+  ApiUploadsSplatRoute: ApiUploadsSplatRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/www/src/routes/api/cron.notify.ts
+++ b/apps/www/src/routes/api/cron.notify.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/solid-router'
+import { Sentry } from '@/lib/sentry'
+
+export const Route = createFileRoute('/api/cron/notify')({
+	server: {
+		handlers: {
+			async POST({ request }) {
+				const { serverEnv } = await import('@/lib/env.server')
+				const auth = request.headers.get('Authorization')
+				const expected = `Bearer ${serverEnv.CRON_SECRET}`
+				if (auth !== expected) {
+					return Response.json({ error: 'Unauthorized' }, { status: 401 })
+				}
+
+				try {
+					const { runAll } = await import('@/lib/notification-runner')
+					const summaries = await runAll()
+					const sent = summaries.reduce((n, s) => n + s.sent, 0)
+					const skipped = summaries.reduce((n, s) => n + s.skipped, 0)
+					const errors = summaries.reduce((n, s) => n + s.errors, 0)
+					return Response.json({ sent, skipped, errors, summaries })
+				} catch (error) {
+					Sentry.captureException(error)
+					return Response.json({ error: 'Notification run failed' }, { status: 500 })
+				}
+			},
+		},
+	},
+})

--- a/apps/www/src/routes/api/listings.$id.unavailable.ts
+++ b/apps/www/src/routes/api/listings.$id.unavailable.ts
@@ -57,7 +57,7 @@ export const Route = createFileRoute('/api/listings/$id/unavailable')({
 					)
 				}
 
-				if (!verifySignature(id, nonce, ts, sig)) {
+				if (!verifySignature(id, { nonce, ts, sig })) {
 					Sentry.captureMessage('Invalid HMAC signature', {
 						level: 'warning',
 						extra: { listingId: id, ageMs: age },

--- a/apps/www/src/routes/api/listings.ts
+++ b/apps/www/src/routes/api/listings.ts
@@ -75,6 +75,14 @@ export const Route = createFileRoute('/api/listings')({
 					const message = error instanceof Error ? error.message : 'Geocoding failed'
 					return Response.json({ error: message }, { status: 400 })
 				}
+				if (!geocodeResult) {
+					return Response.json(
+						{
+							error: 'Address not found. Please check the address and try again.',
+						},
+						{ status: 400 }
+					)
+				}
 
 				// Create the listing
 				try {

--- a/apps/www/src/routes/notifications/index.css
+++ b/apps/www/src/routes/notifications/index.css
@@ -1,0 +1,61 @@
+@layer page {
+	.notifications-page {
+		max-width: 800px;
+		margin: 0 auto;
+		padding: 40px 20px 80px;
+	}
+
+	.notifications-page .notifications-page__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+		margin-bottom: 24px;
+	}
+
+	.notifications-page .notifications-page__header h1 {
+		margin: 0;
+		font-size: 32px;
+		color: var(--color-foreground);
+	}
+
+	.notifications-page .notifications-page__add-link {
+		display: inline-block;
+		background: var(--color-primary);
+		color: var(--color-background);
+		padding: 10px 16px;
+		border-radius: 8px;
+		text-decoration: none;
+		font-weight: 600;
+	}
+
+	.notifications-page .notifications-page__list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		gap: 12px;
+	}
+
+	.notifications-page .notifications-page__item {
+		border: 1px solid oklch(from var(--color-quiet) l c h / 0.2);
+		border-radius: 10px;
+		padding: 16px;
+		background: var(--color-background);
+	}
+
+	.notifications-page .notifications-page__item h2 {
+		margin: 0 0 8px;
+		font-size: 20px;
+	}
+
+	.notifications-page .notifications-page__item p {
+		margin: 4px 0;
+		color: var(--color-foreground);
+	}
+
+	.notifications-page .notifications-page__empty {
+		margin: 0;
+		color: var(--color-quiet);
+	}
+}

--- a/apps/www/src/routes/notifications/index.tsx
+++ b/apps/www/src/routes/notifications/index.tsx
@@ -1,0 +1,88 @@
+import { createFileRoute, Link } from '@tanstack/solid-router'
+import { For, Show } from 'solid-js'
+import Layout from '@/components/Layout'
+import PageHeader from '@/components/PageHeader'
+import { getMySubscriptions } from '@/api/notifications'
+import { authMiddleware } from '@/middleware/auth'
+import {
+	RING_SIZE_LABELS,
+	THROTTLE_PERIOD_LABELS,
+} from '@/lib/subscription-labels'
+import type { NotificationSubscription } from '@/data/schema'
+import '@/routes/notifications/index.css'
+
+interface SubscriptionListItem {
+	label: string
+	placeName: string
+	ringLabel: string
+	throttleLabel: string
+}
+
+function toSubscriptionListItem(
+	subscription: NotificationSubscription
+): SubscriptionListItem {
+	const ringLabel =
+		RING_SIZE_LABELS[subscription.ringSize] ?? `~${subscription.ringSize} ring`
+	const throttleLabel =
+		THROTTLE_PERIOD_LABELS[subscription.throttlePeriod] ??
+		subscription.throttlePeriod
+
+	return {
+		label: subscription.label?.trim() || subscription.placeName,
+		placeName: subscription.placeName,
+		ringLabel,
+		throttleLabel,
+	}
+}
+
+export const Route = createFileRoute('/notifications/')({
+	loader: async () => {
+		const subscriptions = await getMySubscriptions()
+		return subscriptions.map(toSubscriptionListItem)
+	},
+	component: NotificationsPage,
+	server: {
+		middleware: [authMiddleware],
+	},
+})
+
+function NotificationsPage() {
+	const subscriptions = Route.useLoaderData()
+
+	return (
+		<Layout title="Notifications - Pick My Fruit">
+			<PageHeader breadcrumbs={[{ label: 'Notifications' }]} />
+			<main id="main-content" class="notifications-page">
+				<header class="notifications-page__header">
+					<h1>Notifications</h1>
+					<Link to="/notifications/new" class="notifications-page__add-link">
+						Add a subscription
+					</Link>
+				</header>
+
+				<Show
+					when={subscriptions().length > 0}
+					fallback={
+						<p class="notifications-page__empty">
+							No subscriptions yet. Create one to get notified when new produce is
+							posted near you.
+						</p>
+					}
+				>
+					<ul class="notifications-page__list">
+						<For each={subscriptions()}>
+							{(subscription) => (
+								<li class="notifications-page__item">
+									<h2>{subscription.label}</h2>
+									<p>{subscription.placeName}</p>
+									<p>{`Searching within ${subscription.ringLabel}`}</p>
+									<p>{`Delivery: ${subscription.throttleLabel}`}</p>
+								</li>
+							)}
+						</For>
+					</ul>
+				</Show>
+			</main>
+		</Layout>
+	)
+}

--- a/apps/www/src/routes/notifications/new.css
+++ b/apps/www/src/routes/notifications/new.css
@@ -1,0 +1,22 @@
+@layer page {
+	.notifications-new {
+		max-width: 700px;
+		margin: 0 auto;
+		padding: 40px 20px 80px;
+	}
+
+	.notifications-new .notifications-new__header {
+		margin-bottom: 24px;
+	}
+
+	.notifications-new .notifications-new__header h1 {
+		margin: 0 0 8px;
+		font-size: 32px;
+		color: var(--color-foreground);
+	}
+
+	.notifications-new .notifications-new__header p {
+		margin: 0;
+		color: var(--color-quiet);
+	}
+}

--- a/apps/www/src/routes/notifications/new.tsx
+++ b/apps/www/src/routes/notifications/new.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute } from '@tanstack/solid-router'
+import Layout from '@/components/Layout'
+import PageHeader from '@/components/PageHeader'
+import SubscriptionForm from '@/components/SubscriptionForm'
+import { authMiddleware } from '@/middleware/auth'
+import '@/routes/notifications/new.css'
+
+export const Route = createFileRoute('/notifications/new')({
+	component: NewNotificationSubscriptionPage,
+	server: {
+		middleware: [authMiddleware],
+	},
+})
+
+function NewNotificationSubscriptionPage() {
+	return (
+		<Layout title="New Notification Subscription - Pick My Fruit">
+			<PageHeader
+				breadcrumbs={[
+					{ label: 'Notifications', to: '/notifications' },
+					{ label: 'New Subscription' },
+				]}
+			/>
+			<main id="main-content" class="notifications-new">
+				<header class="notifications-new__header">
+					<h1>Create a notification subscription</h1>
+					<p>Get notified when new produce listings are posted near you.</p>
+				</header>
+				<SubscriptionForm />
+			</main>
+		</Layout>
+	)
+}

--- a/apps/www/tests/e2e/notifications.test.ts
+++ b/apps/www/tests/e2e/notifications.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from './helpers/fixtures'
+import { loginViaUI } from './helpers/login'
+
+test.describe('Notifications', () => {
+	test.describe.configure({ mode: 'serial' })
+
+	test('authenticated user can create a subscription and see it in the list', async ({
+		page,
+		testUser,
+	}) => {
+		await loginViaUI(page, testUser)
+
+		await page.goto('/notifications/new')
+		await expect(
+			page.getByRole('heading', { name: 'Create a notification subscription' })
+		).toBeVisible()
+
+		const addressInput = page.getByLabel('Address')
+		await addressInput.fill('Napa, CA 94558')
+		await page.getByRole('button', { name: 'Search' }).click()
+
+		await expect(page.getByText(/Searching within ~3 miles of/i)).toBeVisible()
+
+		await page.getByRole('button', { name: 'Create subscription' }).click()
+
+		await expect(page).toHaveURL('/notifications')
+		await expect(
+			page.getByRole('heading', { name: 'Notifications' })
+		).toBeVisible()
+		await expect(page.getByText('Immediately')).toBeVisible()
+		await expect(
+			page.getByRole('heading', { name: /Napa, Napa County, California/i })
+		).toBeVisible()
+	})
+})

--- a/apps/www/tests/hmac.server.test.ts
+++ b/apps/www/tests/hmac.server.test.ts
@@ -30,13 +30,13 @@ describe('verifySignature', () => {
 	it('accepts a valid, fresh signature', () => {
 		const id = faker.number.int({ min: 1, max: 9999 })
 		const { nonce, ts, sig } = signUrl(id)
-		expect(verifySignature(id, nonce, ts, sig)).toBe(true)
+		expect(verifySignature(id, { nonce, ts, sig })).toBe(true)
 	})
 
 	it('rejects a tampered listing ID', () => {
 		const id = faker.number.int({ min: 1, max: 4999 })
 		const { nonce, ts, sig } = signUrl(id)
-		expect(verifySignature(id + 5000, nonce, ts, sig)).toBe(false)
+		expect(verifySignature(id + 5000, { nonce, ts, sig })).toBe(false)
 	})
 
 	it('rejects a tampered nonce', () => {
@@ -44,41 +44,41 @@ describe('verifySignature', () => {
 		const { nonce, ts, sig } = signUrl(id)
 		const tampered = randomUUID()
 		expect(tampered).not.toBe(nonce)
-		expect(verifySignature(id, tampered, ts, sig)).toBe(false)
+		expect(verifySignature(id, { nonce: tampered, ts, sig })).toBe(false)
 	})
 
 	it('rejects a tampered timestamp', () => {
 		const id = faker.number.int({ min: 1, max: 9999 })
 		const { nonce, ts, sig } = signUrl(id)
-		expect(verifySignature(id, nonce, ts + 1, sig)).toBe(false)
+		expect(verifySignature(id, { nonce, ts: ts + 1, sig })).toBe(false)
 	})
 
 	it('rejects a tampered signature', () => {
 		const id = faker.number.int({ min: 1, max: 9999 })
 		const { nonce, ts } = signUrl(id)
 		const other = signUrl(id + 1)
-		expect(verifySignature(id, nonce, ts, other.sig)).toBe(false)
+		expect(verifySignature(id, { nonce, ts, sig: other.sig })).toBe(false)
 	})
 
 	it('rejects a signature older than max age', () => {
 		const id = faker.number.int({ min: 1, max: 9999 })
 		const { nonce, ts, sig } = signUrl(id)
 		const afterExpiry = ts + SIGNATURE_MAX_AGE_MS + 1
-		expect(verifySignature(id, nonce, ts, sig, afterExpiry)).toBe(false)
+		expect(verifySignature(id, { nonce, ts, sig }, afterExpiry)).toBe(false)
 	})
 
 	it('accepts a signature just under max age', () => {
 		const id = faker.number.int({ min: 1, max: 9999 })
 		const { nonce, ts, sig } = signUrl(id)
 		const justUnderMaxAge = ts + SIGNATURE_MAX_AGE_MS - 1000
-		expect(verifySignature(id, nonce, ts, sig, justUnderMaxAge)).toBe(true)
+		expect(verifySignature(id, { nonce, ts, sig }, justUnderMaxAge)).toBe(true)
 	})
 
 	it('rejects a timestamp from the future', () => {
 		const id = faker.number.int({ min: 1, max: 9999 })
 		const { nonce, ts, sig } = signUrl(id)
 		const beforeSigning = ts - 1000
-		expect(verifySignature(id, nonce, ts, sig, beforeSigning)).toBe(false)
+		expect(verifySignature(id, { nonce, ts, sig }, beforeSigning)).toBe(false)
 	})
 })
 

--- a/apps/www/tests/migrations.server.test.ts
+++ b/apps/www/tests/migrations.server.test.ts
@@ -18,6 +18,7 @@ const EXPECTED_TABLES = [
 	'inquiries',
 	'listing_photos',
 	'listings',
+	'notification_subscriptions',
 	'session',
 	'user',
 	'verification',

--- a/apps/www/tests/subscription-draft.test.ts
+++ b/apps/www/tests/subscription-draft.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+	buildCreateSubscriptionData,
+	buildLocationConfirmationText,
+} from '../src/lib/subscription-draft'
+
+describe('buildCreateSubscriptionData', () => {
+	it('uses resolution 7 for ring size 1 and normalizes optional fields', () => {
+		const data = buildCreateSubscriptionData({
+			label: '  Backyard alerts  ',
+			location: {
+				lat: 38.2975,
+				lng: -122.2869,
+				displayName: 'Napa, CA 94558',
+			},
+			produceTypes: undefined,
+			ringSize: 1,
+			throttlePeriod: 'immediately',
+		})
+
+		expect(data).toMatchObject({
+			label: 'Backyard alerts',
+			resolution: 7,
+			ringSize: 1,
+			placeName: 'Napa, CA 94558',
+			produceTypes: null,
+			throttlePeriod: 'immediately',
+		})
+		expect(data.centerH3).toMatch(/^[0-9a-f]+$/)
+	})
+})
+
+describe('buildLocationConfirmationText', () => {
+	it('includes ring size label and place name', () => {
+		expect(buildLocationConfirmationText('Napa, CA 94558', 1)).toBe(
+			'Searching within ~3 miles of Napa, CA 94558'
+		)
+	})
+})

--- a/docs/0004-notifications.md
+++ b/docs/0004-notifications.md
@@ -1,0 +1,284 @@
+# Notification Subscriptions
+
+Users can subscribe to receive email notifications when new produce listings appear near them.
+
+## Feature Overview
+
+- A user creates a subscription: location (geocoded address + radius) and optional produce-type filter
+- When a new listing is posted that matches one or more subscriptions, subscribers get an email
+- Users can manage (edit, pause, delete) subscriptions and unsubscribe via a one-click link in every email
+- Two throttle periods: **immediately** (implemented as hourly) and **weekly**
+
+## Architecture Decisions
+
+### Cron Infrastructure
+
+The Fly.io durable volume can only be mounted to one machine at a time, so the notification runner must execute on the same machine as the web process. We use an HTTP cron endpoint:
+
+- The web app exposes `POST /api/cron/notify` protected by `Authorization: Bearer {CRON_SECRET}`
+- A `supercronic` process runs in the same Docker container and calls `http://localhost:PORT/api/cron/notify` on a schedule
+- This keeps the runner co-located with the DB volume, requires no separate infrastructure, and is testable with `curl`
+
+`CRON_SECRET` must be set in `fly.toml` secrets. The endpoint returns 401 if the header is missing or wrong, 200 with a JSON summary if the run succeeded.
+
+### Geographic Matching
+
+Listings already store an H3 index (`h3Index`). Subscriptions store a center cell (`centerH3`) at the appropriate H3 resolution for the chosen radius, and the radius in H3 ring distance (`ringSize`). Matching is: `h3.gridDisk(subscription.centerH3, subscription.ringSize).includes(listing.h3Index)`.
+
+H3 resolutions used (from `subscription-matcher.ts`):
+- Ring 0 (~1 mi radius): resolution 8
+- Ring 1–2 (~3–6 mi): resolution 7
+- Ring 3–6 (~10–30 mi): resolution 6
+
+### Location UX
+
+No map is required. After geocoding an address, show a text confirmation under the address field:
+
+> Searching within ~3 miles of Napa, CA 94558
+
+This gives users confidence that the system understood their location without requiring a Leaflet dependency. The geocoded place name (from Nominatim's `display_name`) is stored on the subscription for display.
+
+### Geocoding
+
+Nominatim (free, no API key) until rate-limited. Error handling:
+- 200 with empty results → return `null` (no match found)
+- 429 / 5xx → throw a typed `GeocodingError`; callers surface a retry message; Sentry captures the error with the queried address and response status
+
+### HMAC-Signed Unsubscribe URLs
+
+Every notification email includes a one-click unsubscribe link:
+
+```
+/api/notifications/{subscriptionId}/unsubscribe?sig={hmac}
+```
+
+The HMAC is computed over `subscriptionId` only — **not** `userId`. The server looks up the subscription owner from the DB using `subscriptionId`. This avoids embedding a stable internal identifier in every email.
+
+The `markListingUnavailable` action in listing emails uses a separate HMAC scoped to `{listingId}:{userId}` (the listing owner's ID), so only the owner can mark their own listing unavailable.
+
+### Subscription Limit
+
+Max 10 subscriptions per user, enforced atomically via a SQLite `BEFORE INSERT` trigger:
+
+```sql
+CREATE TRIGGER enforce_subscription_limit
+BEFORE INSERT ON notification_subscriptions
+BEGIN
+  SELECT RAISE(ABORT, 'subscription_limit_exceeded')
+  WHERE (SELECT COUNT(*) FROM notification_subscriptions
+         WHERE user_id = NEW.user_id AND deleted_at IS NULL) >= 10;
+END;
+```
+
+The API catches this error and returns a 422 with a user-facing message.
+
+### Idempotency
+
+The Resend idempotency key is based on the throttle window start time, not wall-clock date:
+
+```
+notify-{subscriptionId}-{throttlePeriod}-{windowStartEpochSeconds}
+```
+
+This survives midnight UTC rollover and cron retries within the same window.
+
+### Throttle Periods
+
+| Period | Label | Schedule | Meaning |
+|--------|-------|----------|---------|
+| `immediately` | Immediately | Hourly cron | Notify within ~1 hour of the listing being posted |
+| `weekly` | Weekly | Weekly cron (Monday 8am local TZ) | Digest of all matching listings from the past 7 days |
+
+A subscription is "due" when `lastNotifiedAt IS NULL OR lastNotifiedAt < windowStart`.
+
+The runner processes throttle periods **sequentially**, not in parallel, to avoid SQLite write contention.
+
+---
+
+## Pull Request Order
+
+### PR 1 — Data Foundation
+
+**Goal:** Subscriptions can be created and managed via API with no UI. The matching and signing logic is fully tested before any email is sent.
+
+**Files:**
+- `apps/www/src/data/schema.ts` — `notificationSubscriptions` table
+- `apps/www/drizzle/000N_add_notification_subscriptions.sql` — migration (generated)
+- `apps/www/src/lib/validation.ts` — `createSubscriptionSchema`, `updateSubscriptionSchema`
+- `apps/www/src/lib/hmac.ts` — `signUnsubscribeUrl`, `verifyUnsubscribeUrl` (no userId in URL)
+- `apps/www/src/lib/geocode.ts` — `geocodeAddress` with typed `GeocodingError` for 429/5xx
+- `apps/www/src/lib/subscription-matcher.ts` — `subscriptionMatchesListing`
+- `apps/www/src/lib/subscription-labels.ts` — human-readable throttle period labels
+- `apps/www/src/data/queries.ts` — `createSubscription`, `getSubscriptions`, `updateSubscription`, `deleteSubscription`, `getSubscriptionsDue`, `getAvailableListings`, `markSubscriptionNotified`
+- `apps/www/src/api/notifications.ts` — server functions wrapping the above queries
+- `apps/www/src/lib/env.server.ts` — add `HMAC_SECRET`, `CRON_SECRET`
+- Tests: `queries.notifications.test.ts`, `subscription-matcher.test.ts`, `hmac.test.ts`, `geocode.test.ts`, `validation.test.ts`
+
+**Schema:**
+```sql
+CREATE TABLE notification_subscriptions (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id     TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  label       TEXT,                    -- user-supplied name, optional
+  center_h3   TEXT NOT NULL,           -- H3 cell at chosen resolution
+  resolution  INTEGER NOT NULL,        -- H3 resolution (6, 7, or 8)
+  ring_size   INTEGER NOT NULL,        -- H3 gridDisk radius
+  place_name  TEXT NOT NULL,           -- geocoded display name for UI confirmation
+  produce_types TEXT,                  -- JSON array of slugs, NULL = all types
+  throttle_period TEXT NOT NULL CHECK (throttle_period IN ('immediately', 'weekly')),
+  last_notified_at INTEGER,            -- Unix epoch seconds
+  enabled     INTEGER NOT NULL DEFAULT 1,
+  created_at  INTEGER NOT NULL,
+  updated_at  INTEGER NOT NULL,
+  deleted_at  INTEGER
+);
+
+CREATE INDEX notification_subscriptions_user_id_idx
+  ON notification_subscriptions(user_id);
+CREATE INDEX notification_subscriptions_throttle_notified_idx
+  ON notification_subscriptions(throttle_period, last_notified_at)
+  WHERE deleted_at IS NULL AND enabled = 1;
+
+CREATE TRIGGER enforce_subscription_limit ...  -- see above
+```
+
+**Key constraints:**
+- `updateSubscription` must require `centerH3` and `resolution` together (never one without the other)
+- `getSubscriptionsDue` cutoff uses `Math.floor(cutoff.getTime() / 1000)` (integer epoch seconds)
+- The composite index must appear in **both** `schema.ts` and the migration (so `db:push` creates it)
+
+**Risks and mitigations:**
+
+| Risk | Mitigation |
+|------|-----------|
+| Migration is hard to undo in production | Review schema carefully before merging; test `db:migrate` in E2E environment |
+| Subscription limit race condition | SQLite `BEFORE INSERT` trigger (100% enforcement) |
+| `centerH3`/`resolution` mismatch on partial update | Validation schema rejects any update that includes one but not both |
+| Composite index missing from `db:push` dev environment | Add index to `schema.ts` Drizzle definition, not only migration SQL |
+| Geocoding 429/503 swallowed silently | `GeocodingError` type; Sentry capture with address + status in callers |
+
+**Testing approach:**
+- Integration tests against a real test DB (same pattern as `queries.notifications.test.ts`)
+- `subscription-matcher.test.ts`: `test.each` over boundary cells (in ring, on edge, outside)
+- `hmac.test.ts`: sign → verify round-trip; tampered sig rejected; different subscriptionId rejected
+- `geocode.test.ts`: 200+results, 200+empty, 429 throws `GeocodingError`, 500 throws `GeocodingError`, Sentry capture verified
+
+---
+
+### PR 2 — Notification Runner + Email
+
+**Goal:** Running the cron script against a seeded DB sends correctly-formatted emails. No UI required.
+
+**Files:**
+- `apps/www/src/lib/notification-runner.ts` — `runForThrottlePeriod`, `runAll`
+- `apps/www/src/lib/email-templates.ts` — `buildNotificationEmailSubject`, `buildNotificationEmailHtml`
+- `apps/www/src/routes/api/cron.notify.ts` — HTTP endpoint, validates `CRON_SECRET`, calls `runAll`
+- `apps/www/src/bin/notify.ts` — thin CLI wrapper for local dev / manual triggering
+- `apps/www/fly.toml` — `supercronic` process and cron schedule
+- `apps/www/Dockerfile` — install `supercronic`, add crontab
+- Tests: `notification-runner.test.ts`, `email-templates.notifications.test.ts`
+
+**Notification runner contract:**
+1. `getSubscriptionsDue(throttlePeriod, cutoff)` — returns subscriptions due for this period
+2. For each subscription: `getAvailableListings(limit: 500)` → filter via `subscriptionMatchesListing` → if matches, send email → `markSubscriptionNotified`
+3. Per-subscription errors are caught, reported to Sentry, and do not abort other subscriptions
+4. Returns a structured summary `{ period, sent, skipped, errors }`
+
+**Email:**
+- Subject: `"3 new produce listings near you"` (immediately) / `"3 produce listings near you this week"` (weekly)
+- Body includes listing title, location, poster name, link
+- Footer includes **both**: "Manage your notifications" link AND "Unsubscribe from this subscription" one-click link
+- `List-Unsubscribe` header present (RFC 8058)
+
+**Idempotency key:** `` `notify-${sub.id}-${throttlePeriod}-${windowStartEpochSeconds}` ``
+
+**HMAC fix:** `markListingUnavailable` in listing emails verifies `HMAC(listingId:userId)` and adds `AND listings.userId = :userId` to the update — same as delete-subscription pattern.
+
+**Key constraints:**
+- Run `immediately` and `weekly` periods sequentially (not `Promise.all`) — avoid SQLite write contention
+- Pass `limit: 500` to `getAvailableListings` as a safeguard; log a warning if the limit is hit
+- Malformed `produceTypes` in the DB → Sentry capture + **skip** the subscription (not match-all)
+
+**Risks and mitigations:**
+
+| Risk | Mitigation |
+|------|-----------|
+| Idempotency key resets at midnight UTC | Window-based key includes `windowStartEpochSeconds` |
+| Email flood if `markSubscriptionNotified` fails after send | Idempotency key covers 24h for Resend; window-based key prevents re-send within same window |
+| HMAC lets any subscriber mark a listing unavailable | HMAC message includes listing owner's `userId`; server verifies ownership |
+| SQLite `SQLITE_BUSY` from concurrent writes | Sequential throttle period processing |
+| Listing table grows beyond memory | `LIMIT 500`; log warning at limit; document as known constraint |
+| `HMAC_SECRET` rotation invalidates in-flight emails | Document in operator runbook: rotating the secret invalidates all existing unsubscribe links; users must re-receive email or unsubscribe via the UI |
+
+**Testing approach:**
+- `notification-runner.test.ts` against real test DB (seed subscriptions, seed listings, assert `sendEmail` calls)
+- Must include: "subscription notified 30 min ago is skipped by hourly runner" (the most important invariant)
+- Must include: "subscription with malformed produceTypes is skipped, not matched"
+- Mock the email sender (not the DB) — verify call arguments including unsubscribe URL
+- `email-templates.notifications.test.ts`: snapshot or structural assertion on HTML output; verify unsubscribe link present
+
+---
+
+### PR 3 — UI + E2E
+
+**Goal:** Users can manage subscriptions in the browser. E2E tests cover the full subscription → notification flow using `EMAIL_PROVIDER=console`.
+
+**Files:**
+- `apps/www/src/components/SubscriptionForm.tsx` and `.css`
+- `apps/www/src/components/ProduceTypeMultiSelect.tsx` and `Combobox.css`
+- `apps/www/src/routes/notifications/new.tsx` and `.css`
+- `apps/www/src/routes/notifications/index.tsx` and `.css`
+- `apps/www/src/routes/notifications/$id.edit.tsx` and `.css`
+- `apps/www/src/routes/notifications/unsubscribed.tsx`
+- `apps/www/src/routes/api/notifications.$id.unsubscribe.ts`
+- `apps/www/src/components/PageHeader.tsx` — add "Notifications" nav link
+- `apps/www/tests/e2e/notifications.test.ts`
+
+**Location UX (no map):**
+- Address search field with a "Search" button
+- After geocoding: show confirmation text below the field:
+  `Searching within ~3 miles of Napa, CA (Napa County, California)` (using Nominatim `display_name`)
+- This text is the same data used for matching — gives users direct confidence
+- Geocoding error states: "Could not find that address — try a nearby city" (no results) and "Location search is temporarily unavailable — try again in a moment" (429/5xx)
+
+**Accessibility requirements (from review):**
+- At the 10-subscription limit: render `<span>` (not `<Link>`) for "Add a subscription" — not navigable
+- `<Input type="email">` (not `type="url"`) for the "Deliver to" field; `value={user()?.email ?? ''}`
+- Range slider: `aria-valuetext={RING_SIZE_LABELS[ringSize()]}` + `aria-describedby` on the value label
+- Delete confirmation: focus first confirmation button when confirmation panel appears; restore focus to "Delete" when cancelled
+- `<label for="...">` on ProduceTypeMultiSelect pointing to the combobox input id
+- Empty state on `/notifications`: descriptive `<p>` with context, not just "No subscriptions yet."
+
+**Unsubscribe flow:**
+- `GET /api/notifications/{id}/unsubscribe?sig={hmac}` verifies signature, deletes (idempotent), redirects to `/notifications/unsubscribed`
+- `/notifications/unsubscribed` copy is accurate for both fresh delete and already-deleted cases: "You are not subscribed to this notification."
+
+**Risks and mitigations:**
+
+| Risk | Mitigation |
+|------|-----------|
+| Nominatim rate limit breaks address search in high-traffic demo | Sentry alert on `GeocodingError`; graceful error message; document plan to switch provider |
+| Geocoded result shown in UI differs from what's matched | Confirmation text is derived from the same `centerH3`/`resolution` stored on the subscription — not a re-geocode |
+| E2E tests flaky on timing (geocode, email) | Stub Nominatim in E2E; use `EMAIL_PROVIDER=console` and parse log output for unsubscribe URL |
+
+**Testing approach:**
+- E2E: create subscription → verify it appears in list → trigger cron endpoint directly → verify email logged to console → follow unsubscribe URL → verify subscription removed
+- Stub Nominatim responses with a fixture (no real HTTP in E2E)
+- Test the at-limit state: create 10 subscriptions → verify "Add a subscription" is not a link
+
+---
+
+## Known Gaps / Deferred
+
+- Daily throttle period (add `daily` to the `CHECK` constraint and runner when needed)
+- Geographic index on listings for server-side radius filter (current approach loads up to 500 listings into memory)
+- Key rotation strategy for `HMAC_SECRET` (operator runbook documents the tradeoff)
+- Interactive map for subscription coverage visualization
+
+## Environment Variables
+
+| Variable | Required in prod | Purpose |
+|----------|-----------------|---------|
+| `HMAC_SECRET` | Yes | Signs unsubscribe and mark-unavailable URLs |
+| `CRON_SECRET` | Yes | Authenticates `POST /api/cron/notify` requests |
+| `NOMINATIM_USER_AGENT` | Yes | Required by Nominatim ToS (app name + contact) |

--- a/docs/0005-notifications.md
+++ b/docs/0005-notifications.md
@@ -40,9 +40,23 @@ This gives users confidence that the system understood their location without re
 
 ### Geocoding
 
-Nominatim (free, no API key) until rate-limited. Error handling:
-- 200 with empty results → return `null` (no match found)
-- 429 / 5xx → throw a typed `GeocodingError`; callers surface a retry message; Sentry captures the error with the queried address and response status
+Nominatim (free, no API key) until rate-limited. The existing `apps/www/src/lib/geocoding.ts` handles listing creation; the notifications branch had a separate `geocode.ts` with a simpler string-query interface and AbortSignal support but swallowed 429/5xx as `null`. These are combined into `geocoding.ts` in PR 1.
+
+Combined `geocoding.ts` design:
+- Accepts either `GeocodingInput` (structured, for listing creation) or a plain string query (for the subscription form search)
+- 10-second timeout + optional caller-supplied `AbortSignal`
+- 200 with empty results → returns `null`
+- 429 / 5xx → throws `GeocodingError`; callers surface a retry message; Sentry captures the error with the queried address and HTTP status
+- User-Agent from `NOMINATIM_USER_AGENT` env var (required; Nominatim ToS requires an identifying contact)
+
+```ts
+export class GeocodingError extends Error {
+  constructor(public readonly status: number, address: string) {
+    super(`Geocoding failed (HTTP ${status}) for: ${address}`)
+    this.name = 'GeocodingError'
+  }
+}
+```
 
 ### HMAC-Signed Unsubscribe URLs
 
@@ -103,16 +117,16 @@ The runner processes throttle periods **sequentially**, not in parallel, to avoi
 
 **Files:**
 - `apps/www/src/data/schema.ts` — `notificationSubscriptions` table
-- `apps/www/drizzle/000N_add_notification_subscriptions.sql` — migration (generated)
+- `apps/www/drizzle/0007_add_notification_subscriptions.sql` — migration (generated; main is at 0006)
 - `apps/www/src/lib/validation.ts` — `createSubscriptionSchema`, `updateSubscriptionSchema`
 - `apps/www/src/lib/hmac.ts` — `signUnsubscribeUrl`, `verifyUnsubscribeUrl` (no userId in URL)
-- `apps/www/src/lib/geocode.ts` — `geocodeAddress` with typed `GeocodingError` for 429/5xx
+- `apps/www/src/lib/geocoding.ts` — combine existing structured-input version with notifications branch's string-query + AbortSignal version; add `GeocodingError`, timeout, env-var User-Agent
 - `apps/www/src/lib/subscription-matcher.ts` — `subscriptionMatchesListing`
 - `apps/www/src/lib/subscription-labels.ts` — human-readable throttle period labels
 - `apps/www/src/data/queries.ts` — `createSubscription`, `getSubscriptions`, `updateSubscription`, `deleteSubscription`, `getSubscriptionsDue`, `getAvailableListings`, `markSubscriptionNotified`
 - `apps/www/src/api/notifications.ts` — server functions wrapping the above queries
 - `apps/www/src/lib/env.server.ts` — add `HMAC_SECRET`, `CRON_SECRET`
-- Tests: `queries.notifications.test.ts`, `subscription-matcher.test.ts`, `hmac.test.ts`, `geocode.test.ts`, `validation.test.ts`
+- Tests: `queries.notifications.test.ts`, `subscription-matcher.test.ts`, `hmac.test.ts`, `geocoding.test.ts`, `validation.test.ts`
 
 **Schema:**
 ```sql
@@ -155,13 +169,13 @@ CREATE TRIGGER enforce_subscription_limit ...  -- see above
 | Subscription limit race condition | SQLite `BEFORE INSERT` trigger (100% enforcement) |
 | `centerH3`/`resolution` mismatch on partial update | Validation schema rejects any update that includes one but not both |
 | Composite index missing from `db:push` dev environment | Add index to `schema.ts` Drizzle definition, not only migration SQL |
-| Geocoding 429/503 swallowed silently | `GeocodingError` type; Sentry capture with address + status in callers |
+| Geocoding 429/5xx swallowed silently (bug in notifications branch) | `GeocodingError` thrown; callers capture to Sentry with address + status |
 
 **Testing approach:**
 - Integration tests against a real test DB (same pattern as `queries.notifications.test.ts`)
 - `subscription-matcher.test.ts`: `test.each` over boundary cells (in ring, on edge, outside)
 - `hmac.test.ts`: sign → verify round-trip; tampered sig rejected; different subscriptionId rejected
-- `geocode.test.ts`: 200+results, 200+empty, 429 throws `GeocodingError`, 500 throws `GeocodingError`, Sentry capture verified
+- `geocoding.test.ts`: 200+results, 200+empty returns `null`, 429 throws `GeocodingError`, 500 throws `GeocodingError`, AbortSignal cancels in-flight request, Sentry capture verified for error cases
 
 ---
 
@@ -174,8 +188,9 @@ CREATE TRIGGER enforce_subscription_limit ...  -- see above
 - `apps/www/src/lib/email-templates.ts` — `buildNotificationEmailSubject`, `buildNotificationEmailHtml`
 - `apps/www/src/routes/api/cron.notify.ts` — HTTP endpoint, validates `CRON_SECRET`, calls `runAll`
 - `apps/www/src/bin/notify.ts` — thin CLI wrapper for local dev / manual triggering
-- `apps/www/fly.toml` — `supercronic` process and cron schedule
-- `apps/www/Dockerfile` — install `supercronic`, add crontab
+- `apps/www/fly.toml` — `supercronic` process and `NOTIFY_CRON_SCHEDULE` secret
+- `apps/www/Dockerfile` — install `supercronic`, add crontab driven by `NOTIFY_CRON_SCHEDULE`
+- `.env.development` — `NOTIFY_CRON_SCHEDULE=* * * * *` (every minute in dev)
 - Tests: `notification-runner.test.ts`, `email-templates.notifications.test.ts`
 
 **Notification runner contract:**
@@ -277,8 +292,9 @@ CREATE TRIGGER enforce_subscription_limit ...  -- see above
 
 ## Environment Variables
 
-| Variable | Required in prod | Purpose |
-|----------|-----------------|---------|
-| `HMAC_SECRET` | Yes | Signs unsubscribe and mark-unavailable URLs |
-| `CRON_SECRET` | Yes | Authenticates `POST /api/cron/notify` requests |
-| `NOMINATIM_USER_AGENT` | Yes | Required by Nominatim ToS (app name + contact) |
+| Variable | Required in prod | Dev default | Purpose |
+|----------|-----------------|-------------|---------|
+| `HMAC_SECRET` | Yes | — | Signs unsubscribe and mark-unavailable URLs |
+| `CRON_SECRET` | Yes | — | Authenticates `POST /api/cron/notify` requests |
+| `NOMINATIM_USER_AGENT` | Yes | — | Required by Nominatim ToS (app name + contact email) |
+| `NOTIFY_CRON_SCHEDULE` | Yes | `* * * * *` | crontab schedule for `supercronic`; prod uses `0 * * * *` (hourly) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add notifications index and new routes with authenticated create+list subscription UX
- add `SubscriptionForm` and `subscription-draft` helper for geocode->payload flow and location confirmation text
- add notifications nav entry in page header
- add outer-loop Playwright e2e test for create->list flow and inner-loop unit test for draft helpers

## Testing
- `pnpm --filter @pickmyfruit/www test:run tests/subscription-draft.test.ts`
- `pnpm --filter @pickmyfruit/www test:e2e tests/e2e/notifications.test.ts`
- `pnpm --filter @pickmyfruit/www typecheck`
- `pnpm --filter @pickmyfruit/www lint`
- `bash bin/code-quality.sh`

## Walkthrough artifacts
[notifications_create_and_list_flow.mp4](https://cursor.com/agents/bc-20f3889a-5341-4195-b72e-964ce43538d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnotifications_create_and_list_flow.mp4)
[Notifications list after creating a subscription](https://cursor.com/agents/bc-20f3889a-5341-4195-b72e-964ce43538d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnotifications_list_after_create.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20f3889a-5341-4195-b72e-964ce43538d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20f3889a-5341-4195-b72e-964ce43538d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

