### PR TITLE
Include magic-link token in sign-in email

### DIFF
--- a/apps/www/src/lib/auth.server.ts
+++ b/apps/www/src/lib/auth.server.ts
@@ -29,6 +29,7 @@ const sendMagicLinkEmail = async ({
 		const { Resend } = await import('resend')
 		const resend = new Resend(serverEnv.email.RESEND_API_KEY)
 
+		const safeUrl = escapeHtml(url)
 		const safeToken = escapeHtml(token)
 
 		const { error } = await resend.emails.send({
@@ -45,7 +46,7 @@ const sendMagicLinkEmail = async ({
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
 	<h1 style="color: #2d5016; margin-bottom: 24px;">Welcome to Pick My Fruit!</h1>
 	<p>Click the button below to sign in:</p>
-	<a href="${url}" style="display: inline-block; padding: 14px 28px; background: #4a7c23; color: white; text-decoration: none; border-radius: 6px; font-weight: 600; margin: 16px 0;">Sign In</a>
+	<a href="${safeUrl}" style="display: inline-block; padding: 14px 28px; background: #4a7c23; color: white; text-decoration: none; border-radius: 6px; font-weight: 600; margin: 16px 0;">Sign In</a>
 	<p style="margin-top: 28px;">If the button does not work, go to the sign-in page on Pick My Fruit and paste the token below into the &ldquo;Or enter the token&rdquo; field.</p>
 	<p style="font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace; font-size: 1.35rem; text-align: center; margin: 12px 0 0 0; letter-spacing: 0.02em;">${safeToken}</p>
 	<p style="color: #666; font-size: 14px; margin-top: 24px;">This link expires in 5 minutes. If you didn't request this, you can safely ignore this email.</p>

--- a/apps/www/src/lib/auth.server.ts
+++ b/apps/www/src/lib/auth.server.ts
@@ -6,6 +6,7 @@ import { tanstackStartCookies } from 'better-auth/tanstack-start/solid'
 import { db } from '../data/db.server'
 import { serverEnv } from './env.server'
 import { logger } from './logger.server'
+import { escapeHtml } from './html-escape.server'
 import { profileNameSchema } from './validation'
 
 const sendMagicLinkEmail = async ({
@@ -28,6 +29,8 @@ const sendMagicLinkEmail = async ({
 		const { Resend } = await import('resend')
 		const resend = new Resend(serverEnv.email.RESEND_API_KEY)
 
+		const safeToken = escapeHtml(token)
+
 		const { error } = await resend.emails.send({
 			from: serverEnv.EMAIL_FROM,
 			to: email,
@@ -43,6 +46,8 @@ const sendMagicLinkEmail = async ({
 	<h1 style="color: #2d5016; margin-bottom: 24px;">Welcome to Pick My Fruit!</h1>
 	<p>Click the button below to sign in:</p>
 	<a href="${url}" style="display: inline-block; padding: 14px 28px; background: #4a7c23; color: white; text-decoration: none; border-radius: 6px; font-weight: 600; margin: 16px 0;">Sign In</a>
+	<p style="margin-top: 28px;">If the button does not work, go to the sign-in page on Pick My Fruit and paste the token below into the &ldquo;Or enter the token&rdquo; field.</p>
+	<p style="font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace; font-size: 1.35rem; text-align: center; margin: 12px 0 0 0; letter-spacing: 0.02em;">${safeToken}</p>
 	<p style="color: #666; font-size: 14px; margin-top: 24px;">This link expires in 5 minutes. If you didn't request this, you can safely ignore this email.</p>
 </body>
 </html>

--- a/apps/www/src/lib/email-templates.server.ts
+++ b/apps/www/src/lib/email-templates.server.ts
@@ -1,6 +1,7 @@
 import { buildUnavailableUrl } from './hmac.server'
 import { serverEnv } from './env.server'
 import { logger } from './logger.server'
+import { escapeHtml } from './html-escape.server'
 
 interface InquiryEmailData {
 	baseUrl: string
@@ -79,15 +80,6 @@ export function buildInquiryEmailHtml(data: InquiryEmailData): string {
   </p>
 </body>
 </html>`
-}
-
-function escapeHtml(text: string): string {
-	return text
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#039;')
 }
 
 /** Sends an inquiry notification email. Throws on failure. */

--- a/apps/www/src/lib/html-escape.server.ts
+++ b/apps/www/src/lib/html-escape.server.ts
@@ -1,0 +1,9 @@
+/** Escapes text for safe interpolation into HTML (body or quoted attribute). */
+export function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#039;')
+}

--- a/apps/www/tests/html-escape.server.test.ts
+++ b/apps/www/tests/html-escape.server.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { escapeHtml } from '../src/lib/html-escape.server'
+
+describe('escapeHtml', () => {
+	it('escapes HTML special characters', () => {
+		expect(escapeHtml(`<&>"'`)).toBe('&lt;&amp;&gt;&quot;&#039;')
+	})
+
+	it('leaves alphanumeric text unchanged', () => {
+		expect(escapeHtml('abc123')).toBe('abc123')
+	})
+})

--- a/apps/www/tests/html-escape.server.test.ts
+++ b/apps/www/tests/html-escape.server.test.ts
@@ -9,4 +9,10 @@ describe('escapeHtml', () => {
 	it('leaves alphanumeric text unchanged', () => {
 		expect(escapeHtml('abc123')).toBe('abc123')
 	})
+
+	it('escapes ampersands in URLs for safe href interpolation', () => {
+		expect(escapeHtml('https://example.com/cb?a=1&b=2')).toBe(
+			'https://example.com/cb?a=1&amp;b=2'
+		)
+	})
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The magic-link waiting UI lets users paste a token when the email link is inconvenient, but the Resend HTML template only included the sign-in URL. The Resend magic-link email now includes the token with short instructions and styling (monospace, larger type, centered, with spacing after the preceding paragraph).

Magic-link HTML now escapes both the **token** and the **sign-in URL** before interpolation (defense in depth for `href` and any future visible URL text), since `callbackURL` can carry user-influenced query state.

<img width="688" height="398" alt="Screenshot 2026-05-11 at 3 46 35 PM" src="https://github.com/user-attachments/assets/9bbde492-3cd5-4404-9cf8-c601660b1bdc" />

## Implementation notes

- Introduced `escapeHtml` in `apps/www/src/lib/html-escape.server.ts` and reused it from `email-templates.server.ts` so user-controlled strings (including the token) stay safe in HTML.
- Unit tests for `escapeHtml`, including ampersands in URL-shaped strings.

## Testing

- `bash bin/after-turn.sh` (format, typecheck, lint, tests, format check)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2c7e775-7c90-4535-b358-d5af764abc7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2c7e775-7c90-4535-b358-d5af764abc7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

