### PR TITLE
chore: lower uploadListingPhoto log level to debug

### DIFF
--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
 			EMAIL_FROM: 'Test <test@example.com>',
 			EMAIL_PROVIDER: 'silent',
 			HMAC_SECRET: 'test-secret-for-e2e-minimum-32-characters',
+			NODE_ENV: 'test',
 			PORT: '5174',
 			STORAGE_PROVIDER: 'local',
 		},

--- a/apps/www/src/lib/listing-photo-upload.server.ts
+++ b/apps/www/src/lib/listing-photo-upload.server.ts
@@ -203,7 +203,7 @@ async function uploadListingPhotoLocked(
 	const rawPathKey = `listing_photos/${id}${opts.fileExt}`
 	const pubPathKey = `listing_photos/${id}.jpg`
 
-	logger.info(
+	logger.debug(
 		{
 			phase: 'start',
 			listingPhotoId: id,
@@ -332,7 +332,7 @@ async function uploadListingPhotoLocked(
 		phase = 'error'
 		throw err
 	} finally {
-		logger.info(
+		logger.debug(
 			{
 				phase,
 				listingPhotoId: id,

--- a/apps/www/tests/listing-photo-upload.server.test.ts
+++ b/apps/www/tests/listing-photo-upload.server.test.ts
@@ -30,11 +30,11 @@ vi.mock('../src/lib/env.server', () => ({
 	serverEnv: { SHARP_CONCURRENCY: 1 },
 }))
 
-const mockLoggerInfo = vi.fn()
+const mockLoggerDebug = vi.fn()
 vi.mock('../src/lib/logger.server', () => ({
 	logger: {
-		info: mockLoggerInfo,
-		debug: vi.fn(),
+		info: vi.fn(),
+		debug: mockLoggerDebug,
 		warn: vi.fn(),
 		error: vi.fn(),
 	},
@@ -177,7 +177,7 @@ describe('uploadListingPhoto', () => {
 			storage: makeStorage(),
 		})
 
-		const phases = mockLoggerInfo.mock.calls
+		const phases = mockLoggerDebug.mock.calls
 			.map(([fields]) => fields as { phase?: string; rssBytes?: number })
 			.filter((f) => f.phase === 'start' || f.phase === 'end')
 		expect(phases.map((f) => f.phase)).toEqual(['start', 'end'])


### PR DESCRIPTION
## Summary

- Ensure E2E tests run with `NODE_ENV=test`. That causes the minimum log level to be `info`.
- Change `uploadListingPhoto` logs to `debug` so they are automatically filtered out in tests.

## Test plan

- [x] `bash bin/code-quality.sh` passes (typecheck, lint, unit tests, format)
- [x] Verify E2E run no longer emits `uploadListingPhoto` log lines