### PR TITLE
Fix Sentry source maps: export Docker build env for CLI and client release

### DIFF
--- a/apps/www/Dockerfile
+++ b/apps/www/Dockerfile
@@ -52,6 +52,14 @@ ARG SENTRY_PROJECT
 ARG SENTRY_RELEASE
 ARG VITE_SENTRY_RELEASE=${SENTRY_RELEASE}
 
+# ARG is not persisted into RUN's process environment. sentry-cli reads
+# SENTRY_ORG / SENTRY_PROJECT / SENTRY_RELEASE from the env; Vite inlines
+# VITE_SENTRY_RELEASE into the client bundle so events match uploaded artifacts.
+ENV SENTRY_ORG=${SENTRY_ORG} \
+	SENTRY_PROJECT=${SENTRY_PROJECT} \
+	SENTRY_RELEASE=${SENTRY_RELEASE} \
+	VITE_SENTRY_RELEASE=${VITE_SENTRY_RELEASE}
+
 # Build the www application.
 # Nitro's Rollup bundling phase (~3400 modules) can exceed Node's default
 # ~2 GB heap. Set a higher limit to avoid OOM during Docker builds.
@@ -61,8 +69,6 @@ RUN cd apps/www && NODE_OPTIONS="--max-old-space-size=4096" pnpm build
 # final image. Runs after the full build so both client (.output/public/)
 # and server (.output/server/) maps exist. If SENTRY_AUTH_TOKEN is absent
 # (e.g. CI smoke tests), the step is a no-op.
-# SENTRY_ORG, SENTRY_PROJECT, and SENTRY_RELEASE are available from the
-# ARG declarations above; sentry-cli reads them from the environment.
 RUN --mount=type=secret,id=sentry_auth_token \
     export SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token 2>/dev/null || true) && \
     if [ -n "$SENTRY_AUTH_TOKEN" ]; then \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Sentry was not symbolicating production errors because two mechanisms were broken in the Docker image build:

1. **`sentry-cli` environment** — `SENTRY_ORG`, `SENTRY_PROJECT`, and `SENTRY_RELEASE` were only declared as `ARG`. In Docker, `ARG` values are **not** automatically available in `RUN` shell commands. `sentry-cli` reads those from the process environment, so uploads could fail, target the wrong org/project, or behave inconsistently depending on defaults.

2. **Release mismatch** — `VITE_SENTRY_RELEASE` was never available to Vite during `pnpm build` (only an `ARG` default with no `ENV`), so `import.meta.env.VITE_SENTRY_RELEASE` was empty in the client bundle. Events therefore did not carry the same **release** identifier as `sentry-cli sourcemaps upload --release "$SENTRY_RELEASE"`, so Sentry could not associate stack frames with uploaded artifacts even when maps existed.

## Change

After the `ARG` block, add `ENV` entries that copy `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_RELEASE`, and `VITE_SENTRY_RELEASE` into the builder stage environment **before** `pnpm build`, so both Vite and `sentry-cli` see consistent values.

## Notes

- Local `pnpm build` already emits `sourcemap: 'hidden'` maps under `.output/public` (no `//# sourceMappingURL` in JS by design).
- If `SENTRY_AUTH_TOKEN` is missing, upload is still skipped (unchanged).
- After deploy, confirm in Sentry that new releases show artifacts and that events include the same release string as CI’s `SENTRY_RELEASE` / `github.sha`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b1a52b3-f4e6-430b-acc6-eb5bf3780561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b1a52b3-f4e6-430b-acc6-eb5bf3780561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

