### PR TITLE
Auto-orient public listing JPEGs with Sharp

### DIFF
--- a/apps/www/src/lib/listing-photo-upload.server.ts
+++ b/apps/www/src/lib/listing-photo-upload.server.ts
@@ -21,6 +21,24 @@ const MIME_TO_EXT = {
 
 export type ALLOWED_EXT = (typeof MIME_TO_EXT)[keyof typeof MIME_TO_EXT]
 
+/**
+ * Maps Sharp-reported EXIF orientation (1–8) to the sole IFD0 tag written on
+ * public JPEGs. Any other value falls back to 1 (normal orientation).
+ */
+export function exifOrientationForPublicCopy(
+	orientation: number | undefined
+): string {
+	if (
+		typeof orientation === 'number' &&
+		Number.isInteger(orientation) &&
+		orientation >= 1 &&
+		orientation <= 8
+	) {
+		return String(orientation)
+	}
+	return '1'
+}
+
 /** Applies production Sharp memory controls once per process. */
 export async function configureSharp(): Promise<void> {
 	const sharp = (await import('sharp')).default
@@ -84,8 +102,19 @@ export async function uploadListingPhoto(opts: {
 	try {
 		await configureSharp()
 		const sharp = (await import('sharp')).default
+		const inputMeta = await sharp(opts.rawBuffer, {
+			sequentialRead: true,
+		}).metadata()
+		const orientation = exifOrientationForPublicCopy(inputMeta.orientation)
 		const cleanStream = Readable.from(opts.rawBuffer).pipe(
-			sharp({ sequentialRead: true }).jpeg()
+			sharp({ sequentialRead: true })
+				// Allow-list: only IFD0 Orientation so GPS and other EXIF/XMP are omitted.
+				.withExif({
+					IFD0: {
+						Orientation: orientation,
+					},
+				})
+				.jpeg()
 		)
 		// Public copy served from CDN
 		await opts.storage.upload('pub', pubPathKey, cleanStream, {

--- a/apps/www/src/lib/listing-photo-upload.server.ts
+++ b/apps/www/src/lib/listing-photo-upload.server.ts
@@ -21,24 +21,6 @@ const MIME_TO_EXT = {
 
 export type ALLOWED_EXT = (typeof MIME_TO_EXT)[keyof typeof MIME_TO_EXT]
 
-/**
- * Maps Sharp-reported EXIF orientation (1–8) to the sole IFD0 tag written on
- * public JPEGs. Any other value falls back to 1 (normal orientation).
- */
-export function exifOrientationForPublicCopy(
-	orientation: number | undefined
-): string {
-	if (
-		typeof orientation === 'number' &&
-		Number.isInteger(orientation) &&
-		orientation >= 1 &&
-		orientation <= 8
-	) {
-		return String(orientation)
-	}
-	return '1'
-}
-
 /** Applies production Sharp memory controls once per process. */
 export async function configureSharp(): Promise<void> {
 	const sharp = (await import('sharp')).default
@@ -102,19 +84,8 @@ export async function uploadListingPhoto(opts: {
 	try {
 		await configureSharp()
 		const sharp = (await import('sharp')).default
-		const inputMeta = await sharp(opts.rawBuffer, {
-			sequentialRead: true,
-		}).metadata()
-		const orientation = exifOrientationForPublicCopy(inputMeta.orientation)
 		const cleanStream = Readable.from(opts.rawBuffer).pipe(
-			sharp({ sequentialRead: true })
-				// Allow-list: only IFD0 Orientation so GPS and other EXIF/XMP are omitted.
-				.withExif({
-					IFD0: {
-						Orientation: orientation,
-					},
-				})
-				.jpeg()
+			sharp({ sequentialRead: true }).autoOrient().jpeg()
 		)
 		// Public copy served from CDN
 		await opts.storage.upload('pub', pubPathKey, cleanStream, {

--- a/apps/www/tests/listing-photo-api.server.test.ts
+++ b/apps/www/tests/listing-photo-api.server.test.ts
@@ -53,11 +53,21 @@ vi.mock('../src/lib/storage.server', () => ({
 // Mock sharp — avoids native binary
 // ============================================================================
 
+const mockSharpJpeg = vi.fn(() => ({ pipe: vi.fn() }))
+const mockSharpWithExif = vi.fn(() => ({ jpeg: mockSharpJpeg }))
+
 vi.mock('sharp', () => ({
 	default: Object.assign(
-		vi.fn(() => ({
-			jpeg: vi.fn(() => ({ pipe: vi.fn() })),
-		})),
+		vi.fn((input: unknown) => {
+			if (Buffer.isBuffer(input)) {
+				return {
+					metadata: vi.fn().mockResolvedValue({ orientation: 1 }),
+				}
+			}
+			return {
+				withExif: mockSharpWithExif,
+			}
+		}),
 		{ concurrency: vi.fn() }
 	),
 }))

--- a/apps/www/tests/listing-photo-api.server.test.ts
+++ b/apps/www/tests/listing-photo-api.server.test.ts
@@ -54,20 +54,13 @@ vi.mock('../src/lib/storage.server', () => ({
 // ============================================================================
 
 const mockSharpJpeg = vi.fn(() => ({ pipe: vi.fn() }))
-const mockSharpWithExif = vi.fn(() => ({ jpeg: mockSharpJpeg }))
+const mockSharpAutoOrient = vi.fn(() => ({ jpeg: mockSharpJpeg }))
 
 vi.mock('sharp', () => ({
 	default: Object.assign(
-		vi.fn((input: unknown) => {
-			if (Buffer.isBuffer(input)) {
-				return {
-					metadata: vi.fn().mockResolvedValue({ orientation: 1 }),
-				}
-			}
-			return {
-				withExif: mockSharpWithExif,
-			}
-		}),
+		vi.fn(() => ({
+			autoOrient: mockSharpAutoOrient,
+		})),
 		{ concurrency: vi.fn() }
 	),
 }))

--- a/apps/www/tests/listing-photo-exif.server.test.ts
+++ b/apps/www/tests/listing-photo-exif.server.test.ts
@@ -14,6 +14,7 @@ import { exiftool } from 'exiftool-vendored'
 import type { StorageAdapter, StorageBody } from '../src/lib/storage.server'
 
 // No vi.mock('sharp') — exercises the real native binary.
+const sharp = (await import('sharp')).default
 const { uploadListingPhoto } =
 	await import('../src/lib/listing-photo-upload.server')
 
@@ -68,4 +69,66 @@ describe('EXIF stripping (real sharp)', () => {
 			unlinkSync(tmpPath)
 		}
 	})
+
+	it(
+		'retains EXIF Orientation on the public copy while stripping other EXIF',
+		{
+			timeout: 30_000,
+		},
+		async () => {
+			const rawBuffer = await sharp({
+				create: {
+					width: 8,
+					height: 4,
+					channels: 3,
+					background: { r: 10, g: 20, b: 30 },
+				},
+			})
+				.withMetadata({ orientation: 6 })
+				.jpeg()
+				.toBuffer()
+
+			let pubBuffer: Buffer | undefined
+			const storage: StorageAdapter = {
+				upload: async (dir: string, _key: string, body: StorageBody) => {
+					if (dir === 'pub') {
+						pubBuffer = Buffer.isBuffer(body)
+							? body
+							: Buffer.concat(await Readable.from(body).toArray())
+					}
+				},
+				read: async () => {
+					throw new Error('not implemented')
+				},
+				readStream: async () => {
+					throw new Error('not implemented')
+				},
+				readWebStream: async () => {
+					throw new Error('not implemented')
+				},
+				publicUrl: (key: string) => `/api/uploads/pub/${key}`,
+				delete: async () => {},
+			}
+
+			await uploadListingPhoto({
+				rawBuffer,
+				mimeType: 'image/jpeg',
+				fileExt: '.jpg',
+				storage,
+			})
+
+			expect(pubBuffer).toBeDefined()
+
+			const tmpPath = join(tmpdir(), `pmf-orient-test-${Date.now()}.jpg`)
+			writeFileSync(tmpPath, pubBuffer!)
+			try {
+				const tags = await exiftool.read(tmpPath)
+				expect(tags.Orientation).toBe(6)
+				expect(tags.Make).toBeUndefined()
+				expect(tags.GPSLatitude).toBeUndefined()
+			} finally {
+				unlinkSync(tmpPath)
+			}
+		}
+	)
 })

--- a/apps/www/tests/listing-photo-exif.server.test.ts
+++ b/apps/www/tests/listing-photo-exif.server.test.ts
@@ -71,7 +71,7 @@ describe('EXIF stripping (real sharp)', () => {
 	})
 
 	it(
-		'retains EXIF Orientation on the public copy while stripping other EXIF',
+		'auto-orients pixels and drops orientation metadata on the public copy',
 		{
 			timeout: 30_000,
 		},
@@ -119,12 +119,16 @@ describe('EXIF stripping (real sharp)', () => {
 
 			expect(pubBuffer).toBeDefined()
 
+			const pubMeta = await sharp(pubBuffer!).metadata()
+			expect(pubMeta.width).toBe(4)
+			expect(pubMeta.height).toBe(8)
+			expect(pubMeta.orientation).toBeUndefined()
+
 			const tmpPath = join(tmpdir(), `pmf-orient-test-${Date.now()}.jpg`)
 			writeFileSync(tmpPath, pubBuffer!)
 			try {
 				const tags = await exiftool.read(tmpPath)
-				expect(tags.Orientation).toBe(6)
-				expect(tags.Make).toBeUndefined()
+				expect(tags.Orientation).toBeUndefined()
 				expect(tags.GPSLatitude).toBeUndefined()
 			} finally {
 				unlinkSync(tmpPath)

--- a/apps/www/tests/listing-photo-upload.server.test.ts
+++ b/apps/www/tests/listing-photo-upload.server.test.ts
@@ -28,6 +28,7 @@ vi.mock('mime-bytes', () => ({
 
 const mockConcurrency = vi.fn()
 const mockJpeg = vi.fn()
+const mockWithExif = vi.fn()
 const mockSharp = vi.fn()
 
 vi.mock('sharp', () => ({
@@ -41,7 +42,7 @@ vi.mock('../src/lib/env.server', () => ({
 }))
 
 // Must import after mocking
-const { validatePhotoFile, uploadListingPhoto } =
+const { validatePhotoFile, uploadListingPhoto, exifOrientationForPublicCopy } =
 	await import('../src/lib/listing-photo-upload.server')
 
 // ============================================================================
@@ -62,6 +63,20 @@ function makeStorage(): StorageAdapter {
 // ============================================================================
 // validatePhotoFile
 // ============================================================================
+
+describe('exifOrientationForPublicCopy', () => {
+	it.each([
+		[1, '1'],
+		[6, '6'],
+		[8, '8'],
+		[undefined, '1'],
+		[0, '1'],
+		[9, '1'],
+		[1.5, '1'],
+	])('maps %p to %s', (input, expected) => {
+		expect(exifOrientationForPublicCopy(input)).toBe(expected)
+	})
+})
 
 describe('validatePhotoFile', () => {
 	const smallBuf = Buffer.from('fake')
@@ -117,7 +132,17 @@ describe('uploadListingPhoto', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		mockJpeg.mockReturnValue(new PassThrough())
-		mockSharp.mockReturnValue({ jpeg: mockJpeg })
+		mockWithExif.mockReturnValue({ jpeg: mockJpeg })
+		mockSharp.mockImplementation((input: unknown) => {
+			if (Buffer.isBuffer(input)) {
+				return {
+					metadata: vi.fn().mockResolvedValue({ orientation: 1 }),
+				}
+			}
+			return {
+				withExif: mockWithExif,
+			}
+		})
 	})
 
 	it('uploads the raw buffer to raw/ dir preserving input extension', async () => {
@@ -153,15 +178,20 @@ describe('uploadListingPhoto', () => {
 
 	it('converts to JPEG and streams the clean image to pub/ dir', async () => {
 		const storage = makeStorage()
+		const rawBuffer = Buffer.from('raw-img')
 
 		await uploadListingPhoto({
-			rawBuffer: Buffer.from('raw-img'),
+			rawBuffer,
 			mimeType: 'image/png',
 			fileExt: '.png',
 			storage,
 		})
 
+		expect(mockSharp).toHaveBeenCalledWith(rawBuffer, { sequentialRead: true })
 		expect(mockSharp).toHaveBeenCalledWith({ sequentialRead: true })
+		expect(mockWithExif).toHaveBeenCalledWith({
+			IFD0: { Orientation: '1' },
+		})
 		expect(mockJpeg).toHaveBeenCalled()
 
 		const { calls } = (storage.upload as ReturnType<typeof vi.fn>).mock

--- a/apps/www/tests/listing-photo-upload.server.test.ts
+++ b/apps/www/tests/listing-photo-upload.server.test.ts
@@ -28,7 +28,7 @@ vi.mock('mime-bytes', () => ({
 
 const mockConcurrency = vi.fn()
 const mockJpeg = vi.fn()
-const mockWithExif = vi.fn()
+const mockAutoOrient = vi.fn()
 const mockSharp = vi.fn()
 
 vi.mock('sharp', () => ({
@@ -42,7 +42,7 @@ vi.mock('../src/lib/env.server', () => ({
 }))
 
 // Must import after mocking
-const { validatePhotoFile, uploadListingPhoto, exifOrientationForPublicCopy } =
+const { validatePhotoFile, uploadListingPhoto } =
 	await import('../src/lib/listing-photo-upload.server')
 
 // ============================================================================
@@ -63,20 +63,6 @@ function makeStorage(): StorageAdapter {
 // ============================================================================
 // validatePhotoFile
 // ============================================================================
-
-describe('exifOrientationForPublicCopy', () => {
-	it.each([
-		[1, '1'],
-		[6, '6'],
-		[8, '8'],
-		[undefined, '1'],
-		[0, '1'],
-		[9, '1'],
-		[1.5, '1'],
-	])('maps %p to %s', (input, expected) => {
-		expect(exifOrientationForPublicCopy(input)).toBe(expected)
-	})
-})
 
 describe('validatePhotoFile', () => {
 	const smallBuf = Buffer.from('fake')
@@ -132,16 +118,9 @@ describe('uploadListingPhoto', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		mockJpeg.mockReturnValue(new PassThrough())
-		mockWithExif.mockReturnValue({ jpeg: mockJpeg })
-		mockSharp.mockImplementation((input: unknown) => {
-			if (Buffer.isBuffer(input)) {
-				return {
-					metadata: vi.fn().mockResolvedValue({ orientation: 1 }),
-				}
-			}
-			return {
-				withExif: mockWithExif,
-			}
+		mockAutoOrient.mockReturnValue({ jpeg: mockJpeg })
+		mockSharp.mockReturnValue({
+			autoOrient: mockAutoOrient,
 		})
 	})
 
@@ -187,11 +166,8 @@ describe('uploadListingPhoto', () => {
 			storage,
 		})
 
-		expect(mockSharp).toHaveBeenCalledWith(rawBuffer, { sequentialRead: true })
 		expect(mockSharp).toHaveBeenCalledWith({ sequentialRead: true })
-		expect(mockWithExif).toHaveBeenCalledWith({
-			IFD0: { Orientation: '1' },
-		})
+		expect(mockAutoOrient).toHaveBeenCalled()
 		expect(mockJpeg).toHaveBeenCalled()
 
 		const { calls } = (storage.upload as ReturnType<typeof vi.fn>).mock


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Public listing photos are re-encoded to JPEG with Sharp. We now use **`autoOrient()`** so EXIF orientation is applied as rotation in the pixel grid, then the orientation tag is removed (Sharp’s default JPEG output still strips other metadata).

## Behaviour

- **`autoOrient()`** — rotate/flip per EXIF Orientation, then drop the tag so viewers do not double-apply orientation.
- **Default metadata stripping** on `.jpeg()` — GPS and other EXIF/XMP stay off the CDN copy; the private `raw/` object is unchanged and still holds the full original.

## Tests

- Unit mocks expect `autoOrient` before `jpeg` in the upload pipeline.
- Integration test: synthetic JPEG with orientation **6** → public output is **4×8** pixels, Sharp reports **no** `orientation`, ExifTool sees **no** `Orientation` or GPS (flower-bees fixture test unchanged for GPS stripping).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c939ca4a-219d-45a8-a190-18113a28e7bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c939ca4a-219d-45a8-a190-18113a28e7bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

