### PR TITLE
fix(a11y): style focus ring in forced colors mode

### DIFF
--- a/apps/www/src/components/Combobox.css
+++ b/apps/www/src/components/Combobox.css
@@ -143,4 +143,14 @@
 	.combobox__item:not([data-selected]) .combobox__item-check {
 		visibility: hidden;
 	}
+
+	@media (forced-colors: active) {
+		.combobox__control:focus-within {
+			border-color: Highlight;
+
+			.combobox__trigger:focus-visible {
+				outline: none;
+			}
+		}
+	}
 }

--- a/apps/www/src/styles/focus.css
+++ b/apps/www/src/styles/focus.css
@@ -35,16 +35,45 @@
 	* foreground colors.
 	* @see https://piccalil.li/blog/taking-a-shot-at-the-double-focus-ring-problem-using-modern-css/
 	*/
-	:focus-visible {
-		box-shadow: var(--_focus-ring-shadow);
-		outline: none;
+	@media not (forced-colors: active) {
+		:focus-visible,
+		.focus-ring:focus-within {
+			box-shadow: var(--_focus-ring-shadow);
+			outline: none;
+		}
+	}
+
+	@media (forced-colors: active) {
+		:focus-visible,
+		.focus-ring:focus-within {
+			box-shadow: none;
+			outline: 2px solid var(--color-accent);
+			outline-offset: 2px;
+		}
 	}
 }
 
 @layer utilities {
-	.focus-ring:focus-within {
-		box-shadow: var(--_focus-ring-shadow);
-		outline: none;
+	@media not (forced-colors: active) {
+		:focus-visible,
+		.focus-ring:focus-within {
+			box-shadow: var(--_focus-ring-shadow);
+			outline: none;
+		}
+	}
+
+	@media (forced-colors: active) {
+		:focus-visible,
+		.focus-ring:focus-within {
+			border-color: Highlight;
+			box-shadow: none;
+			outline: 2px solid Highlight;
+			outline-offset: 3px;
+		}
+
+		.focus-ring-none:focus-visible {
+			outline: none;
+		}
 	}
 
 	.focus-ring-none:focus-visible {


### PR DESCRIPTION
Apply shadow-based focus styles only outside forced-colors. Inside forced-colors (Windows High Contrast), use outline with Highlight color. Apply to all `:focus-visible`, to `.focus-ring:focus-within`, and to the Combobox component.

Forced-Colors: Active
<img width="245" height="58" alt="Screenshot 2026-05-04 at 9 25 45 AM" src="https://github.com/user-attachments/assets/210ed06f-74fc-466d-b523-a29735ebe881" />
<img width="411" height="128" alt="Screenshot 2026-05-04 at 9 26 08 AM" src="https://github.com/user-attachments/assets/68c5d3c0-131b-4b63-a202-0fc9521918ee" />
