### PR TITLE
fix(photos): raise upload limit to 30 MB and resize before autoOrient

### DIFF
--- a/apps/www/src/api/listing-photos.ts
+++ b/apps/www/src/api/listing-photos.ts
@@ -58,7 +58,10 @@ export const addPhotoToListing = createServerFn({ method: 'POST' })
 		// keep accepting 5 MB temp files it can't process.
 		assertPhotoUploadCapacity()
 		if (file.size > MAX_FILE_SIZE_BYTES) {
-			throw new UserError('FILE_TOO_LARGE', 'Photo must be 5 MB or smaller')
+			throw new UserError(
+				'FILE_TOO_LARGE',
+				`Photo must be ${MAX_FILE_SIZE_BYTES / (1024 * 1024)} MB or smaller`
+			)
 		}
 		// Pre-filter on client-supplied type before buffering — avoids reading the
 		// full body for obviously wrong types. The authoritative check (magic bytes)

--- a/apps/www/src/lib/listing-photo-upload.server.ts
+++ b/apps/www/src/lib/listing-photo-upload.server.ts
@@ -19,7 +19,7 @@ export const ALLOWED_MIME_TYPES = [
 ] as const
 export type AllowedMimeType = (typeof ALLOWED_MIME_TYPES)[number]
 
-export const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024
+export const MAX_FILE_SIZE_BYTES = 30 * 1024 * 1024
 
 export const MAX_IMAGE_PIXELS = 16_000_000
 
@@ -122,7 +122,10 @@ export async function validatePhotoFile(
 		)
 	}
 	if (buffer.byteLength > MAX_FILE_SIZE_BYTES) {
-		throw new UserError('FILE_TOO_LARGE', 'Photo must be 5 MB or smaller')
+		throw new UserError(
+			'FILE_TOO_LARGE',
+			`Photo must be ${MAX_FILE_SIZE_BYTES / (1024 * 1024)} MB or smaller`
+		)
 	}
 	return mimeType as AllowedMimeType
 }
@@ -260,20 +263,22 @@ async function uploadListingPhotoLocked(
 					span.setAttribute('sharp.cache_items_current', cacheSnapshot.items.current)
 
 					span.setAttribute('photo.pub_max_dimension', PUB_MAX_DIMENSION)
-					// Order matters: rotate first so .resize() targets display-oriented
-					// dimensions. For JPEG input, libvips uses shrink-on-load to decode
-					// at 1/2, 1/4, or 1/8 — the dominant memory win on the pub pipeline.
+					// Resize before autoOrient: libvips' JPEG shrink-on-load decodes at
+					// 1/2, 1/4, or 1/8 scale when resize is the first pipeline step —
+					// the dominant memory win. The square fit-inside target (2048×2048)
+					// means final pixel dimensions are identical regardless of order, so
+					// autoOrient on the already-small buffer is safe and cheap.
 					const transform = sharp({
 						sequentialRead: true,
 						limitInputPixels: MAX_IMAGE_PIXELS,
 					})
-						.autoOrient()
 						.resize({
 							width: PUB_MAX_DIMENSION,
 							height: PUB_MAX_DIMENSION,
 							fit: 'inside',
 							withoutEnlargement: true,
 						})
+						.autoOrient()
 						.jpeg({ quality: 85, mozjpeg: true })
 					transform.on('info', (info: import('sharp').OutputInfo) => {
 						span.setAttribute('photo.output_width', info.width)

--- a/apps/www/tests/listing-photo-upload.server.test.ts
+++ b/apps/www/tests/listing-photo-upload.server.test.ts
@@ -46,6 +46,7 @@ const {
 	uploadListingPhoto,
 	assertPhotoUploadCapacity,
 	MAX_UPLOAD_QUEUE_DEPTH,
+	MAX_FILE_SIZE_BYTES,
 } = await import('../src/lib/listing-photo-upload.server')
 
 // One reusable real fixture per format. Tiny so the encode is instant.
@@ -122,20 +123,20 @@ describe('validatePhotoFile', () => {
 		await expect(validatePhotoFile(gifMagic)).rejects.toThrow()
 	})
 
-	it('rejects files over 5 MB', async () => {
+	it('rejects files over the size limit', async () => {
 		const oversized = Buffer.concat([
 			jpegFixture,
-			Buffer.alloc(5 * 1024 * 1024 + 1),
+			Buffer.alloc(MAX_FILE_SIZE_BYTES + 1),
 		])
 		await expect(validatePhotoFile(oversized)).rejects.toThrow()
 	})
 
-	it('accepts files exactly at 5 MB', async () => {
-		const exactlyFiveMb = Buffer.concat([
+	it('accepts files exactly at the size limit', async () => {
+		const atLimit = Buffer.concat([
 			jpegFixture,
-			Buffer.alloc(5 * 1024 * 1024 - jpegFixture.byteLength),
+			Buffer.alloc(MAX_FILE_SIZE_BYTES - jpegFixture.byteLength),
 		])
-		await expect(validatePhotoFile(exactlyFiveMb)).resolves.toBe('image/jpeg')
+		await expect(validatePhotoFile(atLimit)).resolves.toBe('image/jpeg')
 	})
 })
 


### PR DESCRIPTION
## Summary

- Raises `MAX_FILE_SIZE_BYTES` from 5 MB to 30 MB — modern phone JPEGs routinely hit 10–20 MB at default quality settings, and the old limit was rejecting them before they even reached the server. The raw path is a pure disk-to-Tigris stream with no size-based memory concern; the Sharp pub path is already guarded by the 16 MP pixel cap (`limitInputPixels`).
- Flips the Sharp pipeline to `.resize()` then `.autoOrient()` so libvips can apply JPEG shrink-on-load (1/2–1/8 decode scale) as the very first step, then correct orientation on the already-small buffer. The square fit-inside target (2048×2048) makes the final pixel output identical regardless of order.
- Error messages now compute the MB value from `MAX_FILE_SIZE_BYTES` so they stay in sync with the constant automatically.

## Test plan

- [x] All 441 unit tests pass (`pnpm test:run` from `apps/www`)
- [x] All existing EXIF/orientation tests in `listing-photo-exif.server.test.ts` pass with the new pipeline order
- [x] Manual: upload a 10–20 MB phone JPEG via the dev server and confirm it is accepted, correctly oriented, and capped at 2048 px on the long edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)