### PR TITLE
fix(nav): make iOS Safari dropdown menu links navigate on tap

### DIFF
--- a/apps/www/src/components/PageHeader.tsx
+++ b/apps/www/src/components/PageHeader.tsx
@@ -1,12 +1,20 @@
 import { DropdownMenu } from '@kobalte/core/dropdown-menu'
 import {
 	Link,
+	useLocation,
 	useNavigate,
 	useRouteContext,
 	useRouter,
 } from '@tanstack/solid-router'
 import { clsx } from 'clsx'
-import { For, Show, type ParentProps } from 'solid-js'
+import {
+	For,
+	Show,
+	createEffect,
+	createSignal,
+	on,
+	type ParentProps,
+} from 'solid-js'
 import { authClient } from '@/lib/auth-client'
 import { displayName } from '@/lib/display-name'
 import './PageHeader.css'
@@ -56,12 +64,22 @@ function getInitials(name: string): string {
 		.slice(0, 2)
 }
 
-/** A dropdown menu item rendered as a router link with aria-current support. */
+/**
+ * A dropdown menu item rendered as a router link.
+ *
+ * `closeOnSelect={false}` prevents Kobalte from scheduling a `setTimeout(0)`
+ * to unmount the portal on `pointerup`. On iOS Safari the synthetic `click`
+ * fires after that timeout, so the portal would be gone before it arrives and
+ * the tap would silently drop. Keeping the portal mounted lets the click land
+ * on the `<a>`, and the controlled DropdownMenu in PageHeader closes via a
+ * reactive effect once the route changes.
+ */
 function DropdownMenuLink(props: ParentProps<{ to: string; class?: string }>) {
 	return (
 		<DropdownMenu.Item
 			as={Link}
 			to={props.to}
+			closeOnSelect={false}
 			class={clsx('page-header__menu-item', props.class)}
 		>
 			{props.children}
@@ -74,6 +92,17 @@ export default function PageHeader(props: PageHeaderProps) {
 	const router = useRouter()
 	const navigate = useNavigate()
 	const context = useRouteContext({ from: '__root__' })
+	const location = useLocation()
+
+	const [menuOpen, setMenuOpen] = createSignal(false)
+	// Close the menu after navigation (e.g. after an iOS tap on a portal link).
+	createEffect(
+		on(
+			() => location().pathname,
+			() => setMenuOpen(false),
+			{ defer: true }
+		)
+	)
 
 	const hasBreadcrumbs = () => (props.breadcrumbs?.length ?? 0) > 0
 	const user = () => context().session?.user
@@ -97,7 +126,7 @@ export default function PageHeader(props: PageHeaderProps) {
 						<span class="page-header__logo-text">Pick My Fruit</span>
 					</Link>
 
-					<DropdownMenu>
+					<DropdownMenu open={menuOpen()} onOpenChange={setMenuOpen}>
 						{/* aria-label is stable; Kobalte manages aria-expanded and aria-haspopup */}
 						<DropdownMenu.Trigger
 							class="page-header__menu-trigger"

--- a/apps/www/tests/PageHeader.test.tsx
+++ b/apps/www/tests/PageHeader.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, waitFor, fireEvent } from '@solidjs/testing-library'
+import { splitProps } from 'solid-js'
+
+const mockNavigate = vi.fn()
+const mockSession = vi.fn(() => ({ session: undefined }))
+vi.mock('@tanstack/solid-router', () => ({
+	// Render Link as a plain <a> while forwarding every other prop. Kobalte's
+	// DropdownMenu.Item uses Polymorphic to inject id, role="menuitem", refs,
+	// and event handlers onto whatever element is supplied via `as` — dropping
+	// those props would short-circuit the behavior under test.
+	Link: (props: any) => {
+		const [local, rest] = splitProps(props, [
+			'to',
+			'replace',
+			'preload',
+			'preloadDelay',
+			'activeProps',
+			'inactiveProps',
+			'resetScroll',
+			'hashScrollIntoView',
+			'startTransition',
+			'viewTransition',
+			'ignoreBlocker',
+		])
+		const handleClick = (event: MouseEvent) => {
+			if (
+				event.button === 0 &&
+				!event.defaultPrevented &&
+				!event.metaKey &&
+				!event.ctrlKey &&
+				!event.shiftKey &&
+				!event.altKey
+			) {
+				event.preventDefault()
+				mockNavigate({ to: local.to })
+			}
+		}
+		return <a {...rest} href={local.to} onClick={handleClick} />
+	},
+	useNavigate: () => mockNavigate,
+	useRouter: () => ({ invalidate: vi.fn() }),
+	useRouteContext: () => mockSession,
+	useLocation: () => () => ({ pathname: '/', search: '', hash: '' }),
+}))
+
+vi.mock('@/lib/auth-client', () => ({
+	authClient: { signOut: vi.fn().mockResolvedValue(undefined) },
+}))
+
+vi.mock('../src/components/NamePromptBanner', () => ({
+	default: () => null,
+}))
+
+const { default: PageHeader } = await import('../src/components/PageHeader')
+
+async function openMenuAndGetFirstItem(
+	getByRole: (role: string, opts?: object) => HTMLElement
+) {
+	const trigger = getByRole('button', { name: 'Navigation menu' })
+	fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+	fireEvent.click(trigger, { button: 0 })
+	return waitFor(
+		() => {
+			const item = document.querySelector(
+				'[role="menuitem"]'
+			) as HTMLElement | null
+			if (!item) throw new Error('menu not yet rendered')
+			return item
+		},
+		{ timeout: 2000 }
+	)
+}
+
+describe('PageHeader navigation menu', () => {
+	beforeEach(() => vi.clearAllMocks())
+	afterEach(cleanup)
+
+	it('keeps the portal mounted after touch pointerup (prevents iOS click suppression)', async () => {
+		// closeOnSelect={false} on DropdownMenuLink prevents Kobalte from
+		// scheduling its setTimeout(0) close inside onSelect. Without that
+		// timeout, iOS Safari's synthetic click lands on a still-mounted <a>
+		// and navigation succeeds. This test asserts the mechanism: the element
+		// must remain in the document after pointerup fires.
+		const { getByRole } = render(() => <PageHeader />)
+		const signIn = await openMenuAndGetFirstItem(getByRole)
+
+		const opts = { bubbles: true, cancelable: true, button: 0 }
+		signIn.dispatchEvent(
+			new PointerEvent('pointerdown', { ...opts, pointerType: 'touch' })
+		)
+		signIn.dispatchEvent(
+			new PointerEvent('pointerup', { ...opts, pointerType: 'touch' })
+		)
+
+		expect(document.contains(signIn)).toBe(true)
+	})
+
+	it('navigates when a menu item is clicked', async () => {
+		const { getByRole } = render(() => <PageHeader />)
+		const signIn = await openMenuAndGetFirstItem(getByRole)
+
+		fireEvent.click(signIn, { button: 0 })
+
+		expect(mockNavigate).toHaveBeenCalledWith({ to: '/login' })
+	})
+
+	it('does not intercept modifier-clicks (browser handles cmd/ctrl/shift natively)', async () => {
+		const { getByRole } = render(() => <PageHeader />)
+		const signIn = await openMenuAndGetFirstItem(getByRole)
+
+		const event = new MouseEvent('click', {
+			bubbles: true,
+			cancelable: true,
+			button: 0,
+			metaKey: true,
+		})
+		signIn.dispatchEvent(event)
+
+		expect(mockNavigate).not.toHaveBeenCalled()
+	})
+})

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -61,7 +61,7 @@ export default defineConfig({
 				test: {
 					name: 'browser-tests',
 					include: [
-						'tests/**/*.ts',
+						'tests/**/*.{ts,tsx}',
 						'!tests/**/*.server.test.ts',
 						'!tests/helpers/**',
 						'!tests/mocks/**',


### PR DESCRIPTION
fix(nav): prevent iOS tap-then-click suppression in hamburger menu On iOS Safari, tapping a portal-rendered link fires `pointerup` first, then dispatches a synthetic click after returning to the event loop Kobalte's default behavior schedules a `setTimeout(0)` inside `onSelect` to unmount the portal, so the `<a>` is gone before the click arrives and iOS silently drops it — no navigation.

Fix: set `closeOnSelect={false}` on `DropdownMenuLink` items. This skips the `setTimeout` close entirely, leaving the portal mounted. iOS fires the click on the live `<a>`, TanStack Router's Link handles it normally, and the controlled `DropdownMenu` closes via a `createEffect` that watches `location().pathname` and calls `setMenuOpen(false)` after navigation.

Also include the vitest config change that adds `.tsx` to browser-tests (needed for `PageHeader.test.tsx` to be picked up).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>