### PR TITLE
Add mock geocoding provider for testing

### DIFF
--- a/apps/www/.env.test
+++ b/apps/www/.env.test
@@ -7,6 +7,7 @@ BETTER_AUTH_URL=http://localhost:5174
 DATABASE_URL=file:data/test.db
 EMAIL_FROM=Pick My Fruit <noreply@example.com>
 EMAIL_PROVIDER=silent
+GEOCODING_PROVIDER=mock
 HMAC_SECRET=test-secret-do-not-use-in-production-min32chars
 STORAGE_PROVIDER=local
 DATA_DIR=./test-uploads

--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
 			DATA_DIR: resolve(__dirname, 'test-uploads'),
 			EMAIL_FROM: 'Test <test@example.com>',
 			EMAIL_PROVIDER: 'silent',
+			GEOCODING_PROVIDER: 'mock',
 			HMAC_SECRET: 'test-secret-for-e2e-minimum-32-characters',
 			PORT: '5174',
 			STORAGE_PROVIDER: 'local',

--- a/apps/www/src/lib/env.server.ts
+++ b/apps/www/src/lib/env.server.ts
@@ -82,6 +82,7 @@ const outputSchema = z
 		EMAIL_FROM: z
 			.string()
 			.regex(/^.+\s<[^@]+@[^>]+>$/, 'Must be in "Display Name <email>" format'),
+		GEOCODING_PROVIDER: z.enum(['nominatim', 'mock']).prefault('nominatim'),
 		HMAC_SECRET: z.string().min(32),
 		MIGRATE_ON_REQUEST: z.stringbool().prefault('false'),
 		NODE_ENV: z.string().prefault('development'),
@@ -105,6 +106,15 @@ const outputSchema = z
 				code: 'custom',
 				path: ['STORAGE_PROVIDER'],
 				message: 'Must be "tigris" in production',
+			})
+		}
+
+		// Synthetic geocoding is for tests only; real lookups are required in production.
+		if (env.NODE_ENV === 'production' && env.GEOCODING_PROVIDER !== 'nominatim') {
+			ctx.addIssue({
+				code: 'custom',
+				path: ['GEOCODING_PROVIDER'],
+				message: 'Must be "nominatim" in production',
 			})
 		}
 	})

--- a/apps/www/src/lib/geocoding.server.ts
+++ b/apps/www/src/lib/geocoding.server.ts
@@ -1,19 +1,23 @@
 import { latLngToCell } from 'h3-js'
+import { z } from 'zod'
 import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
 import { serverEnv } from '@/lib/env.server'
 
-export interface GeocodingResult {
-	lat: number
-	lng: number
-	h3Index: string
-	displayName: string
-}
+const geocodingResultSchema = z.object({
+	lat: z.number().gte(-90).lte(90),
+	lng: z.number().gte(-180).lte(180),
+	h3Index: z.string().min(1),
+	displayName: z.string().min(1),
+})
 
