### PR TITLE
Add Floral produce category (cut flowers, dried flowers, edible flowers)

### DIFF
--- a/apps/www/src/lib/produce-types.csv
+++ b/apps/www/src/lib/produce-types.csv
@@ -124,8 +124,9 @@ ginger,herb,Ginger,Ginger,ginger,ginger,An aromatic rhizome used fresh or dried 
 comb-honey,honey,Comb Honey,Comb Honey,comb honey,comb honey,Fresh honeycomb with wax cells still intact and naturally drizzling.
 honey,honey,Honey,Honey,honey,honey,Pure raw honey harvested from backyard or local hives.
 infused-honey,honey,Infused Honey,Infused Honey,infused honey,infused honey,Honey infused with herbs or spices for a unique flavor.
-dried-flowers,other,Dried Flowers,Dried Flowers,dried flowers,dried flowers,Dried garden flowers for decorative or culinary use.
-edible-flowers,other,Edible Flowers,Edible Flowers,edible flowers,edible flowers,Fresh garden blossoms safe to eat and beautiful on dishes.
+cut-flowers,floral,Cut Flowers,Cut Flowers,cut flowers,cut flowers,Fresh-cut stems and blooms for bouquets and floral arrangements.
+dried-flowers,floral,Dried Flowers,Dried Flowers,dried flowers,dried flowers,Dried garden flowers for decorative or culinary use.
+edible-flowers,floral,Edible Flowers,Edible Flowers,edible flowers,edible flowers,Fresh garden blossoms safe to eat and beautiful on dishes.
 microgreens,other,Microgreens,Microgreens,microgreens,microgreens,Young tender seedlings harvested just after sprouting.
 mushrooms,other,Mushrooms,Mushrooms,mushrooms,mushrooms,Cultivated or foraged fungi with earthy flavors.
 other,other,Other,Produce,other,produce,Any produce type not listed here.

--- a/apps/www/tests/produce-types.test.ts
+++ b/apps/www/tests/produce-types.test.ts
@@ -56,14 +56,15 @@ describe('produceTypes', () => {
 
 	it('all categories are from the allowed set', () => {
 		const allowed = new Set([
-			'fruit',
-			'vegetable',
-			'herb',
 			'egg',
+			'floral',
+			'fruit',
+			'herb',
 			'honey',
-			'seedling',
-			'preserved',
 			'other',
+			'preserved',
+			'seedling',
+			'vegetable',
 		])
 		for (const t of produceTypes) {
 			expect(allowed.has(t.category)).toBe(true)


### PR DESCRIPTION
## Summary

- Adds a new `floral` produce category to replace the mismatched catch-all `other` category for flower types
- Adds `cut-flowers` as a new produce type (the immediate need — 6 uncategorized listings on site)
- Moves `dried-flowers` and `edible-flowers` out of `other` into `floral`, where they belong
- Updates the test's allowed-category set to include `floral`

The `other` category still exists and retains mushrooms, microgreens, sprouts, worm castings, and the generic "Other" fallback.

<img width="349" height="307" alt="produce-type-floral" src="https://github.com/user-attachments/assets/fb74d654-300a-4322-8f0a-149d69f2ea8e" />

## Test plan

- [x] All unit tests pass (`pnpm test:run`)
- [x] All E2E tests pass (`pnpm test:e2e`)
- [x] ProduceTypeSelector shows a "Floral" group containing Cut Flowers, Dried Flowers, and Edible Flowers
- [x] "Other" group no longer contains Dried Flowers or Edible Flowers
- [x] Existing listings with `dried-flowers` or `edible-flowers` slugs still resolve correctly (slugs unchanged)