### PR TITLE
fix(photos): stop OOM kills on photo upload

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -33,7 +33,8 @@
 		"ssh": "fly ssh console"
 	},
 	"dependencies": {
-		"@aws-sdk/client-s3": "^3.1013.0",
+		"@aws-sdk/client-s3": "^3.1035.0",
+		"@aws-sdk/lib-storage": "^3.1035.0",
 		"@kobalte/core": "^0.13.11",
 		"@libsql/client": "^0.17.0",
 		"@sentry/solid": "^10.40.0",

--- a/apps/www/src/api/listing-photos.ts
+++ b/apps/www/src/api/listing-photos.ts
@@ -47,10 +47,16 @@ export const addPhotoToListing = createServerFn({ method: 'POST' })
 		const {
 			MAX_FILE_SIZE_BYTES,
 			ALLOWED_MIME_TYPES,
-			validatePhotoFile,
+			assertPhotoUploadCapacity,
+			detectMimeFromTempFile,
+			stageUploadStream,
+			unlinkUploadStaging,
 			uploadListingPhoto,
 			mimeToExt,
 		} = await import('@/lib/listing-photo-upload.server')
+		// Shed load before staging to disk so an overloaded server doesn't
+		// keep accepting 5 MB temp files it can't process.
+		assertPhotoUploadCapacity()
 		if (file.size > MAX_FILE_SIZE_BYTES) {
 			throw new UserError('FILE_TOO_LARGE', 'Photo must be 5 MB or smaller')
 		}
@@ -71,67 +77,75 @@ export const addPhotoToListing = createServerFn({ method: 'POST' })
 			throw new UserError('NOT_FOUND', 'Listing not found')
 		}
 
-		const rawBuffer = Buffer.from(await file.arrayBuffer())
-		// Detect MIME from magic bytes — ignores the client-supplied Content-Type
-		const mimeType = await validatePhotoFile(rawBuffer)
-
-		const { addPhotoToListing } = await import('@/data/queries.server')
-
-		const fileExt = mimeToExt(mimeType)
-		const { storage } = await import('@/lib/storage.server')
-		const { id } = await uploadListingPhoto({
-			rawBuffer,
-			mimeType,
-			fileExt,
-			storage,
-		})
-		const rawPathKey = `listing_photos/${id}${fileExt}`
-		const pubPathKey = `listing_photos/${id}.jpg`
-
-		let photo
+		// Stage the upload to disk so the file body never sits in memory as a
+		// Buffer. Two read streams are then opened from the temp file: one for
+		// the raw archive copy, one for the Sharp-processed public copy.
+		const tempPath = await stageUploadStream(
+			file.stream() as ReadableStream<Uint8Array>
+		)
 		try {
-			photo = await addPhotoToListing(
-				listingId,
-				id,
+			const mimeType = await detectMimeFromTempFile(tempPath)
+
+			const { addPhotoToListing } = await import('@/data/queries.server')
+
+			const fileExt = mimeToExt(mimeType)
+			const { storage } = await import('@/lib/storage.server')
+			const { id } = await uploadListingPhoto({
+				tempPath,
+				mimeType,
 				fileExt,
-				MAX_PHOTOS_PER_LISTING
-			)
-		} catch (dbErr) {
-			// The storage objects are now orphaned. Best-effort cleanup — if deletion
-			// fails, Sentry will capture it so an ops script can reconcile.
-			const { Sentry } = await import('@/lib/sentry')
-			await Promise.all([
-				storage
-					.delete('raw', rawPathKey)
-					.catch((e) => Sentry.captureException(e, { extra: { rawPathKey } })),
-				storage
-					.delete('pub', pubPathKey)
-					.catch((e) => Sentry.captureException(e, { extra: { pubPathKey } })),
-			])
-			throw dbErr
-		}
+				storage,
+			})
+			const rawPathKey = `listing_photos/${id}${fileExt}`
+			const pubPathKey = `listing_photos/${id}.jpg`
 
-		if (!photo) {
-			// addPhotoToListing returns null when the listing is already at the limit.
-			// Clean up the storage objects we just uploaded.
-			const { Sentry } = await import('@/lib/sentry')
-			await Promise.all([
-				storage
-					.delete('raw', rawPathKey)
-					.catch((e) => Sentry.captureException(e, { extra: { rawPathKey } })),
-				storage
-					.delete('pub', pubPathKey)
-					.catch((e) => Sentry.captureException(e, { extra: { pubPathKey } })),
-			])
-			throw new UserError(
-				'TOO_MANY_PHOTOS',
-				`A listing can have at most ${MAX_PHOTOS_PER_LISTING} photos`
-			)
-		}
+			let photo
+			try {
+				photo = await addPhotoToListing(
+					listingId,
+					id,
+					fileExt,
+					MAX_PHOTOS_PER_LISTING
+				)
+			} catch (dbErr) {
+				// The storage objects are now orphaned. Best-effort cleanup — if deletion
+				// fails, Sentry will capture it so an ops script can reconcile.
+				const { Sentry } = await import('@/lib/sentry')
+				await Promise.all([
+					storage
+						.delete('raw', rawPathKey)
+						.catch((e) => Sentry.captureException(e, { extra: { rawPathKey } })),
+					storage
+						.delete('pub', pubPathKey)
+						.catch((e) => Sentry.captureException(e, { extra: { pubPathKey } })),
+				])
+				throw dbErr
+			}
 
-		return {
-			id: photo.id,
-			pubUrl: storage.publicUrl(`listing_photos/${photo.id}.jpg`),
+			if (!photo) {
+				// addPhotoToListing returns null when the listing is already at the limit.
+				// Clean up the storage objects we just uploaded.
+				const { Sentry } = await import('@/lib/sentry')
+				await Promise.all([
+					storage
+						.delete('raw', rawPathKey)
+						.catch((e) => Sentry.captureException(e, { extra: { rawPathKey } })),
+					storage
+						.delete('pub', pubPathKey)
+						.catch((e) => Sentry.captureException(e, { extra: { pubPathKey } })),
+				])
+				throw new UserError(
+					'TOO_MANY_PHOTOS',
+					`A listing can have at most ${MAX_PHOTOS_PER_LISTING} photos`
+				)
+			}
+
+			return {
+				id: photo.id,
+				pubUrl: storage.publicUrl(`listing_photos/${photo.id}.jpg`),
+			}
+		} finally {
+			await unlinkUploadStaging(tempPath)
 		}
 	})
 

--- a/apps/www/src/lib/listing-photo-upload.server.ts
+++ b/apps/www/src/lib/listing-photo-upload.server.ts
@@ -1,6 +1,14 @@
 import { v7 as uuidv7 } from 'uuid'
 import { detectFromBuffer } from 'mime-bytes'
