### PR TITLE
Handle HEIC photo uploads gracefully (PICKMYFRUIT-15)

### DIFF
--- a/apps/www/src/components/ListingPhotosSection.tsx
+++ b/apps/www/src/components/ListingPhotosSection.tsx
@@ -5,8 +5,10 @@ import { addPhotoToListing, deletePhoto } from '@/api/listing-photos'
 import {
 	LISTING_PHOTO_ACCEPT,
 	MAX_PHOTOS_PER_LISTING,
+	validateListingPhotoFile,
 } from '@/lib/listing-photos'
 import { Sentry } from '@/lib/sentry'
+import { UserError } from '@/lib/user-error'
 import type { PublicPhoto } from '@/data/listing'
 import { createErrorSignal, ErrorMessage } from '@/components/ErrorMessage'
 
@@ -46,6 +48,12 @@ export default function ListingPhotosSection(props: {
 			setError(new Error('Maximum number of photos reached'))
 			return
 		}
+		const rejectionMessage = validateListingPhotoFile(file)
+		if (rejectionMessage) {
+			setError(new UserError('INVALID_PHOTO', rejectionMessage))
+			fileInputRef.value = ''
+			return
+		}
 		setUploading(true)
 		setAnnouncement('Uploading photo…')
 		setError(null)
@@ -58,12 +66,41 @@ export default function ListingPhotosSection(props: {
 			setAnnouncement('Photo uploaded')
 			await router.invalidate()
 		} catch (err) {
-			Sentry.captureException(err)
 			setAnnouncement('')
-			setError(err)
+			if (isOpaqueUploadError(err)) {
+				// "Invariant failed" is thrown by TanStack Start's fetcher when the
+				// response is missing a content-type header, which happens when a
+				// proxy rejects the request (e.g. 413 Payload Too Large with an
+				// empty body). Capture to Sentry with file context so we can tell
+				// whether users are hitting edge limits, and show a helpful
+				// fallback instead of leaking the internal invariant message.
+				Sentry.captureException(err, {
+					extra: {
+						context: 'listing-photo-upload',
+						fileName: file.name,
+						fileType: file.type,
+						fileSize: file.size,
+					},
+				})
+				setError(
+					new Error(
+						'We couldn’t upload that photo. Please try a smaller JPEG, PNG, or WebP.'
+					)
+				)
+			} else {
+				// Server-thrown UserError messages (e.g. INVALID_MIME_TYPE) are
+				// already user-safe; surface them as-is.
+				setError(err)
+			}
 		} finally {
 			setUploading(false)
 		}
+	}
+
+	function isOpaqueUploadError(err: unknown): boolean {
+		if (err instanceof UserError) return false
+		const message = err instanceof Error ? err.message : ''
+		return /invariant failed/i.test(message)
 	}
 
 	async function removePhoto(photoId: string) {

--- a/apps/www/src/lib/listing-photos.ts
+++ b/apps/www/src/lib/listing-photos.ts
@@ -14,8 +14,13 @@ export const MAX_PHOTOS_PER_LISTING = 3
 export const LISTING_PHOTO_MAX_BYTES = 5 * 1024 * 1024
 
 /**
- * HTML `accept` attribute value for listing photo file inputs — only supported
- * image MIME types.
+ * HTML `accept` attribute value for listing photo file inputs. Limited to
+ * supported MIME types — crucially, we do NOT include `image/heic` or
+ * `image/heif`. On iOS, when a file input's `accept` list contains only
+ * JPEG/PNG/WebP, Safari's photo picker transcodes the selected photo to JPEG
+ * automatically, so HEIC never reaches us. If we added `image/heic` here the
+ * picker would keep the original HEIC (which we can't decode without a paid
+ * license). See: https://bugs.webkit.org/show_bug.cgi?id=(WebKit photo picker).
  */
 export const LISTING_PHOTO_ACCEPT = LISTING_PHOTO_MIME_TYPES.join(',')
 
@@ -33,4 +38,41 @@ export function listingPhotoExtensionForMime(
 		default:
 			return null
 	}
+}
+
+/**
+ * Validates a file chosen by the user before upload. Returns a user-facing
+ * error message if the file is rejected, or null if it is acceptable.
+ *
+ * This is a client-side pre-check that mirrors the server's checks. Its
+ * purpose is UX: catching obvious problems (HEIC photos, oversized files)
+ * locally gives a clear error instead of making the user wait for a round
+ * trip — and avoids hitting edge-level request limits that can produce
+ * opaque proxy errors.
+ */
+export function validateListingPhotoFile(file: File): string | null {
+	if (isLikelyHeicFile(file)) {
+		return 'HEIC photos (from iPhone) aren’t supported. In your iPhone Settings → Camera → Formats, choose “Most Compatible” and take a new photo, or export this one as JPEG first.'
+	}
+	if (file.size > LISTING_PHOTO_MAX_BYTES) {
+		return 'Photo must be 5 MB or smaller. Try a lower-resolution version.'
+	}
+	return null
+}
+
+/**
+ * Heuristically detects HEIC/HEIF files by MIME type and extension. iOS Safari
+ * sometimes reports an empty `type` for HEIC files, so the extension check
+ * is the primary signal.
+ */
+export function isLikelyHeicFile(file: {
+	name: string
+	type: string
+}): boolean {
+	const type = file.type.toLowerCase()
+	if (type === 'image/heic' || type === 'image/heif') return true
+	if (type === 'image/heic-sequence' || type === 'image/heif-sequence')
+		return true
+	const lowerName = file.name.toLowerCase()
+	return /\.(heic|heif)$/.test(lowerName)
 }

--- a/apps/www/tests/listing-photos.test.ts
+++ b/apps/www/tests/listing-photos.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import {
+	isLikelyHeicFile,
+	LISTING_PHOTO_MAX_BYTES,
+	validateListingPhotoFile,
+} from '../src/lib/listing-photos'
+
+function makeFile(opts: { name: string; type: string; size?: number }): File {
+	const byteLength = opts.size ?? 4
+	// File.size reflects the blob's byte length — allocate an ArrayBuffer rather
+	// than a large string so tests don't allocate megabytes of content.
+	const data = new Uint8Array(byteLength)
+	return new File([data], opts.name, { type: opts.type })
+}
+
+describe('isLikelyHeicFile', () => {
+	it.each([
+		{ name: 'IMG_1234.HEIC', type: '' },
+		{ name: 'IMG_1234.heic', type: 'image/heic' },
+		{ name: 'IMG_1234.heif', type: 'image/heif' },
+		{ name: 'photo.heic', type: 'application/octet-stream' },
+		{ name: 'photo.HEIF', type: '' },
+		{ name: 'burst.heic-sequence', type: 'image/heic-sequence' },
+	])('detects HEIC/HEIF: %o', (f) => {
+		expect(isLikelyHeicFile(f)).toBe(true)
+	})
+
+	it.each([
+		{ name: 'photo.jpg', type: 'image/jpeg' },
+		{ name: 'photo.png', type: 'image/png' },
+		{ name: 'photo.webp', type: 'image/webp' },
+		{ name: 'heicpedia.jpg', type: 'image/jpeg' },
+	])('passes through supported formats: %o', (f) => {
+		expect(isLikelyHeicFile(f)).toBe(false)
+	})
+})
+
+describe('validateListingPhotoFile', () => {
+	it('returns null for a small JPEG', () => {
+		expect(
+			validateListingPhotoFile(
+				makeFile({ name: 'a.jpg', type: 'image/jpeg', size: 1024 })
+			)
+		).toBeNull()
+	})
+
+	it('returns a HEIC-specific message for HEIC files', () => {
+		const msg = validateListingPhotoFile(
+			makeFile({ name: 'IMG_1234.HEIC', type: '', size: 1024 })
+		)
+		expect(msg).toMatch(/HEIC/i)
+	})
+
+	it('returns a size message for files larger than the limit', () => {
+		const msg = validateListingPhotoFile(
+			makeFile({
+				name: 'big.jpg',
+				type: 'image/jpeg',
+				size: LISTING_PHOTO_MAX_BYTES + 1,
+			})
+		)
+		expect(msg).toMatch(/5 MB/)
+	})
+
+	it('accepts a file exactly at the size limit', () => {
+		expect(
+			validateListingPhotoFile(
+				makeFile({
+					name: 'max.jpg',
+					type: 'image/jpeg',
+					size: LISTING_PHOTO_MAX_BYTES,
+				})
+			)
+		).toBeNull()
+	})
+
+	it('prefers the HEIC message over the size message', () => {
+		const msg = validateListingPhotoFile(
+			makeFile({
+				name: 'big.heic',
+				type: 'image/heic',
+				size: LISTING_PHOTO_MAX_BYTES + 1,
+			})
+		)
+		expect(msg).toMatch(/HEIC/i)
+	})
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Sentry issue [PICKMYFRUIT-15](https://confident-technology.sentry.io/issues/PICKMYFRUIT-15) is an iPhone user hitting `Error: Invariant failed` on `/listings/14` while uploading a listing photo. The underlying cause is almost certainly a HEIC image: the server rejects non-JPEG/PNG/WebP uploads, but the client surfaces a cryptic message that comes from TanStack Start's internal fetcher (`invariant(contentType, "expected content-type header to be set")`).

## Walkthrough

[demo_heic_rejection.mp4](https://cursor.com/agents/bc-aa80e6e2-c942-41a8-8338-e1c40b272cae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_heic_rejection.mp4)

Selecting a `.HEIC` file instantly shows a friendly, actionable error — no network round-trip, no leaked "Invariant failed" message.

[HEIC rejected with friendly message](https://cursor.com/agents/bc-aa80e6e2-c942-41a8-8338-e1c40b272cae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_heic_rejected.png)
[Real JPEG still uploads successfully](https://cursor.com/agents/bc-aa80e6e2-c942-41a8-8338-e1c40b272cae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_real_jpeg_upload.png)

## Approach

Addresses all three suggestions from the issue:

1. **iOS picker behavior.** Our `<input type="file" accept="image/jpeg,image/png,image/webp">` already does the right thing on iOS 17+: when HEIC is *not* in the accept list, Safari's photo picker transcodes the selected image to JPEG automatically. Adding `image/heic` would break that behavior. A comment on `LISTING_PHOTO_ACCEPT` now captures this, so we don't "helpfully" add HEIC later.
2. **Client-side HEIC detection.** New `isLikelyHeicFile()` and `validateListingPhotoFile()` reject HEIC/HEIF files (and oversized files) before upload with a friendly, actionable message. HEIC is detected by MIME type *and* `.heic`/`.heif` extension, since iOS Safari sometimes reports an empty `File.type`. This is a safety net for the paths where the picker leaks HEIC through (e.g. "Choose Files" → third-party file provider, or non-iOS browsers).
3. **Better error for opaque failures.** `ListingPhotosSection.upload()` now distinguishes server-thrown `UserError`s (pass through as-is) from TanStack Start's opaque `"Invariant failed"` — the latter are reported to Sentry with `{ fileName, fileType, fileSize }` extras and replaced with "We couldn't upload that photo. Please try a smaller JPEG, PNG, or WebP." so the user never sees the internal invariant message again.

## Changes

- `apps/www/src/lib/listing-photos.ts` — `isLikelyHeicFile()`, `validateListingPhotoFile()`, accept-list doc comment.
- `apps/www/src/components/ListingPhotosSection.tsx` — call the validator before upload; handle opaque errors with Sentry context + friendly fallback message.
- `apps/www/tests/listing-photos.test.ts` — unit coverage for the new validators.

## Testing

- ✅ `bash bin/code-quality.sh` — typecheck, lint, unit tests (all pass), format
- ✅ `pnpm vitest run tests/listing-photos.test.ts` — 15 new tests pass
- ✅ Manual: selecting `IMG_1234.HEIC` shows the HEIC message immediately (no network call). See demo video above.
- ✅ Manual: uploading a real 75 KB JPEG (`tests/fixtures/flower-bees.jpg`) still works end-to-end.

Fixes PICKMYFRUIT-15


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa80e6e2-c942-41a8-8338-e1c40b272cae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa80e6e2-c942-41a8-8338-e1c40b272cae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

