### PR TITLE
fix(S3Client): no content-length for streaming uploads

### DIFF
--- a/apps/www/src/lib/storage.server.ts
+++ b/apps/www/src/lib/storage.server.ts
@@ -119,6 +119,9 @@ export class TigrisStorageAdapter implements StorageAdapter {
 		this.client = new S3Client({
 			region: 'auto',
 			endpoint: opts.endpointUrl,
+			// Default changed to WHEN_SUPPORTED in SDK v3 — streaming bodies then require
+			// x-amz-decoded-content-length, which is undefined for pipe()-based streams.
+			requestChecksumCalculation: 'WHEN_REQUIRED',
 			credentials: {
 				accessKeyId: opts.accessKeyId,
 				secretAccessKey: opts.secretAccessKey,

--- a/apps/www/tests/storage.server.test.ts
+++ b/apps/www/tests/storage.server.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
 import { mkdtemp, rm, readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -170,6 +172,43 @@ describe(TigrisStorageAdapter, () => {
 			expect(adapter.publicUrl('listings/1/uuid.jpg')).toBe(
 				'https://test-bucket.fly.storage.tigris.dev/pub/listings/1/uuid.jpg'
 			)
+		})
+	})
+
+	describe('upload', () => {
+		it('uploads a Readable stream without throwing x-amz-decoded-content-length error', async () => {
+			// Regression: AWS SDK v3 defaults to WHEN_SUPPORTED for requestChecksumCalculation,
+			// which requires x-amz-decoded-content-length for streaming bodies. That header is
+			// undefined for pipe()-based streams, causing a TypeError in Node's setHeader.
+			// requestChecksumCalculation: 'WHEN_REQUIRED' on the S3Client fixes this.
+			const server = createServer((req, res) => {
+				req.resume()
+				req.on('end', () => {
+					res.writeHead(200)
+					res.end()
+				})
+			})
+			await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+			const { port } = server.address() as AddressInfo
+			const localAdapter = new TigrisStorageAdapter({
+				bucketName: 'test-bucket',
+				accessKeyId: 'fake',
+				secretAccessKey: 'fake',
+				endpointUrl: `http://127.0.0.1:${port}`,
+			})
+
+			try {
+				const stream = Readable.from(Buffer.from('hello'))
+				await expect(
+					localAdapter.upload('raw', 'test/photo.jpg', stream, {
+						mimeType: 'image/jpeg',
+					})
+				).resolves.toBeUndefined()
+			} finally {
+				await new Promise<void>((resolve, reject) =>
+					server.close((err) => (err ? reject(err) : resolve()))
+				)
+			}
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- AWS SDK v3 changed the default for `requestChecksumCalculation` to `WHEN_SUPPORTED`,
  causing streaming bodies to use `aws-chunked` transfer encoding. That encoding requires
  the `x-amz-decoded-content-length` header set upfront, but `pipe()`-based streams have
  no known byte length — triggering a `TypeError` in Node's `setHeader`. Fixes PICKMYFRUIT-17.
- Sets `requestChecksumCalculation: 'WHEN_REQUIRED'` on the `S3Client` so checksums are
  only added when S3 explicitly requires them.

## Test Plan

- `pnpm --filter @pickmyfruit/www test:run tests/storage.server.test.ts` — new regression
  test spins up a local HTTP server and confirms a `Readable` stream upload resolves cleanly
- `bash bin/code-quality.sh`

## Review Notes

- The fix is a single config line; the regression test would fail without it (the SDK would
  throw the TypeError before the request reaches the mock server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)