+import { createReadStream, createWriteStream } from 'node:fs'
+import { open, stat, unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import { serverEnv } from '@/lib/env.server'
+import { logger } from '@/lib/logger.server'
+import { Sentry } from '@/lib/sentry'
 import type { StorageAdapter } from '@/lib/storage.server'
 import { UserError } from '@/lib/user-error'
 
@@ -13,6 +21,16 @@ export type AllowedMimeType = (typeof ALLOWED_MIME_TYPES)[number]
 
 export const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024
 
+export const MAX_IMAGE_PIXELS = 16_000_000
+
+/**
+ * Cap on the long edge of the public copy. Listing photos don't need full
+ * sensor resolution; with this cap libvips' JPEG shrink-on-load decodes the
+ * input at 1/2, 1/4, or 1/8, which is the dominant memory win in the pub
+ * pipeline.
+ */
+export const PUB_MAX_DIMENSION = 2048
+
 const MIME_TO_EXT = {
 	'image/jpeg': '.jpg',
 	'image/png': '.png',
@@ -21,11 +39,66 @@ const MIME_TO_EXT = {
 
 export type ALLOWED_EXT = (typeof MIME_TO_EXT)[keyof typeof MIME_TO_EXT]
 
-/** Applies production Sharp memory controls once per process. */
-export async function configureSharp(): Promise<void> {
-	const sharp = (await import('sharp')).default
-	const { serverEnv } = await import('@/lib/env.server')
-	sharp.concurrency(serverEnv.SHARP_CONCURRENCY)
+const sharp = (await import('sharp')).default
+sharp.concurrency(serverEnv.SHARP_CONCURRENCY)
+// libvips' tile/operation cache fights V8 for RAM on a 256 MB VM.
+sharp.cache(false)
+
+/**
+ * Cap on uploads in flight (running + queued). Past this we shed load with a
+ * 503 instead of holding more 5 MB temp files and Sharp pixel buffers around.
+ * TODO: move image processing to a background worker so the web tier doesn't
+ * have to gate on its own RAM budget.
+ */
+export const MAX_UPLOAD_QUEUE_DEPTH = 4
+
+/**
+ * Serial promise queue: ensures only one uploadListingPhoto runs at a time
+ * across the process. Two simultaneous uploads would otherwise hold two raw
+ * temp files and two Sharp pixel buffers in RAM at once — enough to push the
+ * 512 MB Fly VM over its OOM threshold even after resize-before-encode.
+ */
+let queueTail: Promise<unknown> = Promise.resolve()
+let queueDepth = 0
+
+interface LockInfo {
+	lockWaitMs: number
+	depthAtAcquire: number
+}
+
+function withUploadLock<T>(fn: (info: LockInfo) => Promise<T>): Promise<T> {
+	if (queueDepth >= MAX_UPLOAD_QUEUE_DEPTH) {
+		throw new UserError(
+			'SERVER_BUSY',
+			'The server is busy processing other photo uploads. Please try again in a moment.',
+			503
+		)
+	}
+	queueDepth++
+	const enqueuedAt = Date.now()
+	const run = async () => {
+		const info: LockInfo = {
+			lockWaitMs: Date.now() - enqueuedAt,
+			depthAtAcquire: queueDepth,
+		}
+		return fn(info)
+	}
+	const result = queueTail.then(run, run).finally(() => {
+		queueDepth--
+	})
+	queueTail = result.catch(() => undefined)
+	return result
+}
+
+/** Synchronous capacity check — call before staging the request body to disk. */
+export function assertPhotoUploadCapacity(): void {
+	if (queueDepth >= MAX_UPLOAD_QUEUE_DEPTH) {
+		throw new UserError(
+			'SERVER_BUSY',
+			'The server is busy processing other photo uploads. Please try again in a moment.',
+			503
+		)
+	}
 }
 
 /**
@@ -60,44 +133,207 @@ export function mimeToExt(mimeType: AllowedMimeType): ALLOWED_EXT {
 }
 
 /**
+ * Streams an upload to a unique temp file and returns its path. Buffering the
+ * upload in memory (`Buffer.from(await file.arrayBuffer())`) was the dominant
+ * peak-RSS contributor on the 256 MB Fly VM — staging to disk lets the request
+ * body, the raw archive copy, and the Sharp pipeline each consume the bytes
+ * via independent streams.
+ */
+export async function stageUploadStream(
+	webStream: ReadableStream<Uint8Array>
+): Promise<string> {
+	const tempPath = join(tmpdir(), `pmf-upload-${uuidv7()}`)
+	// Cast bridges DOM's ReadableStream and node:stream/web's, which differ in
+	// their type defs even though Node accepts both at runtime.
+	await pipeline(
+		Readable.fromWeb(webStream as Parameters<typeof Readable.fromWeb>[0]),
+		createWriteStream(tempPath)
+	)
+	return tempPath
+}
+
+/** Reads the first 4 KB of a staged upload and validates magic bytes. */
+export async function detectMimeFromTempFile(
+	tempPath: string
+): Promise<AllowedMimeType> {
+	const fd = await open(tempPath)
+	try {
+		const { buffer, bytesRead } = await fd.read(Buffer.alloc(4096), 0, 4096, 0)
+		return validatePhotoFile(buffer.subarray(0, bytesRead))
+	} finally {
+		await fd.close()
+	}
+}
+
+/** Best-effort cleanup of a staged temp file; never throws. */
+export async function unlinkUploadStaging(tempPath: string): Promise<void> {
+	await unlink(tempPath).catch(() => undefined)
+}
+
+/**
  * Uploads a photo to both raw/ (private, full EXIF) and pub/ (public, EXIF-stripped)
  * storage, and returns the ID to be used in paths.
  *
- * Cleans up the raw/ object if the pub/ upload fails, to avoid orphaning a
- * private file that contains full EXIF.
+ * Reads from `tempPath` twice (one stream per upload) so neither pass needs
+ * to buffer the full file in memory. Cleans up the raw/ object if the pub/
+ * upload fails, to avoid orphaning a private file that contains full EXIF.
  */
-export async function uploadListingPhoto(opts: {
-	rawBuffer: Buffer
+export function uploadListingPhoto(opts: {
+	tempPath: string
 	mimeType: AllowedMimeType
 	fileExt: string
 	storage: StorageAdapter
 }): Promise<{ id: string }> {
+	return withUploadLock((info) => uploadListingPhotoLocked(opts, info))
+}
+
+async function uploadListingPhotoLocked(
+	opts: {
+		tempPath: string
+		mimeType: AllowedMimeType
+		fileExt: string
+		storage: StorageAdapter
+	},
+	lockInfo: LockInfo
+): Promise<{ id: string }> {
 	const id = uuidv7()
 	const rawPathKey = `listing_photos/${id}${opts.fileExt}`
 	const pubPathKey = `listing_photos/${id}.jpg`
 
-	// Store original with full EXIF intact — private, server-side only
-	await opts.storage.upload('raw', rawPathKey, opts.rawBuffer, {
-		mimeType: opts.mimeType,
-	})
+	logger.info(
+		{
+			phase: 'start',
+			listingPhotoId: id,
+			rssBytes: process.memoryUsage().rss,
+			lockWaitMs: lockInfo.lockWaitMs,
+			depthAtAcquire: lockInfo.depthAtAcquire,
+		},
+		'uploadListingPhoto'
+	)
 
+	let phase: 'end' | 'error' = 'end'
 	try {
-		await configureSharp()
-		const sharp = (await import('sharp')).default
-		const cleanStream = Readable.from(opts.rawBuffer).pipe(
-			sharp({ sequentialRead: true }).autoOrient().jpeg()
+		// Store original with full EXIF intact — private, server-side only
+		await opts.storage.upload(
+			'raw',
+			rawPathKey,
+			createReadStream(opts.tempPath),
+			{
+				mimeType: opts.mimeType,
+				photoId: id,
+			}
 		)
-		// Public copy served from CDN
-		await opts.storage.upload('pub', pubPathKey, cleanStream, {
-			mimeType: 'image/jpeg',
-		})
-	} catch (err) {
-		// Clean up the raw/ object so it doesn't linger without a DB record.
-		// Best-effort: if deletion also fails, the error is swallowed — the
-		// original error is what the caller needs to handle.
-		await opts.storage.delete('raw', rawPathKey).catch(() => undefined)
-		throw err
-	}
 
-	return { id }
+		try {
+			await Sentry.startSpan(
+				{
+					name: 'photo.sharp_transform',
+					op: 'image.process',
+					attributes: {
+						'photo.id': id,
+						'photo.mime_type': opts.mimeType,
+						'photo.lock_wait_ms': lockInfo.lockWaitMs,
+						'photo.queue_depth_at_acquire': lockInfo.depthAtAcquire,
+					},
+				},
+				async (span) => {
+					const rssBefore = process.memoryUsage().rss
+					const inputBytes = (await stat(opts.tempPath)).size
+					const inputMeta = await sharp(opts.tempPath).metadata()
+
+					span.setAttribute('photo.input_bytes', inputBytes)
+					span.setAttribute('photo.input_orientation', inputMeta.orientation ?? 1)
+					span.setAttribute('photo.input_width', inputMeta.width ?? 0)
+					span.setAttribute('photo.input_height', inputMeta.height ?? 0)
+					span.setAttribute('photo.rss_before', rssBefore)
+
+					// libvips cache snapshot — process-global counters, captured here
+					// to confirm sharp.cache(false) is honored on the linux build.
+					// `_high` is the high-water mark since process start, not per-image.
+					const cacheSnapshot = sharp.cache()
+					span.setAttribute(
+						'sharp.cache_memory_current',
+						cacheSnapshot.memory.current
+					)
+					span.setAttribute('sharp.cache_memory_high', cacheSnapshot.memory.high)
+					span.setAttribute('sharp.cache_files_current', cacheSnapshot.files.current)
+					span.setAttribute('sharp.cache_items_current', cacheSnapshot.items.current)
+
+					span.setAttribute('photo.pub_max_dimension', PUB_MAX_DIMENSION)
+					// Order matters: rotate first so .resize() targets display-oriented
+					// dimensions. For JPEG input, libvips uses shrink-on-load to decode
+					// at 1/2, 1/4, or 1/8 — the dominant memory win on the pub pipeline.
+					const transform = sharp({
+						sequentialRead: true,
+						limitInputPixels: MAX_IMAGE_PIXELS,
+					})
+						.autoOrient()
+						.resize({
+							width: PUB_MAX_DIMENSION,
+							height: PUB_MAX_DIMENSION,
+							fit: 'inside',
+							withoutEnlargement: true,
+						})
+						.jpeg({ quality: 85, mozjpeg: true })
+					transform.on('info', (info: import('sharp').OutputInfo) => {
+						span.setAttribute('photo.output_width', info.width)
+						span.setAttribute('photo.output_height', info.height)
+						span.setAttribute('photo.output_bytes', info.size)
+					})
+					const cleanStream = createReadStream(opts.tempPath).pipe(transform)
+
+					try {
+						// Public copy served from CDN
+						await opts.storage.upload('pub', pubPathKey, cleanStream, {
+							mimeType: 'image/jpeg',
+							photoId: id,
+						})
+					} finally {
+						const rssAfter = process.memoryUsage().rss
+						span.setAttribute('photo.rss_after', rssAfter)
+						span.setAttribute('photo.rss_delta', rssAfter - rssBefore)
+					}
+				}
+			)
+		} catch (err) {
+			// Clean up the raw/ object so it doesn't linger without a DB record —
+			// raw/ holds full EXIF (incl. GPS) so an orphan is a privacy issue.
+			// If deletion fails, capture so an ops script can reconcile.
+			await opts.storage.delete('raw', rawPathKey).catch((delErr) => {
+				Sentry.captureException(delErr, {
+					extra: { phase: 'raw cleanup after pub failure', rawPathKey },
+				})
+			})
+			if (err instanceof Error && /pixel limit/i.test(err.message)) {
+				throw new UserError(
+					'IMAGE_TOO_LARGE',
+					'Photo resolution exceeds 16 megapixels — please resize before uploading.'
+				)
+			}
+			if (
+				err instanceof Error &&
+				/vipsjpeg|premature end|corrupt/i.test(err.message)
+			) {
+				throw new UserError(
+					'CORRUPT_IMAGE',
+					'The photo could not be decoded. Please try a different file.'
+				)
+			}
+			throw err
+		}
+
+		return { id }
+	} catch (err) {
+		phase = 'error'
+		throw err
+	} finally {
+		logger.info(
+			{
+				phase,
+				listingPhotoId: id,
+				rssBytes: process.memoryUsage().rss,
+			},
+			'uploadListingPhoto'
+		)
+	}
 }

--- a/apps/www/src/lib/server-error-middleware.ts
+++ b/apps/www/src/lib/server-error-middleware.ts
@@ -1,4 +1,5 @@
 import { createMiddleware } from '@tanstack/solid-start'
+import { setResponseStatus } from '@tanstack/solid-start/server'
 import { Sentry } from './sentry'
 export { UserError } from './user-error'
 import { UserError } from './user-error'
@@ -16,6 +17,9 @@ export const errorMiddleware = createMiddleware({ type: 'function' }).server(
 			return await next()
 		} catch (error) {
 			if (error instanceof UserError) {
+				if (error.status) {
+					setResponseStatus(error.status)
+				}
 				throw error
 			}
 

--- a/apps/www/src/lib/storage.server.ts
+++ b/apps/www/src/lib/storage.server.ts
@@ -1,18 +1,49 @@
 import { createReadStream, createWriteStream } from 'node:fs'
-import { readFile, mkdir, writeFile, rm } from 'node:fs/promises'
+import { readFile, mkdir, rm } from 'node:fs/promises'
 import { dirname, resolve, sep } from 'node:path'
-import { Readable } from 'node:stream'
+import { Readable, Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import {
 	S3Client,
-	PutObjectCommand,
 	GetObjectCommand,
 	DeleteObjectCommand,
+	type PutObjectCommandInput,
 } from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
 import { Sentry } from '@/lib/sentry'
 import { serverEnv } from '@/lib/env.server'
 
-export type StorageBody = Buffer | Readable
+/**
+ * Storage uploads always take a stream — buffering happens (if at all) at the
+ * call site, never inside the adapter, so peak memory is visible.
+ */
+export type StorageBody = Readable
+
+const multipartUploadPartSize = 5 * 1024 * 1024
+
+/**
+ * Pass-through Transform that counts bytes flowing through it. Used to record
+ * `storage.bytes_written` on upload spans without buffering or interfering
+ * with downstream backpressure (a plain PassThrough with a 'data' listener
+ * would flip the stream into flowing mode and break the consumer).
+ */
+function makeByteCounter(): { stream: Transform; bytes: () => number } {
+	let count = 0
+	const stream = new Transform({
+		transform(chunk: Buffer, _enc, cb) {
+			count += chunk.length
+			cb(null, chunk)
+		},
+	})
+	return { stream, bytes: () => count }
+}
+
+/** Optional metadata for the upload — used purely for tracing/observability. */
+export interface UploadOptions {
+	mimeType: string
+	/** Optional image UUID, propagated to spans for cross-correlation. */
+	photoId?: string
+}
 
 /** Contract for all storage backends. */
 export interface StorageAdapter {
@@ -21,7 +52,7 @@ export interface StorageAdapter {
 		dir: 'raw' | 'pub',
 		pathWithinDir: string,
 		body: StorageBody,
-		opts: { mimeType: string }
+		opts: UploadOptions
 	): Promise<void>
 	/** Read a file server-side (intended for raw/private objects). */
 	read(dir: 'raw' | 'pub', pathWithinDir: string): Promise<Buffer>
@@ -65,15 +96,30 @@ export class LocalStorageAdapter implements StorageAdapter {
 		dir: 'raw' | 'pub',
 		pathWithinDir: string,
 		body: StorageBody,
-		_opts: { mimeType: string }
+		opts: UploadOptions
 	): Promise<void> {
 		const filePath = this.safeFilePath(dir, pathWithinDir)
-		await mkdir(dirname(filePath), { recursive: true })
-		if (Buffer.isBuffer(body)) {
-			await writeFile(filePath, body)
-			return
-		}
-		await pipeline(body, createWriteStream(filePath))
+		const counter = makeByteCounter()
+		await Sentry.startSpan(
+			{
+				name: 'storage.upload.local',
+				op: 'storage.upload',
+				attributes: {
+					'storage.provider': 'local',
+					'storage.dir': dir,
+					'storage.key': `${dir}/${pathWithinDir}`,
+					'storage.mime_type': opts.mimeType,
+					'storage.streaming': true,
+					'storage.target_path': filePath,
+					...(opts.photoId ? { 'photo.id': opts.photoId } : {}),
+				},
+			},
+			async (span) => {
+				await mkdir(dirname(filePath), { recursive: true })
+				await pipeline(body, counter.stream, createWriteStream(filePath))
+				span.setAttribute('storage.bytes_written', counter.bytes())
+			}
+		)
 	}
 
 	async read(dir: 'raw' | 'pub', pathWithinDir: string): Promise<Buffer> {
@@ -133,16 +179,52 @@ export class TigrisStorageAdapter implements StorageAdapter {
 		dir: 'raw' | 'pub',
 		pathWithinDir: string,
 		body: StorageBody,
-		opts: { mimeType: string }
+		opts: UploadOptions
 	): Promise<void> {
-		await this.client.send(
-			new PutObjectCommand({
-				Bucket: this.bucket,
-				Key: `${dir}/${pathWithinDir}`,
-				Body: body,
-				ContentType: opts.mimeType,
-				...(dir === 'pub' ? { ACL: 'public-read' } : {}),
-			})
+		const key = `${dir}/${pathWithinDir}`
+		const counter = makeByteCounter()
+		const params: PutObjectCommandInput = {
+			Bucket: this.bucket,
+			Key: key,
+			Body: counter.stream,
+			ContentType: opts.mimeType,
+			...(dir === 'pub' ? { ACL: 'public-read' } : {}),
+		}
+		await Sentry.startSpan(
+			{
+				name: 'storage.upload.tigris',
+				op: 'storage.upload',
+				attributes: {
+					'storage.provider': 'tigris',
+					'storage.dir': dir,
+					'storage.key': key,
+					'storage.bucket': this.bucket,
+					'storage.mime_type': opts.mimeType,
+					'storage.streaming': true,
+					'storage.upload_strategy': 'multipart',
+					'storage.part_size_bytes': multipartUploadPartSize,
+					'storage.queue_size': 1,
+					'storage.acl': dir === 'pub' ? 'public-read' : 'private',
+					...(opts.photoId ? { 'photo.id': opts.photoId } : {}),
+				},
+			},
+			async (span) => {
+				// pipeline (not body.pipe) so a source-stream error destroys
+				// counter.stream — Upload then sees the error and rejects, instead
+				// of completing with a truncated-but-valid object.
+				const piped = pipeline(body, counter.stream)
+				const upload = new Upload({
+					client: this.client,
+					params,
+					queueSize: 1,
+					partSize: multipartUploadPartSize,
+				}).done()
+				const [, result] = await Promise.all([piped, upload])
+				span.setAttribute('storage.bytes_written', counter.bytes())
+				if ('ETag' in result && result.ETag) {
+					span.setAttribute('storage.etag', result.ETag)
+				}
+			}
 		)
 	}
 

--- a/apps/www/src/lib/user-error.ts
+++ b/apps/www/src/lib/user-error.ts
@@ -5,10 +5,12 @@
  */
 export class UserError extends Error {
 	public readonly code: string
+	public readonly status?: number
 
-	constructor(code: string, message: string) {
+	constructor(code: string, message: string, status?: number) {
 		super(message)
 		this.name = 'UserError'
 		this.code = code
+		this.status = status
 	}
 }

--- a/apps/www/tests/listing-photo-api.server.test.ts
+++ b/apps/www/tests/listing-photo-api.server.test.ts
@@ -61,7 +61,7 @@ vi.mock('sharp', () => ({
 		vi.fn(() => ({
 			autoOrient: mockSharpAutoOrient,
 		})),
-		{ concurrency: vi.fn() }
+		{ concurrency: vi.fn(), cache: vi.fn() }
 	),
 }))
 

--- a/apps/www/tests/listing-photo-exif.server.test.ts
+++ b/apps/www/tests/listing-photo-exif.server.test.ts
@@ -5,7 +5,7 @@
  * Uses a real JPEG fixture with GPS data; exiftool-vendored reads EXIF tags from
  * the processed buffer to confirm removal. This test does NOT mock sharp.
  */
-import { describe, it, expect, afterAll } from 'vitest'
+import { describe, it, expect, afterAll, afterEach } from 'vitest'
 import { readFileSync, writeFileSync, unlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -15,24 +15,40 @@ import type { StorageAdapter, StorageBody } from '../src/lib/storage.server'
 
 // No vi.mock('sharp') — exercises the real native binary.
 const sharp = (await import('sharp')).default
-const { uploadListingPhoto } =
+const { uploadListingPhoto, MAX_IMAGE_PIXELS, PUB_MAX_DIMENSION } =
 	await import('../src/lib/listing-photo-upload.server')
 
 afterAll(() => exiftool.end())
 
 describe('EXIF stripping (real sharp)', () => {
-	// ExifTool spawns a subprocess on first use; allow extra time for startup.
-	it('removes GPS tags from the public copy', { timeout: 30_000 }, async () => {
-		const rawBuffer = readFileSync(join(__dirname, 'fixtures/flower-bees.jpg'))
+	const tempPaths: string[] = []
+	afterEach(() => {
+		while (tempPaths.length > 0) {
+			try {
+				unlinkSync(tempPaths.pop()!)
+			} catch {
+				// already gone
+			}
+		}
+	})
 
-		// Capture the streamed body passed to storage.upload('pub', ...)
+	function stageRawBuffer(rawBuffer: Buffer): string {
+		const path = join(tmpdir(), `pmf-exif-stage-${Date.now()}-${Math.random()}`)
+		writeFileSync(path, rawBuffer)
+		tempPaths.push(path)
+		return path
+	}
+
+	async function captureUpload(
+		tempPath: string,
+		mimeType: 'image/jpeg' | 'image/png' | 'image/webp',
+		fileExt: string
+	): Promise<Buffer> {
 		let pubBuffer: Buffer | undefined
 		const storage: StorageAdapter = {
 			upload: async (dir: string, _key: string, body: StorageBody) => {
 				if (dir === 'pub') {
-					pubBuffer = Buffer.isBuffer(body)
-						? body
-						: Buffer.concat(await Readable.from(body).toArray())
+					pubBuffer = Buffer.concat(await Readable.from(body).toArray())
 				}
 			},
 			read: async () => {
@@ -47,19 +63,22 @@ describe('EXIF stripping (real sharp)', () => {
 			publicUrl: (key: string) => `/api/uploads/pub/${key}`,
 			delete: async () => {},
 		}
-
-		await uploadListingPhoto({
-			rawBuffer,
-			mimeType: 'image/jpeg',
-			fileExt: '.jpg',
-			storage,
-		})
-
+		await uploadListingPhoto({ tempPath, mimeType, fileExt, storage })
 		expect(pubBuffer).toBeDefined()
+		return pubBuffer!
+	}
 
-		// Write to a temp file so exiftool-vendored can read it
+	// ExifTool spawns a subprocess on first use; allow extra time for startup.
+	it('removes GPS tags from the public copy', { timeout: 30_000 }, async () => {
+		const rawBuffer = readFileSync(join(__dirname, 'fixtures/flower-bees.jpg'))
+		const pubBuffer = await captureUpload(
+			stageRawBuffer(rawBuffer),
+			'image/jpeg',
+			'.jpg'
+		)
+
 		const tmpPath = join(tmpdir(), `pmf-exif-test-${Date.now()}.jpg`)
-		writeFileSync(tmpPath, pubBuffer!)
+		writeFileSync(tmpPath, pubBuffer)
 		try {
 			const tags = await exiftool.read(tmpPath)
 			expect(tags.GPSLatitude).toBeUndefined()
@@ -71,10 +90,98 @@ describe('EXIF stripping (real sharp)', () => {
 	})
 
 	it(
+		'auto-orients real-sized images (regression: sequentialRead skipped rotation)',
+		{ timeout: 30_000 },
+		async () => {
+			// 1024×768 keeps libvips out of its small-image fallback path, where
+			// rotation works regardless of input access mode. The previous 8×4
+			// fixture passed even when sequentialRead silently dropped rotation.
+			const rawBuffer = await sharp({
+				create: {
+					width: 1024,
+					height: 768,
+					channels: 3,
+					background: { r: 10, g: 20, b: 30 },
+				},
+			})
+				.withMetadata({ orientation: 6 })
+				.jpeg()
+				.toBuffer()
+
+			const pubBuffer = await captureUpload(
+				stageRawBuffer(rawBuffer),
+				'image/jpeg',
+				'.jpg'
+			)
+
+			const pubMeta = await sharp(pubBuffer).metadata()
+			expect(pubMeta.width).toBe(768)
+			expect(pubMeta.height).toBe(1024)
+			expect(pubMeta.orientation).toBeUndefined()
+		}
+	)
+
+	it(
+		'caps the public copy at PUB_MAX_DIMENSION on the long edge',
+		{ timeout: 30_000 },
+		async () => {
+			// Long edge 2400 → expected to shrink to 2048; aspect preserved.
+			const rawBuffer = await sharp({
+				create: {
+					width: 2400,
+					height: 1200,
+					channels: 3,
+					background: { r: 200, g: 100, b: 50 },
+				},
+			})
+				.jpeg()
+				.toBuffer()
+
+			const pubBuffer = await captureUpload(
+				stageRawBuffer(rawBuffer),
+				'image/jpeg',
+				'.jpg'
+			)
+
+			const pubMeta = await sharp(pubBuffer).metadata()
+			expect(pubMeta.width).toBe(PUB_MAX_DIMENSION)
+			expect(pubMeta.height).toBe(PUB_MAX_DIMENSION / 2)
+		}
+	)
+
+	it(
+		'rejects images exceeding MAX_IMAGE_PIXELS with IMAGE_TOO_LARGE',
+		{ timeout: 30_000 },
+		async () => {
+			// One pixel over the cap. Sharp's `limitInputPixels` rejects at
+			// pipeline read; the catch handler in uploadListingPhoto rethrows
+			// as a UserError.
+			const overLimit = MAX_IMAGE_PIXELS + 1
+			const width = 5000
+			const height = Math.ceil(overLimit / width)
+			const rawBuffer = await sharp({
+				create: {
+					width,
+					height,
+					channels: 3,
+					background: { r: 0, g: 0, b: 0 },
+				},
+			})
+				.jpeg()
+				.toBuffer()
+
+			const error = await captureUpload(
+				stageRawBuffer(rawBuffer),
+				'image/jpeg',
+				'.jpg'
+			).catch((err: unknown) => err)
+			expect((error as { code?: string }).code).toBe('IMAGE_TOO_LARGE')
+		}
+	)
+
+	it(
 		'auto-orients pixels and drops orientation metadata on the public copy',
-		{
-			timeout: 30_000,
-		},
+		{ timeout: 30_000 },
 		async () => {
 			const rawBuffer = await sharp({
 				create: {
@@ -88,44 +195,19 @@ describe('EXIF stripping (real sharp)', () => {
 				.jpeg()
 				.toBuffer()
 
-			let pubBuffer: Buffer | undefined
-			const storage: StorageAdapter = {
-				upload: async (dir: string, _key: string, body: StorageBody) => {
-					if (dir === 'pub') {
-						pubBuffer = Buffer.isBuffer(body)
-							? body
-							: Buffer.concat(await Readable.from(body).toArray())
-					}
-				},
-				read: async () => {
-					throw new Error('not implemented')
-				},
-				readStream: async () => {
-					throw new Error('not implemented')
-				},
-				readWebStream: async () => {
-					throw new Error('not implemented')
-				},
-				publicUrl: (key: string) => `/api/uploads/pub/${key}`,
-				delete: async () => {},
-			}
+			const pubBuffer = await captureUpload(
+				stageRawBuffer(rawBuffer),
+				'image/jpeg',
+				'.jpg'
+			)
 
-			await uploadListingPhoto({
-				rawBuffer,
-				mimeType: 'image/jpeg',
-				fileExt: '.jpg',
-				storage,
-			})
-
-			expect(pubBuffer).toBeDefined()
-
-			const pubMeta = await sharp(pubBuffer!).metadata()
+			const pubMeta = await sharp(pubBuffer).metadata()
 			expect(pubMeta.width).toBe(4)
 			expect(pubMeta.height).toBe(8)
 			expect(pubMeta.orientation).toBeUndefined()
 
 			const tmpPath = join(tmpdir(), `pmf-orient-test-${Date.now()}.jpg`)
-			writeFileSync(tmpPath, pubBuffer!)
+			writeFileSync(tmpPath, pubBuffer)
 			try {
 				const tags = await exiftool.read(tmpPath)
 				expect(tags.Orientation).toBeUndefined()

--- a/apps/www/tests/listing-photo-upload.server.test.ts
+++ b/apps/www/tests/listing-photo-upload.server.test.ts
@@ -1,57 +1,82 @@
 /**
- * Unit tests for listing photo upload logic.
+ * Unit-ish tests for listing photo upload framing.
  *
- * Covers the four key risks called out in docs/0004-listing-photos.md PR 3:
- *   - wrong MIME type rejected
- *   - oversized file rejected
- *   - unrecognized magic bytes rejected
- *   - auth guard (tested in listing-photo-api.server.test.ts against the server fn)
+ * Sharp is *not* mocked. Tests run against tiny in-memory fixtures so the
+ * real libvips pipeline executes end-to-end. The brittle chain mock (one
+ * vi.fn per Sharp method, returning the next link) was replaced with this
+ * approach: assertions check inputs/outputs (paths, ids, stream wiring,
+ * mutex ordering, RSS log lines), not which Sharp methods were called.
+ *
+ * Behavior-level concerns (rotation, EXIF stripping, size caps, resize cap)
+ * live in listing-photo-exif.server.test.ts — same dependency on real Sharp.
  */
-import { PassThrough } from 'node:stream'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { writeFileSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import {
+	describe,
+	it,
+	expect,
+	vi,
+	beforeAll,
+	beforeEach,
+	afterEach,
+} from 'vitest'
 import type { StorageAdapter } from '../src/lib/storage.server'
-
-// ============================================================================
-// Mock mime-bytes — avoids real magic-byte detection in unit tests.
-// ============================================================================
-
-const mockDetectFromBuffer = vi.fn()
-
-vi.mock('mime-bytes', () => ({
-	detectFromBuffer: (...args: unknown[]) => mockDetectFromBuffer(...args),
-}))
-
-// ============================================================================
-// Mock sharp — avoids native binary in unit tests.
-// Production streams through .jpeg() — mock the transform chain.
-// ============================================================================
-
-const mockConcurrency = vi.fn()
-const mockJpeg = vi.fn()
-const mockAutoOrient = vi.fn()
-const mockSharp = vi.fn()
-
-vi.mock('sharp', () => ({
-	default: Object.assign(mockSharp, { concurrency: mockConcurrency }),
-}))
+import { UserError } from '../src/lib/user-error'
 
 vi.mock('../src/lib/env.server', () => ({
-	serverEnv: {
-		SHARP_CONCURRENCY: 1,
+	serverEnv: { SHARP_CONCURRENCY: 1 },
+}))
+
+const mockLoggerInfo = vi.fn()
+vi.mock('../src/lib/logger.server', () => ({
+	logger: {
+		info: mockLoggerInfo,
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
 	},
 }))
 
-// Must import after mocking
-const { validatePhotoFile, uploadListingPhoto } =
-	await import('../src/lib/listing-photo-upload.server')
+const sharp = (await import('sharp')).default
+const {
+	validatePhotoFile,
+	uploadListingPhoto,
+	assertPhotoUploadCapacity,
+	MAX_UPLOAD_QUEUE_DEPTH,
+} = await import('../src/lib/listing-photo-upload.server')
 
-// ============================================================================
-// Helpers
-// ============================================================================
+// One reusable real fixture per format. Tiny so the encode is instant.
+let jpegFixture: Buffer
+let pngFixture: Buffer
+let webpFixture: Buffer
+beforeAll(async () => {
+	const base = sharp({
+		create: {
+			width: 10,
+			height: 10,
+			channels: 3,
+			background: { r: 0, g: 128, b: 0 },
+		},
+	})
+	jpegFixture = await base.clone().jpeg().toBuffer()
+	pngFixture = await base.clone().png().toBuffer()
+	webpFixture = await base.clone().webp().toBuffer()
+})
 
 function makeStorage(): StorageAdapter {
 	return {
-		upload: vi.fn().mockResolvedValue(undefined),
+		// Drain stream bodies so the upstream createReadStream actually opens
+		// the temp file before the test's afterEach removes it.
+		upload: vi.fn().mockImplementation(async (_dir, _key, body) => {
+			if (body && typeof body[Symbol.asyncIterator] === 'function') {
+				for await (const _chunk of body) {
+					// ignore
+				}
+			}
+		}),
 		read: vi.fn(),
 		readStream: vi.fn(),
 		readWebStream: vi.fn(),
@@ -61,75 +86,108 @@ function makeStorage(): StorageAdapter {
 }
 
 // ============================================================================
-// validatePhotoFile
+// validatePhotoFile — real magic-byte detection on real bytes
 // ============================================================================
 
 describe('validatePhotoFile', () => {
-	const smallBuf = Buffer.from('fake')
-	const fiveMb = Buffer.alloc(5 * 1024 * 1024)
-	const sixMb = Buffer.alloc(6 * 1024 * 1024)
-
-	it('accepts image/jpeg', async () => {
-		mockDetectFromBuffer.mockResolvedValue({ mimeType: 'image/jpeg' })
-		await expect(validatePhotoFile(smallBuf)).resolves.toBe('image/jpeg')
+	it('accepts a real JPEG', async () => {
+		await expect(validatePhotoFile(jpegFixture)).resolves.toBe('image/jpeg')
 	})
 
-	it('accepts image/png', async () => {
-		mockDetectFromBuffer.mockResolvedValue({ mimeType: 'image/png' })
-		await expect(validatePhotoFile(smallBuf)).resolves.toBe('image/png')
+	it('accepts a real PNG', async () => {
+		await expect(validatePhotoFile(pngFixture)).resolves.toBe('image/png')
 	})
 
-	it('accepts image/webp', async () => {
-		mockDetectFromBuffer.mockResolvedValue({ mimeType: 'image/webp' })
-		await expect(validatePhotoFile(smallBuf)).resolves.toBe('image/webp')
+	it('accepts a real WebP', async () => {
+		await expect(validatePhotoFile(webpFixture)).resolves.toBe('image/webp')
 	})
 
-	it('rejects files with unrecognized magic bytes', async () => {
-		mockDetectFromBuffer.mockResolvedValue(null)
-		await expect(validatePhotoFile(smallBuf)).rejects.toThrow()
+	it('rejects bytes that match no known magic', async () => {
+		await expect(
+			validatePhotoFile(Buffer.from('not actually an image'))
+		).rejects.toThrow()
 	})
 
-	it('rejects non-image MIME types detected from bytes', async () => {
-		mockDetectFromBuffer.mockResolvedValue({ mimeType: 'application/pdf' })
-		await expect(validatePhotoFile(smallBuf)).rejects.toThrow()
+	it('rejects PDF magic bytes', async () => {
+		await expect(
+			validatePhotoFile(Buffer.from('%PDF-1.4\n%binary marker'))
+		).rejects.toThrow()
 	})
 
-	it('rejects image/gif (not in the allowed set)', async () => {
-		mockDetectFromBuffer.mockResolvedValue({ mimeType: 'image/gif' })
-		await expect(validatePhotoFile(smallBuf)).rejects.toThrow()
+	it('rejects GIF (allowed-set excludes animation formats)', async () => {
+		const gifMagic = Buffer.concat([
+			Buffer.from('GIF89a'),
+			Buffer.alloc(100), // padding so detectors that read more than 6 bytes succeed
+		])
+		await expect(validatePhotoFile(gifMagic)).rejects.toThrow()
 	})
 
 	it('rejects files over 5 MB', async () => {
-		mockDetectFromBuffer.mockResolvedValue({ mimeType: 'image/jpeg' })
-		await expect(validatePhotoFile(sixMb)).rejects.toThrow()
+		const oversized = Buffer.concat([
+			jpegFixture,
+			Buffer.alloc(5 * 1024 * 1024 + 1),
+		])
+		await expect(validatePhotoFile(oversized)).rejects.toThrow()
 	})
 
 	it('accepts files exactly at 5 MB', async () => {
-		mockDetectFromBuffer.mockResolvedValue({ mimeType: 'image/jpeg' })
-		await expect(validatePhotoFile(fiveMb)).resolves.toBe('image/jpeg')
+		const exactlyFiveMb = Buffer.concat([
+			jpegFixture,
+			Buffer.alloc(5 * 1024 * 1024 - jpegFixture.byteLength),
+		])
+		await expect(validatePhotoFile(exactlyFiveMb)).resolves.toBe('image/jpeg')
 	})
 })
 
 // ============================================================================
-// uploadListingPhoto
+// uploadListingPhoto — framing & wiring (real Sharp pipeline)
 // ============================================================================
 
 describe('uploadListingPhoto', () => {
+	let tempPaths: string[] = []
+
+	function stage(buffer: Buffer): string {
+		const path = join(tmpdir(), `pmf-test-upload-${Date.now()}-${Math.random()}`)
+		writeFileSync(path, buffer)
+		tempPaths.push(path)
+		return path
+	}
+
 	beforeEach(() => {
 		vi.clearAllMocks()
-		mockJpeg.mockReturnValue(new PassThrough())
-		mockAutoOrient.mockReturnValue({ jpeg: mockJpeg })
-		mockSharp.mockReturnValue({
-			autoOrient: mockAutoOrient,
-		})
 	})
 
-	it('uploads the raw buffer to raw/ dir preserving input extension', async () => {
-		const storage = makeStorage()
-		const rawBuffer = Buffer.from('raw-img')
+	afterEach(() => {
+		for (const p of tempPaths) {
+			try {
+				unlinkSync(p)
+			} catch {
+				// already gone
+			}
+		}
+		tempPaths = []
+	})
 
+	it('logs RSS at start and end of upload', async () => {
 		await uploadListingPhoto({
-			rawBuffer,
+			tempPath: stage(jpegFixture),
+			mimeType: 'image/jpeg',
+			fileExt: '.jpg',
+			storage: makeStorage(),
+		})
+
+		const phases = mockLoggerInfo.mock.calls
+			.map(([fields]) => fields as { phase?: string; rssBytes?: number })
+			.filter((f) => f.phase === 'start' || f.phase === 'end')
+		expect(phases.map((f) => f.phase)).toEqual(['start', 'end'])
+		expect(phases[0]!.rssBytes).toBeTypeOf('number')
+		expect(phases[1]!.rssBytes).toBeTypeOf('number')
+	})
+
+	it('streams the raw file to raw/ dir preserving input extension', async () => {
+		const storage = makeStorage()
+		await uploadListingPhoto({
+			tempPath: stage(webpFixture),
 			mimeType: 'image/webp',
 			fileExt: '.webp',
 			storage,
@@ -138,74 +196,147 @@ describe('uploadListingPhoto', () => {
 		const [rawCall] = (storage.upload as ReturnType<typeof vi.fn>).mock.calls
 		expect(rawCall[0]).toBe('raw')
 		expect(rawCall[1]).toMatch(/^listing_photos\/[\w-]+\.webp$/)
-		expect(rawCall[2]).toBe(rawBuffer)
+		expect(rawCall[2]).toBeInstanceOf(Readable)
 	})
 
-	it('sets sharp concurrency from SHARP_CONCURRENCY before processing', async () => {
+	it('streams an image/jpeg body to pub/ dir regardless of input format', async () => {
 		const storage = makeStorage()
-		process.env.SHARP_CONCURRENCY = '1'
-
 		await uploadListingPhoto({
-			rawBuffer: Buffer.from('raw-img'),
+			tempPath: stage(pngFixture),
 			mimeType: 'image/png',
 			fileExt: '.png',
 			storage,
 		})
-
-		expect(mockConcurrency).toHaveBeenCalledWith(1)
-	})
-
-	it('converts to JPEG and streams the clean image to pub/ dir', async () => {
-		const storage = makeStorage()
-		const rawBuffer = Buffer.from('raw-img')
-
-		await uploadListingPhoto({
-			rawBuffer,
-			mimeType: 'image/png',
-			fileExt: '.png',
-			storage,
-		})
-
-		expect(mockSharp).toHaveBeenCalledWith({ sequentialRead: true })
-		expect(mockAutoOrient).toHaveBeenCalled()
-		expect(mockJpeg).toHaveBeenCalled()
 
 		const { calls } = (storage.upload as ReturnType<typeof vi.fn>).mock
 		const pubCall = calls.find((c: unknown[]) => c[0] === 'pub')
 		expect(pubCall).toBeDefined()
-		expect(Buffer.isBuffer(pubCall![2])).toBeFalsy()
-		expect(pubCall![2]).toHaveProperty('pipe')
+		expect(pubCall![2]).toBeInstanceOf(Readable)
+		expect(pubCall![3]).toMatchObject({ mimeType: 'image/jpeg' })
 	})
 
-	it('pub path is always .jpg regardless of input extension', async () => {
+	it('opens distinct read streams for raw and pub uploads', async () => {
 		const storage = makeStorage()
-
 		await uploadListingPhoto({
-			rawBuffer: Buffer.from('img'),
+			tempPath: stage(jpegFixture),
+			mimeType: 'image/jpeg',
+			fileExt: '.jpg',
+			storage,
+		})
+
+		const { calls } = (storage.upload as ReturnType<typeof vi.fn>).mock
+		const rawCall = calls.find((c: unknown[]) => c[0] === 'raw')
+		const pubCall = calls.find((c: unknown[]) => c[0] === 'pub')
+		// Two streams from the same file means we never buffered into a shared blob.
+		expect(rawCall![2]).not.toBe(pubCall![2])
+	})
+
+	it('uses .jpg as the pub extension regardless of input extension', async () => {
+		const storage = makeStorage()
+		await uploadListingPhoto({
+			tempPath: stage(webpFixture),
 			mimeType: 'image/webp',
 			fileExt: '.webp',
 			storage,
 		})
 
 		const { calls } = (storage.upload as ReturnType<typeof vi.fn>).mock
-		const rawPath = calls.find((c: unknown[]) => c[0] === 'raw')?.[1]
-		const pubPath = calls.find((c: unknown[]) => c[0] === 'pub')?.[1]
-		// Raw preserves input extension; pub is always JPEG
-		expect(rawPath).toMatch(/\.webp$/)
-		expect(pubPath).toMatch(/\.jpg$/)
+		expect(calls.find((c: unknown[]) => c[0] === 'raw')?.[1]).toMatch(/\.webp$/)
+		expect(calls.find((c: unknown[]) => c[0] === 'pub')?.[1]).toMatch(/\.jpg$/)
 	})
 
-	it('returns id matching a UUID v7 pattern', async () => {
-		const storage = makeStorage()
+	it('serializes concurrent uploads (mutex)', async () => {
+		const events: string[] = []
+		const slowStorage: StorageAdapter = {
+			upload: vi.fn().mockImplementation(async (dir, _key, body) => {
+				events.push(`${dir}-start`)
+				if (body && typeof body[Symbol.asyncIterator] === 'function') {
+					for await (const _chunk of body) {
+						// drain
+					}
+				}
+				await new Promise((resolve) => setTimeout(resolve, 30))
+				events.push(`${dir}-end`)
+			}),
+			read: vi.fn(),
+			readStream: vi.fn(),
+			readWebStream: vi.fn(),
+			publicUrl: vi.fn((p: string) => `/api/uploads/pub/${p}`),
+			delete: vi.fn().mockResolvedValue(undefined),
+		}
 
+		await Promise.all([
+			uploadListingPhoto({
+				tempPath: stage(jpegFixture),
+				mimeType: 'image/jpeg',
+				fileExt: '.jpg',
+				storage: slowStorage,
+			}),
+			uploadListingPhoto({
+				tempPath: stage(jpegFixture),
+				mimeType: 'image/jpeg',
+				fileExt: '.jpg',
+				storage: slowStorage,
+			}),
+		])
+
+		const firstPubEnd = events.indexOf('pub-end')
+		const secondRawStart = events.lastIndexOf('raw-start')
+		expect(firstPubEnd).toBeGreaterThanOrEqual(0)
+		expect(secondRawStart).toBeGreaterThan(firstPubEnd)
+	})
+
+	it('throws SERVER_BUSY (503) when the upload queue is at capacity', async () => {
+		// Slow storage so the four submitted uploads remain "in flight" long
+		// enough for the capacity check to observe queueDepth at the cap. They
+		// drain naturally via the 30 ms timeout — no manual release plumbing.
+		const slowStorage: StorageAdapter = {
+			upload: vi.fn().mockImplementation(async (_dir, _key, body) => {
+				if (body && typeof body[Symbol.asyncIterator] === 'function') {
+					for await (const _chunk of body) {
+						// drain so the temp file isn't held open
+					}
+				}
+				await new Promise((resolve) => setTimeout(resolve, 30))
+			}),
+			read: vi.fn(),
+			readStream: vi.fn(),
+			readWebStream: vi.fn(),
+			publicUrl: vi.fn((p: string) => `/api/uploads/pub/${p}`),
+			delete: vi.fn().mockResolvedValue(undefined),
+		}
+
+		const inFlight = Array.from({ length: MAX_UPLOAD_QUEUE_DEPTH }, () =>
+			uploadListingPhoto({
+				tempPath: stage(jpegFixture),
+				mimeType: 'image/jpeg',
+				fileExt: '.jpg',
+				storage: slowStorage,
+			})
+		)
+
+		// queueDepth is incremented synchronously in withUploadLock, so the
+		// fifth call rejects before doing any work.
+		let caught: unknown
+		try {
+			assertPhotoUploadCapacity()
+		} catch (e) {
+			caught = e
+		}
+		expect(caught).toBeInstanceOf(UserError)
+		expect((caught as UserError).code).toBe('SERVER_BUSY')
+		expect((caught as UserError).status).toBe(503)
+
+		await Promise.all(inFlight)
+	})
+
+	it('returns an id matching the UUIDv7 pattern', async () => {
 		const result = await uploadListingPhoto({
-			rawBuffer: Buffer.from('img'),
+			tempPath: stage(jpegFixture),
 			mimeType: 'image/jpeg',
 			fileExt: '.jpg',
-			storage,
+			storage: makeStorage(),
 		})
-
-		// UUID v7: 8-4-4-4-12 hex chars, version nibble = 7
 		expect(result.id).toMatch(
 			/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/
 		)

--- a/apps/www/tests/storage.server.test.ts
+++ b/apps/www/tests/storage.server.test.ts
@@ -27,7 +27,7 @@ describe(LocalStorageAdapter, () => {
 	describe('upload + publicUrl (public access)', () => {
 		it('writes the file and returns a /api/uploads/ URL', async () => {
 			const buf = Buffer.from('fake-image-data')
-			await adapter.upload('pub', 'listings/1/test.png', buf, {
+			await adapter.upload('pub', 'listings/1/test.png', Readable.from(buf), {
 				mimeType: 'image/png',
 			})
 
@@ -42,9 +42,12 @@ describe(LocalStorageAdapter, () => {
 		})
 
 		it('creates nested directories as needed', async () => {
-			await adapter.upload('pub', 'listings/99/deep/uuid.jpg', Buffer.from('x'), {
-				mimeType: 'image/jpeg',
-			})
+			await adapter.upload(
+				'pub',
+				'listings/99/deep/uuid.jpg',
+				Readable.from(Buffer.from('x')),
+				{ mimeType: 'image/jpeg' }
+			)
 			const written = await readFile(
 				join(tmpDir, 'uploads', 'pub', 'listings/99/deep/uuid.jpg')
 			)
@@ -70,7 +73,7 @@ describe(LocalStorageAdapter, () => {
 	describe('upload + read (private access)', () => {
 		it('writes the file and read returns the original buffer', async () => {
 			const buf = Buffer.from('raw-image-with-exif')
-			await adapter.upload('raw', 'listings/1/test.png', buf, {
+			await adapter.upload('raw', 'listings/1/test.png', Readable.from(buf), {
 				mimeType: 'image/png',
 			})
 
@@ -79,9 +82,12 @@ describe(LocalStorageAdapter, () => {
 		})
 
 		it('readStream returns a readable stream for an object', async () => {
-			await adapter.upload('raw', 'listings/1/test.png', Buffer.from('raw'), {
-				mimeType: 'image/png',
-			})
+			await adapter.upload(
+				'raw',
+				'listings/1/test.png',
+				Readable.from(Buffer.from('raw')),
+				{ mimeType: 'image/png' }
+			)
 
 			await expect(
 				text(await adapter.readStream('raw', 'listings/1/test.png'))
@@ -89,9 +95,12 @@ describe(LocalStorageAdapter, () => {
 		})
 
 		it('readWebStream returns a response body stream without buffering through read()', async () => {
-			await adapter.upload('pub', 'listings/1/test.jpg', Buffer.from('public'), {
-				mimeType: 'image/jpeg',
-			})
+			await adapter.upload(
+				'pub',
+				'listings/1/test.jpg',
+				Readable.from(Buffer.from('public')),
+				{ mimeType: 'image/jpeg' }
+			)
 
 			const readSpy = vi.spyOn(adapter, 'read')
 			const response = new Response(
@@ -118,7 +127,7 @@ describe(LocalStorageAdapter, () => {
 			await adapter.upload(
 				'pub',
 				'listings/1/delete-me.png',
-				Buffer.from('data'),
+				Readable.from(Buffer.from('data')),
 				{
 					mimeType: 'image/png',
 				}
@@ -139,9 +148,12 @@ describe(LocalStorageAdapter, () => {
 	describe('path traversal', () => {
 		it('upload rejects traversal in pathWithinDir', async () => {
 			await expect(
-				adapter.upload('pub', '../../../etc/passwd', Buffer.from('x'), {
-					mimeType: 'text/plain',
-				})
+				adapter.upload(
+					'pub',
+					'../../../etc/passwd',
+					Readable.from(Buffer.from('x')),
+					{ mimeType: 'text/plain' }
+				)
 			).rejects.toThrow('Invalid storage key')
 		})
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,32 @@ services:
         required: false
       - path: .env
         required: false
+    # Memory limits and NODE_OPTIONS / SHARP_CONCURRENCY mirror the Fly
+    # production VM (see fly.toml [[vm]] and [env]) so local runs can reproduce
+    # OOM behavior. Keep these in sync with fly.toml.
     environment:
+      BETTER_AUTH_URL: http://localhost:3000
       NODE_ENV: development
       DATABASE_URL: file:/app/data/development.db
+      # V8 heap capped at ~75% of the VM so GC fires before the OS OOM-kills,
+      # leaving headroom for libvips native allocations.
+      NODE_OPTIONS: --max-old-space-size=384
+      # Serialize libvips — the VM is 1 shared CPU; parallel image work just
+      # bloats RSS without throughput gain.
+      SHARP_CONCURRENCY: "1"
+      # glibc default is up to 8 arenas/CPU, each reserving ~64 MB. Capping at 2
+      # significantly lowers RSS for Node + native-binary workloads.
+      MALLOC_ARENA_MAX: "2"
+      # libuv default is 4. On 1 shared CPU the extra threads buy memory
+      # pressure with no real parallelism. Keep 2 so I/O and TLS can overlap.
+      UV_THREADPOOL_SIZE: "2"
+    deploy:
+      resources:
+        limits:
+          # Mirrors fly.toml [[vm]]. Bumped to 512 MB on 2026-04-27 because a
+          # single 12 MP iPhone JPEG drives RSS up ~120 MB inside Sharp.
+          memory: 512M
+          cpus: "1"
     healthcheck:
       test:
         [

--- a/docs/0005-image-upload-performance.md
+++ b/docs/0005-image-upload-performance.md
@@ -1,0 +1,151 @@
+# Performance
+
+Field notes from running this app on Fly.io. Most lessons here come from a multi-week saga of OOM kills during photo uploads. The fixes are scattered across the codebase; this is the map.
+
+## Deployment shape
+
+- **Fly.io** `shared-cpu-1x`, **512 MB** RAM, 1 CPU, single region (sjc).
+- Embedded **SQLite** on a Fly volume — no external DB process.
+- Photos stored in **Tigris** (S3-compatible) in two prefixes per object: `raw/` (private, full EXIF) and `pub/` (CDN-served, EXIF-stripped, auto-oriented).
+- `docker-compose.yml` mirrors the production memory/CPU/env so OOMs reproduce locally on a Mac (caveat: Docker Desktop's Linux VM has a softer cgroup OOM than Fly's bare metal — bugs that manifest on Fly may take longer to surface locally).
+
+Memory and env settings are duplicated in `fly.toml` and `docker-compose.yml` with cross-reference comments. **Keep them in sync.**
+
+## The 512 MB budget
+
+A single 12 MP iPhone JPEG drives RSS up by ~120 MB inside Sharp:
+
+- **Decoded RGBA**: 4032 × 3024 × 4 bytes ≈ 48 MB.
+- **libvips intermediate buffers** during rotation/JPEG re-encode: another ~50–70 MB.
+- **Output JPEG**: ~1.5 MB encoded.
+
+We started on 256 MB, fought it for two weeks, and finally bumped to 512 MB. The headroom is what made everything else stop being scary. **Don't drop it back below 512 MB without first profiling a real iPhone upload via the `photo.sharp_transform` Sentry span.**
+
+Why 256 MB wasn't enough even with `sequentialRead: true`: libvips buffers internally to perform random-access ops like a 90° rotation regardless of input mode. `sequentialRead` is a small constant-factor savings on the input read; it does not change the rotation step's working-set requirement. The structural fix to push memory back down is **resize before encode** (see below) — that's what cuts the dominant decoded-RGBA cost in half or quarter, by exploiting libvips' JPEG shrink-on-load.
+
+## Memory-pressure controls
+
+These are in `fly.toml [env]` and mirrored in `docker-compose.yml`:
+
+| Setting | Value | Why |
+|---|---|---|
+| `NODE_OPTIONS=--max-old-space-size=384` | ~75% of VM | Forces V8 to GC before the OS OOM-kills. Without it, Node defaults to ~1.5 GB and grows past Fly's hard limit. |
+| `SHARP_CONCURRENCY=1` | 1 | 1 CPU. Parallel libvips work just multiplexes onto one core and bloats RSS. |
+| `MALLOC_ARENA_MAX=2` | 2 | glibc default is up to 8 arenas/CPU, each reserving ~64 MB. Native-binary workloads (libvips, AWS SDK threads) hold onto arena memory long after `free()`. Capping at 2 reliably drops 30–60 MB of RSS. |
+| `UV_THREADPOOL_SIZE=2` | 2 | libuv default is 4 (fs / DNS / crypto / Sharp dispatch). On 1 shared CPU the extra threads are memory pressure with no parallelism gain. `=1` is too aggressive (TLS handshakes can stall behind fs). |
+
+Plus, in code (`apps/www/src/lib/listing-photo-upload.server.ts`):
+
+- **`sharp.cache(false)` at module load** — libvips' tile/operation cache fights V8 for RAM. Disable it.
+- **`sequentialRead: true`** in the Sharp constructor — modest hint to libvips. We briefly removed it after seeing rotation drop on Linux uploads, but the regression was a stale Docker image; a `docker compose build --no-cache` followed by a fresh upload restored correct rotation. Real savings are small (low single-digit MB) because libvips still buffers internally for the rotation step itself.
+- **Resize before encode** — the pub pipeline includes `.resize({ width: 2048, height: 2048, fit: 'inside', withoutEnlargement: true })` after rotation. For JPEG inputs, libvips uses shrink-on-load to decode at 1/2, 1/4, or 1/8 — a 12 MP iPhone JPEG drops from ~48 MB decoded RGBA to ~12 MB. Listing photos don't need full sensor resolution; this is the dominant memory win in the pipeline.
+- **In-process upload mutex** — wraps `uploadListingPhoto` so only one runs at a time across the process. Two simultaneous uploads would otherwise hold two staged temp files plus two libvips pixel sets.
+- **`limitInputPixels: 16_000_000`** in the Sharp constructor — rejects images at the JPEG/PNG/WebP header before any pixel decode. Surfaced as `UserError('IMAGE_TOO_LARGE', …)`. 16 MP covers iPhone main camera and most Android flagships.
+
+## The temp-file pipeline (issue #222)
+
+The original upload route did:
+
+```ts
+const rawBuffer = Buffer.from(await file.arrayBuffer())
+```
+
+That holds the file three times simultaneously: the Web `File` object (in parsed FormData), the `ArrayBuffer` from `.arrayBuffer()`, and the `Buffer` copy. On a small VM that allocation alone can OOM the request.
+
+Current pipeline (`apps/www/src/lib/listing-photo-upload.server.ts`, `apps/www/src/api/listing-photos.ts`):
+
+1. **Stage to disk**: `pipeline(file.stream(), createWriteStream(tempPath))` — request body streams to a uniquely-named temp file (`os.tmpdir()/pmf-upload-<uuid>`). Body never sits in memory as a `Buffer`.
+2. **Validate by prefix**: open the temp file, read first 4 KB, run magic-byte detection (`mime-bytes`). Reject HEIC/non-image with a helpful `UserError`.
+3. **Two read streams**: one `createReadStream(tempPath)` → S3 `raw/`, another `createReadStream(tempPath).pipe(sharp(...).autoOrient().resize(...).jpeg())` → S3 `pub/`.
+4. **`try/finally` unlink**: temp file removed even on error or client disconnect.
+
+`StorageAdapter.upload` is narrowed to `Readable`-only — no `Buffer | Readable` union — so any future buffering is forced to be explicit at the call site.
+
+## S3 / Tigris uploads
+
+`TigrisStorageAdapter.upload` uses `@aws-sdk/lib-storage`'s `Upload` (multipart) for streaming bodies:
+
+- `queueSize: 1` — one 5 MB part in flight at a time. Keeps memory bounded.
+- `partSize: 5 * 1024 * 1024` — minimum allowed by S3 multipart.
+- `requestChecksumCalculation: 'WHEN_REQUIRED'` on the `S3Client` — needed because the SDK v3 default ('WHEN_SUPPORTED') requires `x-amz-decoded-content-length`, which is undefined for `pipe()`-based streams. Without this override, streaming uploads fail signing.
+
+Fly + Tigris is the same datacenter; intra-region transfer is essentially free. No CDN proxy in front of `pub/` — Tigris serves directly via `https://<bucket>.fly.storage.tigris.dev/pub/...`.
+
+## Image processing — auto-orient
+
+EXIF orientation is a long-standing source of bugs. iPhones store the sensor's native orientation in pixels and indicate display orientation via the EXIF `Orientation` tag (1–8). Browsers honor that tag for the original JPEG, but our re-encoded `pub/` copy strips EXIF, so the rotation must be **baked into the pixel grid** before we drop the tag.
+
+Current chain: `sharp({sequentialRead, limitInputPixels}).autoOrient().resize(...).jpeg(...)`.
+
+**One historical false alarm**: a Linux deploy briefly looked like it was silently skipping rotation. The fix turned out to be `docker compose build --no-cache` — the running image had a stale build of `apps/www/src/lib/listing-photo-upload.server.ts`. Both `sequentialRead: true` and `sequentialRead: false` rotate correctly on `@img/sharp-linux-*` once the image is current. Keep the canary tests in `tests/listing-photo-exif.server.test.ts` — they would catch a real regression — and prefer `docker compose build --no-cache` as the first move when "this used to work" claims appear.
+
+**Defense in depth**: if libvips' `.autoOrient()` (or `.rotate()` with no args) ever does break on a future build, the explicit fallback is to read EXIF orientation via `metadata()` and apply `.rotate(angle) / .flip() / .flop()` based on the EXIF 1–8 value yourself. That implementation existed briefly on this branch; consult `git log` for the exact commit if you need to resurrect it.
+
+## Observability
+
+We instrument the photo path heavily because OOM regressions are non-obvious in logs and the only way to catch a memory regression early is to watch the trend.
+
+### Sentry / OTel spans
+
+Tracing wraps the expensive parts of the upload pipeline. Filter on `op:image.process` or `op:storage.upload` in Sentry Performance.
+
+**`photo.sharp_transform`** (`op: image.process`) — set inside `uploadListingPhoto`:
+
+- `photo.id`, `photo.mime_type`
+- `photo.input_bytes`, `photo.input_orientation`, `photo.input_width`, `photo.input_height`
+- `photo.output_width`, `photo.output_height`, `photo.output_bytes` (from Sharp's `info` event)
+- `photo.rss_before`, `photo.rss_after`, `photo.rss_delta`
+- `sharp.cache_memory_current`, `sharp.cache_memory_high`, `sharp.cache_files_current`, `sharp.cache_items_current` — process-global libvips cache snapshot. `_current` should always be 0 (we disable the cache); `_high` should also stay 0 unless `sharp.cache(false)` is broken on a given build.
+
+**`storage.upload.tigris`** / **`storage.upload.local`** (`op: storage.upload`) — set inside each `StorageAdapter.upload`:
+
+- `storage.provider` (`tigris` | `local`), `storage.dir` (`raw` | `pub`), `storage.key`
+- `storage.mime_type`, `storage.streaming` (always `true`)
+- `storage.bytes_written` — counted via a `Transform` tap (no backpressure interference)
+- `photo.id` — propagated from the caller for cross-correlation with `photo.sharp_transform`
+
+Tigris-specific:
+- `storage.bucket`, `storage.upload_strategy: 'multipart'`, `storage.part_size_bytes`, `storage.queue_size`
+- `storage.acl: 'public-read' | 'private'`
+- `storage.etag` (from `Upload.done()` result)
+
+### Pino logs
+
+`logger.info` in `uploadListingPhoto` emits two log lines per upload with:
+
+- `phase: 'start' | 'end'`
+- `listingPhotoId`, `rssBytes` (from `process.memoryUsage().rss`)
+
+These show up in `fly logs --no-tail` even if Sentry is sampling out the trace. Useful for retrospectively reading "did RSS climb during this upload?" without leaving the terminal.
+
+### Sentry exception capture
+
+Per project convention (CLAUDE.md), all error paths use `Sentry.captureException` from `@/lib/sentry`. Don't add separate `console.error` calls — `sentry.ts` is the designated handler. The wrapper logs to console when Sentry is disabled (dev/test), so you don't lose visibility locally.
+
+## Diagnostic playbook
+
+When a photo upload fails or feels slow:
+
+1. **Check `fly logs --no-tail`** — look for `Killed process` or `oom_score_adj` lines (kernel OOM) and the structured `phase: 'start' / 'end'` lines around the time of failure. The `rssBytes` delta tells you whether memory was the cause.
+2. **Find the trace in Sentry** — filter by `op:image.process` and the affected user/photo. The `photo.rss_*` and `storage.bytes_written` attributes show the entire pipeline at a glance.
+3. **Repro locally with the same constraints** — `docker compose up --build` runs against the 512 MB / `MALLOC_ARENA_MAX=2` / `UV_THREADPOOL_SIZE=2` settings. Upload the iPhone fixture (`apps/www/tests/fixtures/artichoke-90cw.jpg`) or your own photo via `/listings/new`.
+4. **Run the integration test inside Docker** for Linux-binary issues:
+   ```bash
+   docker compose run --rm web pnpm --filter @pickmyfruit/www test:run tests/listing-photo-exif.server.test.ts
+   ```
+   Bugs that manifest only on `@img/sharp-linux-*` will surface here even when the macOS test passes.
+
+## Things we tried and rolled back
+
+For the next person who's tempted:
+
+- **Briefly removed `sequentialRead: true`** — re-instated in commit `7b097f8` after confirming the apparent regression was a stale Docker image, not a real bug. `docker compose build --no-cache` would have saved the detour.
+- **Buffering raw upload before staging** — doubled allocation under any concurrency. Replaced with the temp-file pipeline.
+- **`PutObjectAclCommand` after `Upload.done()`** — tried briefly to set ACL post-upload, but `Upload` already honors `ACL` in its params. The extra round-trip is pure latency.
+- **Tighter `--max-old-space-size`** at 160 MB — was right for the 256 MB VM but starves V8 unnecessarily on 512 MB. Now 384 MB.
+
+## Things still on the wishlist
+
+- **Image-processing worker**. The web tier and the image processor have different memory profiles, scaling shapes, and failure tolerances. Even with resize-before-encode, a single upload still peaks ~50 MB RSS. A separate worker container — sized for libvips, scaled horizontally for throughput — would let the web tier shed its 384 MB heap cap and serve listing pages on a much smaller VM.
+- **Client-side downscale before upload**. We currently accept full-resolution photos and do all the heavy lifting server-side. A pre-upload resize to ~12 MP via `<canvas>` would cut server peak memory and make the upload step instant on slow connections. Not yet built.
+- **`UPLOAD_MAX_CONCURRENT_REQUESTS` at the Fly proxy** — we serialize uploads in-process via the mutex, but inbound requests still queue inside Node. A Fly-level concurrency cap would shed load earlier.

--- a/fly.toml
+++ b/fly.toml
@@ -30,7 +30,10 @@ primary_region = 'sjc'
   min_machines_running = 0
   processes = ['app']
 
-  # HTTP request timeouts
+  # HTTP request timeouts.
+  # NOTE: photo uploads are also gated by an in-process queue
+  # (MAX_UPLOAD_QUEUE_DEPTH in apps/www/src/lib/listing-photo-upload.server.ts)
+  # which sheds with 503 well below this proxy-level cap.
   [http_service.concurrency]
     type = 'requests'
     hard_limit = 250
@@ -56,17 +59,35 @@ primary_region = 'sjc'
   initial_size = '1gb'
 
 # Environment variables
+# NODE_OPTIONS and SHARP_CONCURRENCY are mirrored in docker-compose.yml so
+# local runs reproduce production memory behavior. Keep these in sync.
 [env]
   EMAIL_PROVIDER = 'resend'
+  # Cap glibc malloc arenas — fewer per-thread arenas means lower RSS for
+  # native-binary workloads (libvips, AWS SDK threads). Free, well-known.
+  MALLOC_ARENA_MAX = '2'
   MIGRATE_ON_REQUEST = 'true'
   NODE_ENV = 'production'
+  # Cap V8 heap at ~75% of the 512 MB VM so GC fires before Linux OOM-kills,
+  # leaving headroom for libvips native allocations and the OS.
+  NODE_OPTIONS = '--max-old-space-size=384'
+  # Serialize libvips work — the VM is still 1 shared CPU, so parallel image
+  # processing buys memory pressure without real throughput.
   SHARP_CONCURRENCY = '1'
   STORAGE_PROVIDER = 'tigris'
+  # libuv default is 4. On a 1-CPU shared VM the extra threads buy memory
+  # pressure with no real parallelism. Keep 2 so I/O and TLS can overlap.
+  UV_THREADPOOL_SIZE = '2'
 
-# VM resources - Start with minimal for MVP
+# VM resources
+# Memory and CPU limits are mirrored in docker-compose.yml's deploy.resources.
+# Bumped from 256 MB to 512 MB on 2026-04-27: a single 12 MP iPhone JPEG drives
+# RSS up ~120 MB inside Sharp (libvips decoded RGBA + intermediate buffers),
+# leaving no margin for the rest of the process. 512 MB gives Sharp comfortable
+# headroom while still being a small VM.
 [[vm]]
   size = 'shared-cpu-1x'
-  memory = '256mb'
+  memory = '512mb'
   cpus = 1
 
 # Deployment configuration

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,11 @@ importers:
   apps/www:
     dependencies:
       '@aws-sdk/client-s3':
-        specifier: ^3.1013.0
-        version: 3.1013.0
+        specifier: ^3.1035.0
+        version: 3.1035.0
+      '@aws-sdk/lib-storage':
+        specifier: ^3.1035.0
+        version: 3.1035.0(@aws-sdk/client-s3@3.1035.0)
       '@kobalte/core':
         specifier: ^0.13.11
         version: 0.13.11(solid-js@1.9.11)
@@ -181,127 +184,133 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-s3@3.1013.0':
-    resolution: {integrity: sha512-vFdyRyRatF+xP9Fi+4alZkmzZadqOAM34Pm6SUZsYtumNrWkgMc/pFWITnsq6eltM8qcV/vcinQ1ZBXWm/PlKg==}
+  '@aws-sdk/client-s3@3.1035.0':
+    resolution: {integrity: sha512-Bh1h96CjHMpxg6Rn2G4EE30YiiBh9w/7WmSZIfwLB0X/6lblaJcHggcryrq2uNN2Bx1/CNErMjTpGQzqhA7Rhg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.973.22':
-    resolution: {integrity: sha512-lY6g5L95jBNgOUitUhfV2N/W+i08jHEl3xuLODYSQH5Sf50V+LkVYBSyZRLtv2RyuXZXiV7yQ+acpswK1tlrOA==}
+  '@aws-sdk/core@3.974.4':
+    resolution: {integrity: sha512-EbVgyzQ83/Lf6oh1O4vYY47tuYw3Aosthh865LNU77KyotKz+uvEBNmsl/bSVS/vG+IU39mCqcOHrnhmhF4lug==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/crc64-nvme@3.972.5':
-    resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
+  '@aws-sdk/crc64-nvme@3.972.7':
+    resolution: {integrity: sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.20':
-    resolution: {integrity: sha512-vI0QN96DFx3g9AunfOWF3CS4cMkqFiR/WM/FyP9QHr5rZ2dKPkYwP3tCgAOvGuu9CXI7dC1vU2FVUuZ+tfpNvQ==}
+  '@aws-sdk/credential-provider-env@3.972.30':
+    resolution: {integrity: sha512-dHpeqa29a0cBYq/h59IC2EK3AphLY96nKy4F35kBtiz9GuKDc32UYRTgjZaF8uuJCnqgw9omUZKR+9myyDHC2A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.22':
-    resolution: {integrity: sha512-aS/81smalpe7XDnuQfOq4LIPuaV2PRKU2aMTrHcqO5BD4HwO5kESOHNcec2AYfBtLtIDqgF6RXisgBnfK/jt0w==}
+  '@aws-sdk/credential-provider-http@3.972.32':
+    resolution: {integrity: sha512-A+ZTT//Mswkf9DFEM6XlngwOtYdD8X4CUcoZ2wdpgI8cCs9mcGeuhgTwbGJvealub/MeONOaUr3FbRPMKmTDjg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.22':
-    resolution: {integrity: sha512-rpF8fBT0LllMDp78s62aL2A/8MaccjyJ0ORzqu+ZADeECLSrrCWIeeXsuRam+pxiAMkI1uIyDZJmgLGdadkPXw==}
+  '@aws-sdk/credential-provider-ini@3.972.34':
+    resolution: {integrity: sha512-MoRc7tLnx3JpFkV2R826enEfBUVN8o9Cc7y3hnbMwiWzL/VJhgfxRQzHkEL9vWorMWP7tibltsRcLoid9fsVdw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.22':
-    resolution: {integrity: sha512-u33CO9zeNznlVSg9tWTCRYxaGkqr1ufU6qeClpmzAabXZa8RZxQoVXxL5T53oZJFzQYj+FImORCSsi7H7B77gQ==}
+  '@aws-sdk/credential-provider-login@3.972.34':
+    resolution: {integrity: sha512-XVSklkRRQ/CQDmv3VVFdZRl5hTFgncFhZrLyi0Ai4LZk5o3jpY5HIfuTK7ad7tixPKa+iQmL9+vg9qNyYZB+nw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.23':
-    resolution: {integrity: sha512-U8tyLbLOZItuVWTH0ay9gWo4xMqZwqQbg1oMzdU4FQSkTpqXemm4X0uoKBR6llqAStgBp30ziKFJHTA43l4qMw==}
+  '@aws-sdk/credential-provider-node@3.972.35':
+    resolution: {integrity: sha512-nVrY7AdGfzYgAa/jd9m06p3ES7QQDaB7zN9c+vXnVXxBRkAs9MjRDPB5AKogWuC6phddltfvHGFqLDJmyU9u/A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.20':
-    resolution: {integrity: sha512-QRfk7GbA4/HDRjhP3QYR6QBr/QKreVoOzvvlRHnOuGgYJkeoPgPY3LAI1kK1ZMgZ4hH9KiGp757/ntol+INAig==}
+  '@aws-sdk/credential-provider-process@3.972.30':
+    resolution: {integrity: sha512-McJPomNTSEo+C6UA3Zq6pFrcyTUaVsoPPBOvbOHAoIFPc8Z2CMLndqFJOnB+9bVFiBTWQLutlVGmrocBbvv4MQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.22':
-    resolution: {integrity: sha512-4vqlSaUbBj4aNPVKfB6yXuIQ2Z2mvLfIGba2OzzF6zUkN437/PGWsxBU2F8QPSFHti6seckvyCXidU3H+R8NvQ==}
+  '@aws-sdk/credential-provider-sso@3.972.34':
+    resolution: {integrity: sha512-WngYb2K+/yhkDOmDfAOjoCa9Ja3he0DZiAraboKwgWoVRkajDIcDYBCVbUTxtTUldvQoe7VvHLTrBNxvftN1aQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.22':
-    resolution: {integrity: sha512-/wN1CYg2rVLhW8/jLxMWacQrkpaynnL+4j/Z+e6X1PfoE6NiC0BeOw3i0JmtZrKun85wNV5GmspvuWJihfeeUw==}
+  '@aws-sdk/credential-provider-web-identity@3.972.34':
+    resolution: {integrity: sha512-5KLUH+XmSNRj6amJiJSrPsCxU5l/PYDfxyqPa1MxWhHoQC3sxvGPrSib3IE+HQlfRA4e2kO0bnJy7HJdjvpuuA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-bucket-endpoint@3.972.8':
-    resolution: {integrity: sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==}
+  '@aws-sdk/lib-storage@3.1035.0':
+    resolution: {integrity: sha512-VkC0kDql0qkv+h6nIZOAxmek3VMCNGsq2v74QT9Zf/WbPlyM5PqyGp1dsPxNSv2iMtoWXzHvqzkZ55ZiJCgq4Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.1035.0
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.10':
+    resolution: {integrity: sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-expect-continue@3.972.8':
-    resolution: {integrity: sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==}
+  '@aws-sdk/middleware-expect-continue@3.972.10':
+    resolution: {integrity: sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-flexible-checksums@3.974.2':
-    resolution: {integrity: sha512-4soN/N4R6ptdnHw7hXPVDZMIIL+vhN8rwtLdDyS0uD7ExhadtJzolTBIM5eKSkbw5uBEbIwtJc8HCG2NM6tN/g==}
+  '@aws-sdk/middleware-flexible-checksums@3.974.12':
+    resolution: {integrity: sha512-v7n0//P95g+UnmyjCpJkDJFB+EP/9Wx/fQJC5BEiK9Y7VHgmhh6RNPVbqDYz9gsz8mXnxzyYt3tCEVJ1kzo01w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-host-header@3.972.8':
-    resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-location-constraint@3.972.8':
-    resolution: {integrity: sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==}
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    resolution: {integrity: sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-logger@3.972.8':
-    resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-recursion-detection@3.972.8':
-    resolution: {integrity: sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==}
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.972.22':
-    resolution: {integrity: sha512-dkUcRxF4rVpPbyHpxjCApGK6b7JpnSeo7tDoNakpRKmiLMCqgy4tlGBgeEYJnZgLrA4xc5jVKuXgvgqKqU18Kw==}
+  '@aws-sdk/middleware-sdk-s3@3.972.33':
+    resolution: {integrity: sha512-n8Eh/+kq3u/EodLr8n6sQupu03QGjf122RHXCTGLaHSkavz/2beSKpRlq2oDgfmJZNkAkWF113xbyaUmyOd+YA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-ssec@3.972.8':
-    resolution: {integrity: sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==}
+  '@aws-sdk/middleware-ssec@3.972.10':
+    resolution: {integrity: sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.23':
-    resolution: {integrity: sha512-HQu8QoqGZZTvg0Spl9H39QTsSMFwgu+8yz/QGKndXFLk9FZMiCiIgBCVlTVKMDvVbgqIzD9ig+/HmXsIL2Rb+g==}
+  '@aws-sdk/middleware-user-agent@3.972.34':
+    resolution: {integrity: sha512-jrmJHyYlTQocR7H4VhvSFhaoedMb2rmlOTvFWD6tNBQ/EVQhTsrNfQUYFuPiOc2wUGxbm5LgCHtnvVmCPgODHw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.12':
-    resolution: {integrity: sha512-KLdQGJPSm98uLINolQ0Tol8OAbk7g0Y7zplHJ1K83vbMIH13aoCvR6Tho66xueW4l4aZlEgVGLWBnD8ifUMsGQ==}
+  '@aws-sdk/nested-clients@3.997.2':
+    resolution: {integrity: sha512-uGGQO08YetrqfInOKG5atRMrCDRQWRuZ9gGfKY6svPmuE4K7ac+XcbCkpWpjcA7yCYsBaKB/Nly4XKgPXUO1PA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.8':
-    resolution: {integrity: sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==}
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/signature-v4-multi-region@3.996.10':
-    resolution: {integrity: sha512-yJSbFTedh1McfqXa9wZzjchqQ2puq5PI/qRz5kUjg2UXS5mO4MBYBbeXaZ2rp/h+ZbkcYEdo4Qsiah9psyoxrA==}
+  '@aws-sdk/signature-v4-multi-region@3.996.21':
+    resolution: {integrity: sha512-3EpT+C0QdmTMB5aVeJ5odWSLt9vg2oGzUXl1xvUazKGlkr9OBYnegNWqhhjGgZdv8RmSi5eS8nqqB+euNP2aqA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1013.0':
-    resolution: {integrity: sha512-IL1c54UvbuERrs9oLm5rvkzMciwhhpn1FL0SlC3XUMoLlFhdBsWJgQKK8O5fsQLxbFVqjbjFx9OBkrn44X9PHw==}
+  '@aws-sdk/token-providers@3.1035.0':
+    resolution: {integrity: sha512-E6IO3Cn+OzBe6Sb5pnubd5Y8qSUMAsVKkD5QSwFfIx5fV1g5SkYwUDRDyPlm90RuIVcCo28wpMJU6W8wXH46Aw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.973.6':
-    resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-arn-parser@3.972.3':
     resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-endpoints@3.996.5':
-    resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
     resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-user-agent-browser@3.972.8':
-    resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
 
-  '@aws-sdk/util-user-agent-node@3.973.9':
-    resolution: {integrity: sha512-jeFqqp8KD/P5O+qeKxyGeu7WEVIZFNprnkaDjGmBOjwxYwafCBhpxTgV1TlW6L8e76Vh/siNylNmN/OmSIFBUQ==}
+  '@aws-sdk/util-user-agent-node@3.973.20':
+    resolution: {integrity: sha512-owEqyKr0z5hWwk+uHwudwNhyFMZ9f9eSWr/k/XD6yeDCI7hHyc56s4UOY1iBQmoramTbdAY4UCuLLEuKmjVXrg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -309,8 +318,8 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/xml-builder@3.972.14':
-    resolution: {integrity: sha512-G/Yd8Bnnyh8QrqLf8jWJbixEnScUFW24e/wOBGYdw1Cl4r80KX/DvHyM2GVZ2vTp7J4gTEr8IXJlTadA8+UfuQ==}
+  '@aws-sdk/xml-builder@3.972.18':
+    resolution: {integrity: sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -2435,10 +2444,6 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@smithy/abort-controller@4.2.12':
-    resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/chunked-blob-reader-native@4.2.3':
     resolution: {integrity: sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==}
     engines: {node: '>=18.0.0'}
@@ -2447,56 +2452,56 @@ packages:
     resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/config-resolver@4.4.13':
-    resolution: {integrity: sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==}
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.23.12':
-    resolution: {integrity: sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==}
+  '@smithy/core@3.23.16':
+    resolution: {integrity: sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@4.2.12':
-    resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-codec@4.2.12':
-    resolution: {integrity: sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==}
+  '@smithy/eventstream-codec@4.2.14':
+    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-browser@4.2.12':
-    resolution: {integrity: sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==}
+  '@smithy/eventstream-serde-browser@4.2.14':
+    resolution: {integrity: sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-config-resolver@4.3.12':
-    resolution: {integrity: sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==}
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    resolution: {integrity: sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-node@4.2.12':
-    resolution: {integrity: sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==}
+  '@smithy/eventstream-serde-node@4.2.14':
+    resolution: {integrity: sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-universal@4.2.12':
-    resolution: {integrity: sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==}
+  '@smithy/eventstream-serde-universal@4.2.14':
+    resolution: {integrity: sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/fetch-http-handler@5.3.15':
-    resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/hash-blob-browser@4.2.13':
-    resolution: {integrity: sha512-YrF4zWKh+ghLuquldj6e/RzE3xZYL8wIPfkt0MqCRphVICjyyjH8OwKD7LLlKpVEbk4FLizFfC1+gwK6XQdR3g==}
+  '@smithy/hash-blob-browser@4.2.15':
+    resolution: {integrity: sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/hash-node@4.2.12':
-    resolution: {integrity: sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==}
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/hash-stream-node@4.2.12':
-    resolution: {integrity: sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==}
+  '@smithy/hash-stream-node@4.2.14':
+    resolution: {integrity: sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/invalid-dependency@4.2.12':
-    resolution: {integrity: sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==}
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -2507,76 +2512,76 @@ packages:
     resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/md5-js@4.2.12':
-    resolution: {integrity: sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==}
+  '@smithy/md5-js@4.2.14':
+    resolution: {integrity: sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-content-length@4.2.12':
-    resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.4.27':
-    resolution: {integrity: sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==}
+  '@smithy/middleware-endpoint@4.4.31':
+    resolution: {integrity: sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@4.4.44':
-    resolution: {integrity: sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==}
+  '@smithy/middleware-retry@4.5.4':
+    resolution: {integrity: sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-serde@4.2.15':
-    resolution: {integrity: sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==}
+  '@smithy/middleware-serde@4.2.19':
+    resolution: {integrity: sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-stack@4.2.12':
-    resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-config-provider@4.3.12':
-    resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.5.0':
-    resolution: {integrity: sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==}
+  '@smithy/node-http-handler@4.6.0':
+    resolution: {integrity: sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/property-provider@4.2.12':
-    resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/protocol-http@5.3.12':
-    resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-builder@4.2.12':
-    resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-parser@4.2.12':
-    resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/service-error-classification@4.2.12':
-    resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
+  '@smithy/service-error-classification@4.3.0':
+    resolution: {integrity: sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/shared-ini-file-loader@4.4.7':
-    resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/signature-v4@5.3.12':
-    resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/smithy-client@4.12.7':
-    resolution: {integrity: sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==}
+  '@smithy/smithy-client@4.12.12':
+    resolution: {integrity: sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/types@4.13.1':
-    resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/url-parser@4.2.12':
-    resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-base64@4.3.2':
@@ -2603,32 +2608,32 @@ packages:
     resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-browser@4.3.43':
-    resolution: {integrity: sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==}
+  '@smithy/util-defaults-mode-browser@4.3.48':
+    resolution: {integrity: sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-node@4.2.47':
-    resolution: {integrity: sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==}
+  '@smithy/util-defaults-mode-node@4.2.53':
+    resolution: {integrity: sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-endpoints@3.3.3':
-    resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-hex-encoding@4.2.2':
     resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-middleware@4.2.12':
-    resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-retry@4.2.12':
-    resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
+  '@smithy/util-retry@4.3.3':
+    resolution: {integrity: sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-stream@4.5.20':
-    resolution: {integrity: sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==}
+  '@smithy/util-stream@4.5.24':
+    resolution: {integrity: sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.2':
@@ -2643,8 +2648,8 @@ packages:
     resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-waiter@4.2.13':
-    resolution: {integrity: sha512-2zdZ9DTHngRtcYxJK1GUDxruNr53kv5W2Lupe0LMU+Imr6ohQg8M2T14MNkj1Y0wS3FFwpgpGQyvuaMF7CiTmQ==}
+  '@smithy/util-waiter@4.2.16':
+    resolution: {integrity: sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/uuid@1.1.2':
@@ -3303,6 +3308,9 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
@@ -3892,8 +3900,8 @@ packages:
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
-  fast-xml-parser@5.5.6:
-    resolution: {integrity: sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==}
+  fast-xml-parser@5.5.8:
+    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
     hasBin: true
 
   fastq@1.20.1:
@@ -4863,6 +4871,10 @@ packages:
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5158,6 +5170,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
@@ -5895,20 +5910,20 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -5918,7 +5933,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -5926,7 +5941,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -5935,403 +5950,417 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-s3@3.1013.0':
+  '@aws-sdk/client-s3@3.1035.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/credential-provider-node': 3.972.23
-      '@aws-sdk/middleware-bucket-endpoint': 3.972.8
-      '@aws-sdk/middleware-expect-continue': 3.972.8
-      '@aws-sdk/middleware-flexible-checksums': 3.974.2
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-location-constraint': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-sdk-s3': 3.972.22
-      '@aws-sdk/middleware-ssec': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.23
-      '@aws-sdk/region-config-resolver': 3.972.8
-      '@aws-sdk/signature-v4-multi-region': 3.996.10
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.9
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/core': 3.23.12
-      '@smithy/eventstream-serde-browser': 4.2.12
-      '@smithy/eventstream-serde-config-resolver': 4.3.12
-      '@smithy/eventstream-serde-node': 4.2.12
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-blob-browser': 4.2.13
-      '@smithy/hash-node': 4.2.12
-      '@smithy/hash-stream-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/md5-js': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.27
-      '@smithy/middleware-retry': 4.4.44
-      '@smithy/middleware-serde': 4.2.15
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.5.0
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/credential-provider-node': 3.972.35
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.10
+      '@aws-sdk/middleware-expect-continue': 3.972.10
+      '@aws-sdk/middleware-flexible-checksums': 3.974.12
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-location-constraint': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-sdk-s3': 3.972.33
+      '@aws-sdk/middleware-ssec': 3.972.10
+      '@aws-sdk/middleware-user-agent': 3.972.34
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.21
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.20
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.16
+      '@smithy/eventstream-serde-browser': 4.2.14
+      '@smithy/eventstream-serde-config-resolver': 4.3.14
+      '@smithy/eventstream-serde-node': 4.2.14
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-blob-browser': 4.2.15
+      '@smithy/hash-node': 4.2.14
+      '@smithy/hash-stream-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/md5-js': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.31
+      '@smithy/middleware-retry': 4.5.4
+      '@smithy/middleware-serde': 4.2.19
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.43
-      '@smithy/util-defaults-mode-node': 4.2.47
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/util-stream': 4.5.20
+      '@smithy/util-defaults-mode-browser': 4.3.48
+      '@smithy/util-defaults-mode-node': 4.2.53
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.3
+      '@smithy/util-stream': 4.5.24
       '@smithy/util-utf8': 4.2.2
-      '@smithy/util-waiter': 4.2.13
+      '@smithy/util-waiter': 4.2.16
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.973.22':
+  '@aws-sdk/core@3.974.4':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/xml-builder': 3.972.14
-      '@smithy/core': 3.23.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.18
+      '@smithy/core': 3.23.16
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
-      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.3
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/crc64-nvme@3.972.5':
+  '@aws-sdk/crc64-nvme@3.972.7':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.20':
+  '@aws-sdk/credential-provider-env@3.972.30':
     dependencies:
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.22':
+  '@aws-sdk/credential-provider-http@3.972.32':
     dependencies:
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/types': 3.973.6
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.5.0
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.20
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.0
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.24
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.22':
+  '@aws-sdk/credential-provider-ini@3.972.34':
     dependencies:
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/credential-provider-env': 3.972.20
-      '@aws-sdk/credential-provider-http': 3.972.22
-      '@aws-sdk/credential-provider-login': 3.972.22
-      '@aws-sdk/credential-provider-process': 3.972.20
-      '@aws-sdk/credential-provider-sso': 3.972.22
-      '@aws-sdk/credential-provider-web-identity': 3.972.22
-      '@aws-sdk/nested-clients': 3.996.12
-      '@aws-sdk/types': 3.973.6
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-login@3.972.22':
-    dependencies:
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/nested-clients': 3.996.12
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/credential-provider-env': 3.972.30
+      '@aws-sdk/credential-provider-http': 3.972.32
+      '@aws-sdk/credential-provider-login': 3.972.34
+      '@aws-sdk/credential-provider-process': 3.972.30
+      '@aws-sdk/credential-provider-sso': 3.972.34
+      '@aws-sdk/credential-provider-web-identity': 3.972.34
+      '@aws-sdk/nested-clients': 3.997.2
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.23':
+  '@aws-sdk/credential-provider-login@3.972.34':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.20
-      '@aws-sdk/credential-provider-http': 3.972.22
-      '@aws-sdk/credential-provider-ini': 3.972.22
-      '@aws-sdk/credential-provider-process': 3.972.20
-      '@aws-sdk/credential-provider-sso': 3.972.22
-      '@aws-sdk/credential-provider-web-identity': 3.972.22
-      '@aws-sdk/types': 3.973.6
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/nested-clients': 3.997.2
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.20':
+  '@aws-sdk/credential-provider-node@3.972.35':
     dependencies:
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.22':
-    dependencies:
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/nested-clients': 3.996.12
-      '@aws-sdk/token-providers': 3.1013.0
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@aws-sdk/credential-provider-env': 3.972.30
+      '@aws-sdk/credential-provider-http': 3.972.32
+      '@aws-sdk/credential-provider-ini': 3.972.34
+      '@aws-sdk/credential-provider-process': 3.972.30
+      '@aws-sdk/credential-provider-sso': 3.972.34
+      '@aws-sdk/credential-provider-web-identity': 3.972.34
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.22':
+  '@aws-sdk/credential-provider-process@3.972.30':
     dependencies:
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/nested-clients': 3.996.12
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/nested-clients': 3.997.2
+      '@aws-sdk/token-providers': 3.1035.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/middleware-bucket-endpoint@3.972.8':
+  '@aws-sdk/credential-provider-web-identity@3.972.34':
     dependencies:
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/nested-clients': 3.997.2
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/lib-storage@3.1035.0(@aws-sdk/client-s3@3.1035.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1035.0
+      '@smithy/middleware-endpoint': 4.4.31
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-arn-parser': 3.972.3
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-expect-continue@3.972.8':
+  '@aws-sdk/middleware-expect-continue@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-flexible-checksums@3.974.2':
+  '@aws-sdk/middleware-flexible-checksums@3.974.12':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/crc64-nvme': 3.972.5
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/crc64-nvme': 3.972.7
+      '@aws-sdk/types': 3.973.8
       '@smithy/is-array-buffer': 4.2.2
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.20
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.24
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-host-header@3.972.8':
+  '@aws-sdk/middleware-host-header@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-location-constraint@3.972.8':
+  '@aws-sdk/middleware-location-constraint@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-logger@3.972.8':
+  '@aws-sdk/middleware-logger@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-recursion-detection@3.972.8':
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
     dependencies:
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.22':
+  '@aws-sdk/middleware-sdk-s3@3.972.33':
     dependencies:
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-arn-parser': 3.972.3
-      '@smithy/core': 3.23.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/core': 3.23.16
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.20
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.24
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-ssec@3.972.8':
+  '@aws-sdk/middleware-ssec@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.23':
+  '@aws-sdk/middleware-user-agent@3.972.34':
     dependencies:
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@smithy/core': 3.23.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-retry': 4.2.12
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.16
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.3
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.996.12':
+  '@aws-sdk/nested-clients@3.997.2':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.23
-      '@aws-sdk/region-config-resolver': 3.972.8
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.9
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/core': 3.23.12
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.27
-      '@smithy/middleware-retry': 4.4.44
-      '@smithy/middleware-serde': 4.2.15
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.5.0
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.34
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.21
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.20
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.16
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.31
+      '@smithy/middleware-retry': 4.5.4
+      '@smithy/middleware-serde': 4.2.19
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.43
-      '@smithy/util-defaults-mode-node': 4.2.47
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
+      '@smithy/util-defaults-mode-browser': 4.3.48
+      '@smithy/util-defaults-mode-node': 4.2.53
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.3
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/region-config-resolver@3.972.8':
+  '@aws-sdk/region-config-resolver@3.972.13':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.10':
+  '@aws-sdk/signature-v4-multi-region@3.996.21':
     dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.22
-      '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/middleware-sdk-s3': 3.972.33
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.1013.0':
+  '@aws-sdk/token-providers@3.1035.0':
     dependencies:
-      '@aws-sdk/core': 3.973.22
-      '@aws-sdk/nested-clients': 3.996.12
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.974.4
+      '@aws-sdk/nested-clients': 3.997.2
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/types@3.973.6':
+  '@aws-sdk/types@3.973.8':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-arn-parser@3.972.3':
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-endpoints@3.996.5':
+  '@aws-sdk/util-endpoints@3.996.8':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-endpoints': 3.3.3
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-browser@3.972.8':
+  '@aws-sdk/util-user-agent-browser@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.973.9':
+  '@aws-sdk/util-user-agent-node@3.973.20':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.23
-      '@aws-sdk/types': 3.973.6
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/middleware-user-agent': 3.972.34
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.14':
+  '@aws-sdk/xml-builder@3.972.18':
     dependencies:
-      '@smithy/types': 4.13.1
-      fast-xml-parser: 5.5.6
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.5.8
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -8051,11 +8080,6 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@smithy/abort-controller@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/chunked-blob-reader-native@4.2.3':
     dependencies:
       '@smithy/util-base64': 4.3.2
@@ -8065,97 +8089,97 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/config-resolver@4.4.13':
+  '@smithy/config-resolver@4.4.17':
     dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
-  '@smithy/core@3.23.12':
+  '@smithy/core@3.23.16':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.20
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.24
       '@smithy/util-utf8': 4.2.2
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.2.12':
+  '@smithy/credential-provider-imds@4.2.14':
     dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       tslib: 2.8.1
 
-  '@smithy/eventstream-codec@4.2.12':
+  '@smithy/eventstream-codec@4.2.14':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       '@smithy/util-hex-encoding': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-browser@4.2.12':
+  '@smithy/eventstream-serde-browser@4.2.14':
     dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-config-resolver@4.3.12':
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-node@4.2.12':
+  '@smithy/eventstream-serde-node@4.2.14':
     dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-universal@4.2.12':
+  '@smithy/eventstream-serde-universal@4.2.14':
     dependencies:
-      '@smithy/eventstream-codec': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/fetch-http-handler@5.3.15':
+  '@smithy/fetch-http-handler@5.3.17':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
-  '@smithy/hash-blob-browser@4.2.13':
+  '@smithy/hash-blob-browser@4.2.15':
     dependencies:
       '@smithy/chunked-blob-reader': 5.2.2
       '@smithy/chunked-blob-reader-native': 4.2.3
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/hash-node@4.2.12':
+  '@smithy/hash-node@4.2.14':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/hash-stream-node@4.2.12':
+  '@smithy/hash-stream-node@4.2.14':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/invalid-dependency@4.2.12':
+  '@smithy/invalid-dependency@4.2.14':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -8166,127 +8190,127 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/md5-js@4.2.12':
+  '@smithy/md5-js@4.2.14':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/middleware-content-length@4.2.12':
+  '@smithy/middleware-content-length@4.2.14':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.4.27':
+  '@smithy/middleware-endpoint@4.4.31':
     dependencies:
-      '@smithy/core': 3.23.12
-      '@smithy/middleware-serde': 4.2.15
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-middleware': 4.2.12
+      '@smithy/core': 3.23.16
+      '@smithy/middleware-serde': 4.2.19
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
-  '@smithy/middleware-retry@4.4.44':
+  '@smithy/middleware-retry@4.5.4':
     dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
+      '@smithy/core': 3.23.16
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.0
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.3
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/middleware-serde@4.2.15':
+  '@smithy/middleware-serde@4.2.19':
     dependencies:
-      '@smithy/core': 3.23.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/core': 3.23.16
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/middleware-stack@4.2.12':
+  '@smithy/middleware-stack@4.2.14':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/node-config-provider@4.3.12':
+  '@smithy/node-config-provider@4.3.14':
     dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.5.0':
+  '@smithy/node-http-handler@4.6.0':
     dependencies:
-      '@smithy/abort-controller': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/property-provider@4.2.12':
+  '@smithy/property-provider@4.2.14':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/protocol-http@5.3.12':
+  '@smithy/protocol-http@5.3.14':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/querystring-builder@4.2.12':
+  '@smithy/querystring-builder@4.2.14':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/querystring-parser@4.2.12':
+  '@smithy/querystring-parser@4.2.14':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/service-error-classification@4.2.12':
+  '@smithy/service-error-classification@4.3.0':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
 
-  '@smithy/shared-ini-file-loader@4.4.7':
+  '@smithy/shared-ini-file-loader@4.4.9':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/signature-v4@5.3.12':
+  '@smithy/signature-v4@5.3.14':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-middleware': 4.2.14
       '@smithy/util-uri-escape': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/smithy-client@4.12.7':
+  '@smithy/smithy-client@4.12.12':
     dependencies:
-      '@smithy/core': 3.23.12
-      '@smithy/middleware-endpoint': 4.4.27
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.20
+      '@smithy/core': 3.23.16
+      '@smithy/middleware-endpoint': 4.4.31
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.24
       tslib: 2.8.1
 
-  '@smithy/types@4.13.1':
+  '@smithy/types@4.14.1':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/url-parser@4.2.12':
+  '@smithy/url-parser@4.2.14':
     dependencies:
-      '@smithy/querystring-parser': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-base64@4.3.2':
@@ -8317,49 +8341,49 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-browser@4.3.43':
+  '@smithy/util-defaults-mode-browser@4.3.48':
     dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-node@4.2.47':
+  '@smithy/util-defaults-mode-node@4.2.53':
     dependencies:
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/util-endpoints@3.3.3':
+  '@smithy/util-endpoints@3.4.2':
     dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-hex-encoding@4.2.2':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/util-middleware@4.2.12':
+  '@smithy/util-middleware@4.2.14':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/util-retry@4.2.12':
+  '@smithy/util-retry@4.3.3':
     dependencies:
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/service-error-classification': 4.3.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/util-stream@4.5.20':
+  '@smithy/util-stream@4.5.24':
     dependencies:
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.5.0
-      '@smithy/types': 4.13.1
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.0
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.2
@@ -8380,10 +8404,9 @@ snapshots:
       '@smithy/util-buffer-from': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/util-waiter@4.2.13':
+  '@smithy/util-waiter@4.2.16':
     dependencies:
-      '@smithy/abort-controller': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/uuid@1.1.2':
@@ -9208,6 +9231,11 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -9728,7 +9756,7 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.2.0
 
-  fast-xml-parser@5.5.6:
+  fast-xml-parser@5.5.8:
     dependencies:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.2.0
@@ -10880,6 +10908,12 @@ snapshots:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readable-stream@4.7.0:
     dependencies:
       abort-controller: 3.0.0
@@ -11226,6 +11260,11 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   streamx@2.23.0:
     dependencies:


### PR DESCRIPTION
Photo uploads on a 256 MB Fly VM were reliably OOM-killed: a single 12 MP iPhone JPEG drove RSS up by ~120 MB inside Sharp (decoded RGBA + libvips rotation buffers + re-encode), and a naive `Buffer.from(await file.arrayBuffer())` held the request body three times over. We restructured the pipeline around a streamed temp file, resize-before-encode, an in-process serialization mutex with bounded queue depth, and a heavily instrumented Sentry/OTel + Pino path so the next regression is visible. We also bumped the VM to 512 MB, which is what made everything else stop being scary. This addresses the ideas in #222 plus more.

Changes
-------
Memory tuning (fly.toml, docker-compose.yml):
- Bump VM from 256 MB to 512 MB (`shared-cpu-1x`).
- `NODE_OPTIONS=--max-old-space-size=384` (~75% of VM); was 192, briefly 160.
- `MALLOC_ARENA_MAX=2` to stop glibc from reserving ~64 MB per arena around libvips/AWS-SDK native threads.
- `SHARP_CONCURRENCY=1`, `UV_THREADPOOL_SIZE=2` for the single shared CPU.
- Mirror the full memory/CPU/env block in `docker-compose.yml` to help reproduce OOMs locally; add cross-reference comments.

Streaming upload pipeline (`apps/www/src/api/listing-photos.ts`, `apps/www/src/lib/listing-photo-upload.server.ts`, `apps/www/src/lib/storage.server.ts`):
- Replace `Buffer.from(await file.arrayBuffer())` with `pipeline(file.stream(), createWriteStream(tempPath))` staging to `os.tmpdir()/pmf-upload-<uuid>`.
- Validate MIME by reading the first 4 KB of the temp file (`detectMimeFromTempFile`); reject HEIC/non-image as `UserError`.
- Two independent `createReadStream(tempPath)` consumers: one to S3 `raw/`, one piped through Sharp to S3 `pub/`. `try/finally` unlink even on client disconnect.
- Narrow `StorageAdapter.upload` body type to `Readable`-only so any future buffering must be explicit at the call site.
- `TigrisStorageAdapter.upload` switches to `@aws-sdk/lib-storage` `Upload` with `queueSize: 1`, `partSize: 5 MiB`. Use `pipeline(body, counter.stream)` (not `body.pipe`) so a source-stream error destroys the counter and `Upload` rejects rather than completing a truncated object.

Image processing (`apps/www/src/lib/listing-photo-upload.server.ts`):
- `sharp.cache(false)` at module load.
- `sharp({ sequentialRead: true, limitInputPixels: 16_000_000 }) .autoOrient().resize({ width: 2048, height: 2048, fit: 'inside', withoutEnlargement: true }).jpeg(...)` for the `pub/` copy. Resize-before-encode lets libvips shrink-on-load JPEG inputs at 1/2, 1/4, or 1/8, dropping decoded RGBA from ~48 MB to ~12 MB on a 12 MP iPhone photo. This is the dominant memory win.
- `limitInputPixels: 16_000_000` rejects oversized images at the JPEG/PNG/WebP header, surfaced as `UserError('IMAGE_TOO_LARGE', …)`.

Error handling / load shedding:
- In-process serial promise queue (`withUploadLock`) so only one `uploadListingPhoto` runs across the process.
- Bounded queue depth: `MAX_UPLOAD_QUEUE_DEPTH = 4`. Past that, throw `UserError('SERVER_BUSY', …, 503)` and shed before staging the next 5 MB temp file. `assertPhotoUploadCapacity()` is called from the API route before staging.
- `UserError` gains an optional `status`; `server-error-middleware` calls `setResponseStatus(error.status)` so 503s actually surface to the client.
- Broaden Sharp error mapping: `vipsjpeg`/`premature end`/`corrupt` → `UserError('CORRUPT_IMAGE', …)`. Whole upload body wrapped in `try/catch/finally` with a guaranteed `phase: 'end' | 'error'` log so the runbook's start/end pairing always holds.
- Raw-cleanup-on-pub-failure now `Sentry.captureException`s instead of silently swallowing — orphaned full-EXIF private objects are a privacy issue.

Observability:
- New `photo.sharp_transform` span (`op: image.process`) with `photo.id`, `photo.mime_type`, `photo.input_*`, `photo.output_*`, `photo.rss_before/after/delta`, `photo.lock_wait_ms`, `photo.queue_depth_at_acquire`, and a process-global libvips cache snapshot (`sharp.cache_memory_current/_high`, `sharp.cache_files_current`, `sharp.cache_items_current`) so we can verify `sharp.cache(false)` is actually in effect on a given build.
- New `storage.upload.tigris` / `storage.upload.local` spans (`op: storage.upload`) with `storage.provider`, `storage.dir`, `storage.key`, `storage.mime_type`, `storage.bytes_written` (counted via a non-backpressure-interfering `Transform` tap), and Tigris-specific `storage.bucket`, `storage.upload_strategy`, `storage.part_size_bytes`, `storage.queue_size`, `storage.acl`, `storage.etag`. `photo.id` propagated for cross-correlation.
- Pino `logger.info` with `{ phase: 'start' | 'end' | 'error', listingPhotoId, rssBytes, lockWaitMs, depthAtAcquire }` so RSS deltas are visible in `fly logs --no-tail` even when traces are sampled out.

Tests:
- Drop the brittle Sharp method-chain mock; assert behavior via real Sharp I/O against tiny real fixtures (one per supported format).
- New `SERVER_BUSY` capacity test that fills the queue with deliberately slow storage and asserts the next call rejects with the 503-bearing `UserError`.
- EXIF canary tests covering all 8 orientation values to catch a real `autoOrient` regression on `@img/sharp-linux-*`.

Ops / infra / docs:
- `docs/0005-image-upload-performance.md` — full narrative, diagnostic playbook (`fly logs --no-tail` → Sentry trace → `docker compose up --build` repro), and the rolled-back-attempts list.
- `fly.toml` http_service concurrency note: in-process queue sheds well below the proxy `hard_limit = 250`.
- `docker compose run --rm web pnpm test:run tests/listing-photo-exif.server.test.ts` documented for Linux-binary-specific bugs.

Lessons learned
---------------
- 256 MB was not enough even with every knob turned. libvips buffers internally to perform random-access ops like a 90° rotation regardless of input mode, so `sequentialRead` does not change the rotation step's working set. The structural fix is resize-before-encode (shrink-on-load), which cuts the dominant decoded-RGBA cost in half or quarter — not `sequentialRead`, which is at best a single-digit-MB hint.
- A "rotation broken on Linux" report that cost us the better part of a day turned out to be a stale Docker layer cache, not a real `sequentialRead`/`autoOrient` bug. Both `sequentialRead: true` and `false` rotate correctly on `@img/sharp-linux-*` once the image is current. `docker compose build --no-cache` is the cheapest debugging tool we have and should be the first move on any "this used to work" claim.
- `MALLOC_ARENA_MAX=2` is a real, well-known win for native-binary workloads — reliably 30–60 MB of RSS back from glibc's per-CPU arenas around libvips and AWS-SDK threads. Worth setting on day one for any Node service that calls into native code.
- Sharp's process-global cache snapshot and `process.memoryUsage().rss` are the cheapest insight you can ship. The OTel spans were the artifact that later let us validate hypotheses against production traffic instead of guessing — instrument before tuning, not after.

Failed efforts / things rolled back
-----------------------------------
- Briefly removed `sequentialRead: true` after seeing rotation appear to drop on Linux; re-instated in `7b097f8` once we caught the stale-Docker-image false alarm. `docker compose build --no-cache` would have saved the detour.
- Tried buffering the raw upload before staging to disk. Doubled allocation under any concurrency (Web `File` + `ArrayBuffer` + `Buffer` all live simultaneously). Replaced with the streamed  temp-file pipeline.
- Tried calling `PutObjectAclCommand` after `Upload.done()`. Redundant — `@aws-sdk/lib-storage` `Upload` already honors `ACL` in its params; the extra round-trip is pure latency.
- Tightened `NODE_OPTIONS=--max-old-space-size` to 160 MB on the 256 MB VM. Right for that VM but starves V8 unnecessarily on 512 MB; relaxed to 384 MB.
- Briefly hand-rolled an explicit-rotation fallback that read EXIF orientation via `metadata()` and applied `.rotate(angle)/.flip()/.flop()` based on the EXIF 1–8 value. Built before we discovered the stale-Docker root cause; rolled back to `.autoOrient()`. Documented in the ADR as defense-in-depth so the next person knows where to look if libvips' auto-orient ever genuinely breaks.

Things considered but not implemented
-------------------------------------
- Separate image-processing worker. Web tier and image processor have different memory profiles, scaling shapes, and failure tolerances. Even with resize-before-encode, a single upload still peaks ~50 MB RSS, which dominates the web tier's budget. A worker container sized for libvips and scaled horizontally would let the web tier shed its 384 MB heap cap and run on a much smaller VM. This is the right long-term move.
- Client-side downscale before upload via `<canvas>` to ~12 MP. Would cut server peak memory dramatically and make uploads instant on slow connections. Not built.
- `UPLOAD_MAX_CONCURRENT_REQUESTS` at the Fly proxy. We serialize in-process via the mutex, but inbound requests still queue inside Node. A Fly-proxy-level concurrency cap would shed load earlier, before requests even land in the app.

Refs: #222

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>