### PR TITLE
fix(photos): set ContentLength on Tigris uploads

### DIFF
--- a/apps/www/src/lib/listing-photo-upload.server.ts
+++ b/apps/www/src/lib/listing-photo-upload.server.ts
@@ -213,7 +213,12 @@ async function uploadListingPhotoLocked(
 
 	let phase: 'end' | 'error' = 'end'
 	try {
-		// Store original with full EXIF intact — private, server-side only
+		const rawBytes = (await stat(opts.tempPath)).size
+
+		// Store original with full EXIF intact — private, server-side only.
+		// ContentLength is required so `lib-storage`'s small-body fallback to
+		// PutObject doesn't go out chunked-encoded (Tigris rejects that with
+		// MissingContentLength).
 		await opts.storage.upload(
 			'raw',
 			rawPathKey,
@@ -221,6 +226,7 @@ async function uploadListingPhotoLocked(
 			{
 				mimeType: opts.mimeType,
 				photoId: id,
+				contentLength: rawBytes,
 			}
 		)
 
@@ -263,7 +269,13 @@ async function uploadListingPhotoLocked(
 					// Order matters: rotate first so .resize() targets display-oriented
 					// dimensions. For JPEG input, libvips uses shrink-on-load to decode
 					// at 1/2, 1/4, or 1/8 — the dominant memory win on the pub pipeline.
-					const transform = sharp({
+					//
+					// Encode to a Buffer (not a stream) so the upload has a known
+					// ContentLength. After resize-to-PUB_MAX_DIMENSION the encoded JPEG
+					// is ~0.2–2 MB; the peak-memory cost of buffering is negligible
+					// compared to the libvips working set, and it lets Tigris accept
+					// the body without chunked transfer encoding.
+					const { data: pubBuffer, info } = await sharp(opts.tempPath, {
 						sequentialRead: true,
 						limitInputPixels: MAX_IMAGE_PIXELS,
 					})
@@ -275,18 +287,17 @@ async function uploadListingPhotoLocked(
 							withoutEnlargement: true,
 						})
 						.jpeg({ quality: 85, mozjpeg: true })
-					transform.on('info', (info: import('sharp').OutputInfo) => {
-						span.setAttribute('photo.output_width', info.width)
-						span.setAttribute('photo.output_height', info.height)
-						span.setAttribute('photo.output_bytes', info.size)
-					})
-					const cleanStream = createReadStream(opts.tempPath).pipe(transform)
+						.toBuffer({ resolveWithObject: true })
+					span.setAttribute('photo.output_width', info.width)
+					span.setAttribute('photo.output_height', info.height)
+					span.setAttribute('photo.output_bytes', info.size)
 
 					try {
 						// Public copy served from CDN
-						await opts.storage.upload('pub', pubPathKey, cleanStream, {
+						await opts.storage.upload('pub', pubPathKey, Readable.from(pubBuffer), {
 							mimeType: 'image/jpeg',
 							photoId: id,
+							contentLength: pubBuffer.byteLength,
 						})
 					} finally {
 						const rssAfter = process.memoryUsage().rss

--- a/apps/www/src/lib/storage.server.ts
+++ b/apps/www/src/lib/storage.server.ts
@@ -43,6 +43,14 @@ export interface UploadOptions {
 	mimeType: string
 	/** Optional image UUID, propagated to spans for cross-correlation. */
 	photoId?: string
+	/**
+	 * Body length in bytes when known. `lib-storage`'s `Upload` falls back to
+	 * a single `PutObjectCommand` for bodies smaller than `partSize`; without
+	 * a `Content-Length` header that PutObject goes out chunked-encoded, which
+	 * Tigris rejects with `MissingContentLength`. Set this whenever the size
+	 * can be determined ahead of time (file `stat`, buffered output, …).
+	 */
+	contentLength?: number
 }
 
 /** Contract for all storage backends. */
@@ -188,6 +196,9 @@ export class TigrisStorageAdapter implements StorageAdapter {
 			Key: key,
 			Body: counter.stream,
 			ContentType: opts.mimeType,
+			...(opts.contentLength !== undefined
+				? { ContentLength: opts.contentLength }
+				: {}),
 			...(dir === 'pub' ? { ACL: 'public-read' } : {}),
 		}
 		await Sentry.startSpan(
@@ -205,6 +216,9 @@ export class TigrisStorageAdapter implements StorageAdapter {
 					'storage.part_size_bytes': multipartUploadPartSize,
 					'storage.queue_size': 1,
 					'storage.acl': dir === 'pub' ? 'public-read' : 'private',
+					...(opts.contentLength !== undefined
+						? { 'storage.content_length': opts.contentLength }
+						: {}),
 					...(opts.photoId ? { 'photo.id': opts.photoId } : {}),
 				},
 			},


### PR DESCRIPTION
## Summary

Both raw and pub uploads went through `@aws-sdk/lib-storage`'s `Upload`, but `Upload` falls back to a single `PutObjectCommand` when the body fits under `partSize` (5 MiB). With a `Readable` body and no `Content-Length`, that PutObject goes out chunked-encoded — and Tigris rejects chunked PutObject with `MissingContentLength`. Raw uploads (< 5 MiB) and resized pub JPEGs (~0.2–2 MiB after the 2048px cap) both hit this fallback on every upload.

- Extend `UploadOptions` with `contentLength?: number`; Tigris adapter passes it as `params.ContentLength` and records `storage.content_length` on the span.
- raw: pass `stat(tempPath).size`.
- pub: switch from streaming to `transform.toBuffer({ resolveWithObject: true })`; ContentLength is `buffer.byteLength`. Negligible memory cost vs. the libvips working set; replaces the previous `'info'` listener with the resolved `info` object.

## Test plan

- [x] `bash bin/code-quality.sh` — typecheck, lint, tests, format
- [x] Photo unit + integration tests (39 tests across 4 files)
- [ ] Deploy to staging and confirm `MissingContentLength` no longer appears
- [ ] Upload an iPhone JPEG end-to-end; verify `pub/` object is correct (orientation, dimensions ≤ 2048, EXIF stripped)
- [ ] Check `photo.sharp_transform` and `storage.upload.tigris` spans show `storage.content_length`

🤖 Generated with [Claude Code](https://claude.com/claude-code)