-export interface NominatimResponse {
-	lat: string
-	lon: string
-	display_name: string
-}
+/** A geocoded location with H3 index and display name. */
+export type GeocodingResult = z.infer<typeof geocodingResultSchema>
+
+const nominatimResponseSchema = z.object({
+	lat: z.coerce.number(),
+	lon: z.coerce.number(),
+	display_name: z.string(),
+})
 
 export interface GeocodingInput {
 	address: string
@@ -25,46 +29,36 @@ export interface GeocodingInput {
 const GEOCODE_URL =
 	'https://nominatim.openstreetmap.org/search?format=json&limit=1&countrycodes=us'
 
-/** Downtown Napa — used as the anchor for synthetic geocoding in tests. */
+/** Downtown Napa — anchor point for synthetic geocoding in tests. */
 const MOCK_ANCHOR = { lat: 38.2975, lng: -122.2869 }
 
-/**
- * Deterministic synthetic geocoding for tests. Spreads addresses around a
- * fixed anchor so different inputs produce different (but stable) coordinates.
- */
-function mockGeocode(input: GeocodingInput): GeocodingResult {
-	const query = [input.address, input.city, input.state, input.zip]
+function buildQuery(input: GeocodingInput): string {
+	return [input.address, input.city, input.state, input.zip]
 		.filter(Boolean)
 		.join(', ')
+}
+
+/** Deterministic synthetic geocoding spread around a fixed anchor. */
+function mockGeocode(input: GeocodingInput): GeocodingResult {
+	const query = buildQuery(input)
 	let hash = 0
 	for (let i = 0; i < query.length; i++) {
 		hash = (hash * 31 + query.charCodeAt(i)) | 0
 	}
 	const lat = MOCK_ANCHOR.lat + ((hash & 0xff) - 128) * 0.0001
 	const lng = MOCK_ANCHOR.lng + (((hash >> 8) & 0xff) - 128) * 0.0001
-	return {
+	return geocodingResultSchema.parse({
 		lat,
 		lng,
 		h3Index: latLngToCell(lat, lng, H3_RESOLUTIONS.STORAGE),
 		displayName: query,
-	}
+	})
 }
 
-/**
- * Geocode an address using OpenStreetMap's Nominatim API.
- * Rate limited to 1 request/second - fine for MVP.
- *
- * @throws Error if geocoding fails or no results found
- */
-export async function geocodeAddress(
+async function nominatimGeocode(
 	input: GeocodingInput
 ): Promise<GeocodingResult> {
-	if (serverEnv.GEOCODING_PROVIDER === 'mock') {
-		return mockGeocode(input)
-	}
-
-	const { address, city, state, zip } = input
-	const query = [address, city, state, zip].filter(Boolean).join(', ')
+	const query = buildQuery(input)
 	const url = new URL(GEOCODE_URL)
 	url.searchParams.append('q', query)
 
@@ -78,7 +72,7 @@ export async function geocodeAddress(
 		throw new Error(`Geocoding request failed: ${response.status}`)
 	}
 
-	const results: NominatimResponse[] = await response.json()
+	const results = z.array(nominatimResponseSchema).parse(await response.json())
 
 	if (results.length === 0) {
 		throw new Error(
@@ -87,15 +81,26 @@ export async function geocodeAddress(
 	}
 
 	const [result] = results
-	const lat = parseFloat(result.lat)
-	const lng = parseFloat(result.lon)
-
-	const h3Index = latLngToCell(lat, lng, H3_RESOLUTIONS.STORAGE)
-
-	return {
-		lat,
-		lng,
-		h3Index,
+	return geocodingResultSchema.parse({
+		lat: result.lat,
+		lng: result.lon,
+		h3Index: latLngToCell(result.lat, result.lon, H3_RESOLUTIONS.STORAGE),
 		displayName: result.display_name,
+	})
+}
+
+/**
+ * Geocode an address. Uses Nominatim by default; returns deterministic
+ * synthetic results when GEOCODING_PROVIDER=mock.
+ * Rate limited to 1 request/second - fine for MVP.
+ *
+ * @throws Error if geocoding fails or no results found
+ */
+export async function geocodeAddress(
+	input: GeocodingInput
+): Promise<GeocodingResult> {
+	if (serverEnv.GEOCODING_PROVIDER === 'mock') {
+		return mockGeocode(input)
 	}
+	return nominatimGeocode(input)
 }

--- a/apps/www/src/lib/geocoding.server.ts
+++ b/apps/www/src/lib/geocoding.server.ts
@@ -1,5 +1,6 @@
 import { latLngToCell } from 'h3-js'
 import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
+import { serverEnv } from '@/lib/env.server'
 
 export interface GeocodingResult {
 	lat: number
@@ -24,6 +25,31 @@ export interface GeocodingInput {
 const GEOCODE_URL =
 	'https://nominatim.openstreetmap.org/search?format=json&limit=1&countrycodes=us'
 
+/** Downtown Napa — used as the anchor for synthetic geocoding in tests. */
+const MOCK_ANCHOR = { lat: 38.2975, lng: -122.2869 }
+
+/**
+ * Deterministic synthetic geocoding for tests. Spreads addresses around a
+ * fixed anchor so different inputs produce different (but stable) coordinates.
+ */
+function mockGeocode(input: GeocodingInput): GeocodingResult {
+	const query = [input.address, input.city, input.state, input.zip]
+		.filter(Boolean)
+		.join(', ')
+	let hash = 0
+	for (let i = 0; i < query.length; i++) {
+		hash = (hash * 31 + query.charCodeAt(i)) | 0
+	}
+	const lat = MOCK_ANCHOR.lat + ((hash & 0xff) - 128) * 0.0001
+	const lng = MOCK_ANCHOR.lng + (((hash >> 8) & 0xff) - 128) * 0.0001
+	return {
+		lat,
+		lng,
+		h3Index: latLngToCell(lat, lng, H3_RESOLUTIONS.STORAGE),
+		displayName: query,
+	}
+}
+
 /**
  * Geocode an address using OpenStreetMap's Nominatim API.
  * Rate limited to 1 request/second - fine for MVP.
@@ -33,6 +59,10 @@ const GEOCODE_URL =
 export async function geocodeAddress(
 	input: GeocodingInput
 ): Promise<GeocodingResult> {
+	if (serverEnv.GEOCODING_PROVIDER === 'mock') {
+		return mockGeocode(input)
+	}
+
 	const { address, city, state, zip } = input
 	const query = [address, city, state, zip].filter(Boolean).join(', ')
 	const url = new URL(GEOCODE_URL)

--- a/apps/www/src/lib/migrations.server.ts
+++ b/apps/www/src/lib/migrations.server.ts
@@ -1,4 +1,3 @@
-import { migrate } from 'drizzle-orm/libsql/migrator'
 import { db } from '@/data/db.server'
 import { Sentry } from '@/lib/sentry'
 import { logger } from '@/lib/logger.server'
@@ -27,6 +26,7 @@ export function runMigrations(): Promise<void> {
 	pending ??= (async () => {
 		const start = Date.now()
 		logger.info('Running database migrations')
+		const { migrate } = await import('drizzle-orm/libsql/migrator')
 		await migrate(db, { migrationsFolder: './drizzle' })
 		logger.info({ elapsed: Date.now() - start }, 'Database migrations complete')
 	})().catch((err) => {

--- a/apps/www/src/routes/api/listings.ts
+++ b/apps/www/src/routes/api/listings.ts
@@ -1,7 +1,6 @@
 import { createFileRoute } from '@tanstack/solid-router'
 import { z } from 'zod'
 import { listingFormSchema } from '@/lib/validation'
-import { geocodeAddress } from '@/lib/geocoding'
 import { Sentry } from '@/lib/sentry'
 import { produceTypes } from '@/lib/produce-types'
 
@@ -64,6 +63,7 @@ export const Route = createFileRoute('/api/listings')({
 				const formData = parsed.data
 
 				// Geocode the address
+				const { geocodeAddress } = await import('@/lib/geocoding.server')
 				let geocodeResult
 				try {
 					geocodeResult = await geocodeAddress({

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
 						DATABASE_URL: `file:${dbPath}`,
 						EMAIL_FROM: 'Test <test@example.com>',
 						EMAIL_PROVIDER: 'silent',
+						GEOCODING_PROVIDER: 'mock',
 						HMAC_SECRET: 'test-secret-do-not-use-in-production-min32chars',
 						NODE_ENV: 'test',
 						STORAGE_PROVIDER: 'local',


### PR DESCRIPTION
## Summary
This PR adds support for a mock geocoding provider to enable deterministic address geocoding in test environments, eliminating the need for external API calls during testing.

## Key Changes
- **New mock geocoding implementation**: Added `mockGeocode()` function that generates deterministic coordinates based on a hash of the input address, anchored around Downtown Napa
- **Zod schema**: Validate mock and Nominatim outputs against shared zod schema
- **Environment configuration**: Added `GEOCODING_PROVIDER` environment variable with support for 'nominatim' (production) and 'mock' (testing) providers
- **Production safety**: Added validation to enforce that only 'nominatim' provider is used in production environments
- **Conditional provider selection**: Updated `geocodeAddress()` to use mock provider when configured
- **Test environment setup**: Configured mock provider in `.env.test`, `playwright.config.ts`, and `vitest.config.ts`
- **Dynamic imports**: Converted static imports to dynamic imports for `drizzle-orm/libsql/migrator` and `geocoding.server` to improve code splitting

## Implementation Details
- The mock geocoding function uses a simple hash algorithm on the concatenated address fields to produce stable, deterministic coordinates
- Each address component (address, city, state, zip) contributes to the hash, ensuring different inputs produce different coordinates
- Coordinates are spread within a ±0.0128° range around the anchor point, providing realistic geographic distribution for testing
- The H3 index is still computed for mock results to maintain compatibility with the rest of the system

https://claude.ai/code/session_01YH47L3ZB8bWbCNo5v1gxEh