### PR TITLE
fix(ci): detect PR inside Deploy Preview to fix race condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,28 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Detects whether the pushed branch has an open PR.
-  # Runs in parallel with `test`; result is consumed by `preview`.
-  context:
-    name: Detect PR
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    outputs:
-      pr-number: ${{ steps.pr.outputs.number }}
-    steps:
-      - name: Find open PR for branch
-        id: pr
-        run: |
-          NUMBER=$(gh pr list \
-            --repo "${{ github.repository }}" \
-            --head "${{ github.ref_name }}" \
-            --state open \
-            --json number \
-            --jq '.[0].number' 2>/dev/null || echo '')
-          echo "number=${NUMBER:-}" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ github.token }}
-
   test:
     name: Test and Lint
     runs-on: ubuntu-latest
@@ -127,26 +105,44 @@ jobs:
   preview:
     name: Deploy Preview
     runs-on: ubuntu-latest
-    needs: [test, context]
-    if: needs.context.outputs.pr-number != ''
+    needs: [test]
+    if: github.event_name != 'pull_request'
     environment:
       name: preview
-      url: https://pickmyfruit-pr-${{ needs.context.outputs.pr-number }}.fly.dev
+      url: ${{ steps.pr.outputs.number != '' && format('https://pickmyfruit-pr-{0}.fly.dev', steps.pr.outputs.number) || '' }}
     steps:
+      - name: Find open PR for branch
+        id: pr
+        run: |
+          NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "${{ github.ref_name }}" \
+            --state open \
+            --json number \
+            --jq '.[0].number' 2>/dev/null || echo '')
+          echo "number=${NUMBER:-}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - uses: actions/checkout@v4
+        if: steps.pr.outputs.number != ''
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
+        if: steps.pr.outputs.number != ''
 
       - name: Set app name
-        run: echo "APP_NAME=pickmyfruit-pr-${{ needs.context.outputs.pr-number }}" >> $GITHUB_ENV
+        if: steps.pr.outputs.number != ''
+        run: echo "APP_NAME=pickmyfruit-pr-${{ steps.pr.outputs.number }}" >> $GITHUB_ENV
 
       - name: Create app (idempotent)
+        if: steps.pr.outputs.number != ''
         # status 1 means "name taken", which we can ignore; bubble other errors
         run: flyctl apps create $APP_NAME --org personal || [ $? -eq 1 ]
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Set secrets
+        if: steps.pr.outputs.number != ''
         run: |
           flyctl secrets set --app $APP_NAME \
             BETTER_AUTH_SECRET="${{ secrets.PREVIEW_BETTER_AUTH_SECRET }}" \
@@ -156,6 +152,7 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Deploy
+        if: steps.pr.outputs.number != ''
         run: ./bin/deploy.sh
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Removes the separate `Detect PR` job that ran immediately on push (before a PR might exist)
- Moves PR detection to the first step of `Deploy Preview`, which runs only after `Test and Lint` passes (~5 min) — by then the PR is virtually always open
- Gates all deployment steps on a found PR number; the job still runs (and succeeds cleanly) on branches without a PR

## Why this fixes the problem

The old `context` job ran in parallel with `test`, completing in ~5s. If you pushed and then opened a PR, the detection happened before the PR existed. The preview job saw an empty PR number and was skipped. Re-running all jobs worked only because the PR was open by then.

Now detection happens at the start of `Deploy Preview` — after tests finish — so the timing aligns naturally with the normal open-PR workflow.

## Test plan

- [x] Push a branch and immediately open a PR — confirm `Deploy Preview` runs (not skipped) after tests pass
- [x] Confirm the preview URL is reachable at `pickmyfruit-pr-{N}.fly.dev`
- [x] Push to a branch with no PR — confirm `Deploy Preview` runs but skips all deployment steps cleanly
- [ ] Merge the PR — confirm `Destroy Preview` tears down the Fly app

🤖 Generated with [Claude Code](https://claude.com/claude-code)