### PR TITLE
refactor(css): introduce reusable .button / .button--primary / .button--ghost

### DIFF
--- a/apps/www/src/components/InquiryForm.css
+++ b/apps/www/src/components/InquiryForm.css
@@ -28,28 +28,6 @@
 		color: var(--color-quiet);
 	}
 
-	.inquiry-submit {
-		width: 100%;
-		padding: 14px 28px;
-		background: var(--color-primary);
-		color: var(--color-background);
-		border: none;
-		border-radius: 8px;
-		font-size: 16px;
-		font-weight: 600;
-		cursor: pointer;
-		transition: background-color 0.2s;
-	}
-
-	.inquiry-submit:hover:not(:disabled) {
-		background: oklch(from var(--color-primary) calc(l - 0.08) c h);
-	}
-
-	.inquiry-submit:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
 	.name-interstitial h3 {
 		font-size: 20px;
 		font-weight: 600;
@@ -81,10 +59,6 @@
 		flex-direction: column;
 		gap: 12px;
 		align-items: flex-start;
-	}
-
-	.name-interstitial-actions .inquiry-submit {
-		width: 100%;
 	}
 
 	.name-interstitial-skip {

--- a/apps/www/src/components/InquiryForm.tsx
+++ b/apps/www/src/components/InquiryForm.tsx
@@ -246,7 +246,7 @@ export default function InquiryForm(props: InquiryFormProps) {
 									maxlength={100}
 								/>
 								<div class="name-interstitial-actions">
-									<button type="submit" class="inquiry-submit">
+									<button type="submit" class="button button--primary button--block">
 										Update name &amp; send inquiry
 									</button>
 									<button
@@ -324,7 +324,7 @@ export default function InquiryForm(props: InquiryFormProps) {
 
 					<button
 						type="submit"
-						class="inquiry-submit"
+						class="button button--primary button--block"
 						disabled={formState() === 'submitting'}
 					>
 						{formState() === 'submitting' ? 'Sending…' : 'Put me in touch'}

--- a/apps/www/src/components/ListingForm.css
+++ b/apps/www/src/components/ListingForm.css
@@ -43,46 +43,6 @@
 		margin-top: 32px;
 	}
 
-	.form-actions .submit-button {
-		background: var(--color-primary);
-		color: var(--color-background);
-		padding: 14px 28px;
-		border-radius: 8px;
-		border: none;
-		font-weight: 600;
-		font-size: 16px;
-		cursor: pointer;
-		transition: background-color 0.2s;
-	}
-
-	.form-actions .submit-button:hover:not(:disabled) {
-		background: oklch(from var(--color-primary) calc(l - 0.08) c h);
-	}
-
-	.form-actions .submit-button:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	.form-actions .cancel-button {
-		background: transparent;
-		color: var(--color-quiet);
-		padding: 14px 28px;
-		border-radius: 8px;
-		border: 1px solid oklch(from var(--color-quiet) l calc(c * 0.3) h);
-		font-weight: 500;
-		font-size: 16px;
-		cursor: pointer;
-		transition:
-			border-color 0.2s,
-			color 0.2s;
-	}
-
-	.form-actions .cancel-button:hover {
-		border-color: var(--color-foreground);
-		color: var(--color-foreground);
-	}
-
 	.form-message {
 		padding: 16px;
 		border-radius: 8px;

--- a/apps/www/src/components/ListingForm.tsx
+++ b/apps/www/src/components/ListingForm.tsx
@@ -313,10 +313,14 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 				</fieldset>
 
 				<div class="form-actions">
-					<button type="submit" class="submit-button" disabled={isSubmitting()}>
+					<button
+						type="submit"
+						class="button button--primary"
+						disabled={isSubmitting()}
+					>
 						{isSubmitting() ? 'Submitting…' : 'Share my produce'}
 					</button>
-					<Link to="/" class="cancel-button">
+					<Link to="/" class="button button--ghost">
 						Cancel
 					</Link>
 				</div>

--- a/apps/www/src/components/MagicLinkWaiting.css
+++ b/apps/www/src/components/MagicLinkWaiting.css
@@ -61,27 +61,6 @@
 		outline: none;
 	}
 
-	.magic-link-waiting .verify-button {
-		padding: 10px 16px;
-		background: var(--color-primary);
-		color: var(--color-background);
-		border: none;
-		border-radius: 6px;
-		font-weight: 600;
-		font-size: 14px;
-		cursor: pointer;
-		white-space: nowrap;
-	}
-
-	.magic-link-waiting .verify-button:hover:not(:disabled) {
-		background: oklch(from var(--color-primary) calc(l - 0.08) c h);
-	}
-
-	.magic-link-waiting .verify-button:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
 	.magic-link-waiting .token-error {
 		margin-top: 8px;
 	}
@@ -117,24 +96,5 @@
 
 	.magic-link-waiting .resend-error {
 		text-align: center;
-	}
-
-	.magic-link-waiting .cancel-button {
-		padding: 12px;
-		background: transparent;
-		color: var(--color-quiet);
-		border: 1px solid oklch(from var(--color-quiet) l calc(c * 0.3) h);
-		border-radius: 8px;
-		font-size: 14px;
-		font-weight: 500;
-		cursor: pointer;
-		transition:
-			border-color 0.2s,
-			color 0.2s;
-	}
-
-	.magic-link-waiting .cancel-button:hover {
-		border-color: var(--color-foreground);
-		color: var(--color-foreground);
 	}
 }

--- a/apps/www/src/components/MagicLinkWaiting.tsx
+++ b/apps/www/src/components/MagicLinkWaiting.tsx
@@ -65,7 +65,11 @@ export default function MagicLinkWaiting(props: MagicLinkWaitingProps) {
 						placeholder="Paste token here"
 						disabled={isVerifying()}
 					/>
-					<button type="submit" class="verify-button" disabled={isVerifying()}>
+					<button
+						type="submit"
+						class="button button--primary button--sm"
+						disabled={isVerifying()}
+					>
 						{isVerifying() ? 'Verifying…' : 'Verify'}
 					</button>
 				</div>
@@ -101,7 +105,11 @@ export default function MagicLinkWaiting(props: MagicLinkWaitingProps) {
 					defaultMessage="Failed to resend. Please try again."
 					error={resendError()}
 				/>
-				<button type="button" class="cancel-button" onClick={props.onCancel}>
+				<button
+					type="button"
+					class="button button--ghost button--block"
+					onClick={props.onCancel}
+				>
 					Use different email
 				</button>
 			</div>

--- a/apps/www/src/components/button.css
+++ b/apps/www/src/components/button.css
@@ -1,0 +1,83 @@
+/**
+ * CSS-first reusable button. Applies equally to <button> and <a>; pick a
+ * variant class (e.g. .button--primary) and optionally a size modifier.
+ *
+ * Variants:
+ *   .button--primary  Solid filled button using --color-primary.
+ *   .button--ghost    Outlined secondary/cancel button on transparent bg.
+ *
+ * Size modifiers (default is comfortable mid-size):
+ *   .button--sm       Compact (matches inline tool-row buttons).
+ *   .button--lg       Hero CTA size.
+ *   .button--block    Full-width (for column-stacked forms).
+ */
+@layer components {
+	.button {
+		--_button-bg: transparent;
+		--_button-fg: currentColor;
+		--_button-border-color: transparent;
+		--_button-px: 28px;
+		--_button-py: 14px;
+		--_button-font-size: 16px;
+
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+
+		background: var(--_button-bg);
+		color: var(--_button-fg);
+		border: 1px solid var(--_button-border-color);
+		border-radius: 8px;
+		padding: var(--_button-py) var(--_button-px);
+		font-size: var(--_button-font-size);
+		font-weight: 600;
+		line-height: 1.2;
+		text-decoration: none;
+		cursor: pointer;
+		transition:
+			background-color 0.2s,
+			border-color 0.2s,
+			color 0.2s;
+	}
+
+	.button:is(:disabled, [aria-disabled='true']) {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.button--primary {
+		--_button-bg: var(--color-primary);
+		--_button-fg: var(--color-background);
+	}
+
+	.button--primary:hover:not(:disabled, [aria-disabled='true']) {
+		--_button-bg: oklch(from var(--color-primary) calc(l - 0.08) c h);
+	}
+
+	.button--ghost {
+		--_button-fg: var(--color-quiet);
+		--_button-border-color: oklch(from var(--color-quiet) l calc(c * 0.3) h);
+	}
+
+	.button--ghost:hover:not(:disabled, [aria-disabled='true']) {
+		--_button-fg: var(--color-foreground);
+		--_button-border-color: var(--color-foreground);
+	}
+
+	.button--sm {
+		--_button-py: 10px;
+		--_button-px: 16px;
+		--_button-font-size: 14px;
+	}
+
+	.button--lg {
+		--_button-py: 16px;
+		--_button-px: 32px;
+	}
+
+	.button--block {
+		display: flex;
+		width: 100%;
+	}
+}

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import '../styles/base.css'
 import '../styles/colors.css'
 import '../styles/focus.css'
 import '../styles/surfaces.css'
+import '../components/button.css'
 
 export const Route = createRootRoute({
 	beforeLoad: async () => {

--- a/apps/www/src/routes/about.tsx
+++ b/apps/www/src/routes/about.tsx
@@ -67,7 +67,7 @@ function AboutPage() {
 					</section>
 
 					<section class="about-ctas">
-						<Link to="/listings/new" class="cta-button">
+						<Link to="/listings/new" class="button button--primary button--lg">
 							List My Fruit Tree
 						</Link>
 						<p class="contact-cta">

--- a/apps/www/src/routes/index.css
+++ b/apps/www/src/routes/index.css
@@ -24,24 +24,6 @@
 			line-height: 1.5;
 		}
 
-		& .cta-button {
-			display: inline-block;
-			background: var(--color-primary);
-			color: var(--color-background);
-			padding: 16px 32px;
-			border-radius: 8px;
-			border: none;
-			text-decoration: none;
-			font-weight: 600;
-			font-size: 16px;
-			transition: background-color 0.2s;
-			cursor: pointer;
-		}
-
-		& .cta-button:hover {
-			background: oklch(from var(--color-primary) calc(l - 0.08) c h);
-		}
-
 		/* How It Works Section */
 		& .how-it-works {
 			padding: 80px 0;

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -65,7 +65,7 @@ function HomePage() {
 								<br />
 								Starting in Napa and available everywhere.
 							</p>
-							<Link to="/listings/new" class="cta-button">
+							<Link to="/listings/new" class="button button--primary button--lg">
 								Share What I'm Growing
 							</Link>
 						</div>
@@ -91,7 +91,7 @@ function HomePage() {
 									<p>Surplus feeds families</p>
 								</div>
 							</div>
-							<Link to="/listings/new" class="cta-button">
+							<Link to="/listings/new" class="button button--primary button--lg">
 								Add a Listing
 							</Link>
 						</div>

--- a/apps/www/src/routes/listings/mine.css
+++ b/apps/www/src/routes/listings/mine.css
@@ -51,22 +51,6 @@
 			margin-top: 32px;
 		}
 
-		& .add-button {
-			display: inline-block;
-			background: var(--color-primary);
-			color: var(--color-background);
-			padding: 14px 28px;
-			border-radius: 8px;
-			font-weight: 600;
-			font-size: 16px;
-			text-decoration: none;
-			transition: background-color 0.2s;
-
-			&:hover {
-				background: oklch(from var(--color-primary) calc(l - 0.08) c h);
-			}
-		}
-
 		@media (max-width: 600px) {
 			& .listings-grid {
 				grid-template-columns: 1fr;

--- a/apps/www/src/routes/listings/mine.tsx
+++ b/apps/www/src/routes/listings/mine.tsx
@@ -29,7 +29,7 @@ function EmptyState() {
 		<div class="empty-state">
 			<h2>No listings yet</h2>
 			<p>Share something from your garden with the community!</p>
-			<Link to="/listings/new" class="add-button">
+			<Link to="/listings/new" class="button button--primary">
 				Add a Listing
 			</Link>
 		</div>
@@ -59,7 +59,7 @@ function MyGardenPage() {
 					</div>
 
 					<div class="page-actions">
-						<Link to="/listings/new" class="add-button">
+						<Link to="/listings/new" class="button button--primary">
 							Add Another Tree
 						</Link>
 					</div>

--- a/apps/www/src/routes/login.css
+++ b/apps/www/src/routes/login.css
@@ -41,28 +41,6 @@
 		gap: 20px;
 	}
 
-	.login-form .submit-button {
-		width: 100%;
-		padding: 14px;
-		background: var(--color-primary);
-		color: var(--color-background);
-		border: none;
-		border-radius: 8px;
-		font-size: 16px;
-		font-weight: 600;
-		cursor: pointer;
-		transition: background-color 0.2s;
-	}
-
-	.login-form .submit-button:hover:not(:disabled) {
-		background: oklch(from var(--color-primary) calc(l - 0.08) c h);
-	}
-
-	.login-form .submit-button:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
 	.login-footer {
 		margin-top: 24px;
 		font-size: 14px;

--- a/apps/www/src/routes/login.tsx
+++ b/apps/www/src/routes/login.tsx
@@ -130,7 +130,11 @@ function LoginPage() {
 									name="email"
 								/>
 
-								<button type="submit" class="submit-button" disabled={isSubmitting()}>
+								<button
+									type="submit"
+									class="button button--primary button--block"
+									disabled={isSubmitting()}
+								>
 									{isSubmitting() ? 'Sending…' : 'Send sign-in link'}
 								</button>
 							</form>

--- a/apps/www/src/routes/profile.css
+++ b/apps/www/src/routes/profile.css
@@ -28,26 +28,5 @@
 			gap: 12px;
 			align-items: center;
 		}
-
-		& .submit-button {
-			background: var(--color-primary);
-			color: var(--color-background);
-			border: none;
-			padding: 12px 24px;
-			border-radius: 8px;
-			font-size: 16px;
-			font-weight: 600;
-			cursor: pointer;
-			transition: background-color 0.2s;
-
-			&:hover:not(:disabled) {
-				background: oklch(from var(--color-primary) calc(l - 0.08) c h);
-			}
-
-			&:disabled {
-				opacity: 0.6;
-				cursor: not-allowed;
-			}
-		}
 	}
 }

--- a/apps/www/src/routes/profile.tsx
+++ b/apps/www/src/routes/profile.tsx
@@ -72,7 +72,11 @@ function ProfilePage() {
 						required
 					/>
 					<div class="form-actions">
-						<button type="submit" class="submit-button" disabled={submitting()}>
+						<button
+							type="submit"
+							class="button button--primary"
+							disabled={submitting()}
+						>
 							{submitting() ? 'Saving…' : 'Save'}
 						</button>
 						<Show when={saved()}>

--- a/apps/www/tests/e2e/auth.test.ts
+++ b/apps/www/tests/e2e/auth.test.ts
@@ -32,7 +32,7 @@ test.describe('Authentication', () => {
 		await expect(emailInput).toHaveValue(testUser.email)
 
 		// Submit the form (same as first test)
-		const submitButton = page.locator('button.submit-button')
+		const submitButton = page.getByRole('button', { name: /send sign-in link/i })
 		const responsePromise = page.waitForResponse((resp) =>
 			resp.url().includes('/api/auth/sign-in/magic-link')
 		)

--- a/apps/www/tests/e2e/helpers/login.ts
+++ b/apps/www/tests/e2e/helpers/login.ts
@@ -17,7 +17,7 @@ export async function loginViaUI(page: Page, testUser: TestUser) {
 	const responsePromise = page.waitForResponse((resp) =>
 		resp.url().includes('/api/auth/sign-in/magic-link')
 	)
-	await page.locator('button.submit-button').click()
+	await page.getByRole('button', { name: /send sign-in link/i }).click()
 	await responsePromise
 
 	await expect(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
First commit in the CSS-consolidation series identified during the all-CSS review.

## What

Adds a CSS-first reusable button at `apps/www/src/components/button.css` and migrates every existing primary/ghost button to it. No new SolidJS component — none of the call sites need JS-layer logic beyond native `type` / `disabled` attributes (the 3-reuse-with-JS-logic bar has not been met).

### API

```html
<a class="button button--primary button--lg">…</a>
<button class="button button--primary">…</button>
<button class="button button--primary button--block">…</button>
<button class="button button--ghost">…</button>
<button class="button button--primary button--sm">…</button>
```

- Variants: `--primary` (filled, `--color-primary`), `--ghost` (transparent, `--color-quiet` border).
- Size modifiers: `--sm`, `--lg`, `--block` (full-width). Default is the comfortable mid-size that 4 of the 7 original sites used.
- Works equally for `<button>` and `<a>` via `display: inline-flex` + `text-decoration: none`.
- Uses local `--_button-*` custom properties internally so variants are token swaps, not separate property lists. Hover and disabled states are defined once on `.button--primary` / `.button--ghost`.

### Removed duplications

Seven near-identical primary buttons collapsed into one declaration:

- `.cta-button` in `routes/index.css`
- `.form-actions .submit-button` in `components/ListingForm.css`
- `.inquiry-submit` in `components/InquiryForm.css`
- `.verify-button` in `components/MagicLinkWaiting.css`
- `.add-button` in `routes/listings/mine.css`
- `.login-form .submit-button` in `routes/login.css`
- `.profile-page .submit-button` in `routes/profile.css`

Two ghost buttons:

- `.form-actions .cancel-button` in `components/ListingForm.css`
- `.magic-link-waiting .cancel-button` in `components/MagicLinkWaiting.css`

`.resend-button` in `MagicLinkWaiting.css` is intentionally left in place — it's an accent-colored variant that is out of scope for this commit (primary + ghost only).

### Other touches

- Imported `button.css` from `routes/__root.tsx` so it lands in the `components` cascade layer at the top of the app.
- Updated two E2E selectors that targeted `button.submit-button` to use `getByRole('button', { name: /send sign-in link/i })` instead.

## Diff stats

19 files changed, 119 insertions(+), 198 deletions(-).

## Testing

- `bash bin/code-quality.sh` (typecheck + lint + unit tests + format check): ✅
- `pnpm test:e2e` (31 Playwright tests): ✅
- Manual UI walkthrough on 8 pages — home, about, login, magic-link-waiting, listings/mine empty state, listings/new form actions, profile.

### Walkthrough

[button_refactor_hover_demo.mp4](https://cursor.com/agents/bc-4e2b1162-51cc-4a68-a828-3dd747851bfc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbutton_refactor_hover_demo.mp4)

Hover transitions on primary (background darkens) and ghost (border + text shift to `--color-foreground`) across home hero, listings/new form actions, and login.

[Home hero primary button](https://cursor.com/agents/bc-4e2b1162-51cc-4a68-a828-3dd747851bfc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F01_home_hero_share_button.webp)
[Magic-link waiting view: primary --sm, accent (out of scope), ghost --block](https://cursor.com/agents/bc-4e2b1162-51cc-4a68-a828-3dd747851bfc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F04_magic_link_waiting_buttons.webp)
[Listing form: primary + ghost side-by-side](https://cursor.com/agents/bc-4e2b1162-51cc-4a68-a828-3dd747851bfc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F07_new_listing_form_action_buttons.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e2b1162-51cc-4a68-a828-3dd747851bfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e2b1162-51cc-4a68-a828-3dd747851bfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

