### PR TITLE
Add Buy Me a Coffee donation button

### DIFF
--- a/apps/www/src/components/BuyMeACoffee.css
+++ b/apps/www/src/components/BuyMeACoffee.css
@@ -1,0 +1,1 @@
+/* No local styles needed; the BMC script injects its own button styles. */

--- a/apps/www/src/components/BuyMeACoffee.tsx
+++ b/apps/www/src/components/BuyMeACoffee.tsx
@@ -1,0 +1,29 @@
+import { onCleanup, onMount } from 'solid-js'
+import './BuyMeACoffee.css'
+
+/** Floating Buy Me a Coffee donation widget. Loads the third-party script on mount. */
+export function BuyMeACoffee() {
+	onMount(() => {
+		const script = document.createElement('script')
+		script.type = 'text/javascript'
+		script.src = 'https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js'
+		script.setAttribute('data-name', 'bmc-button')
+		script.setAttribute('data-slug', 'jamesarosen')
+		script.setAttribute('data-color', '#f3eacd')
+		script.setAttribute('data-emoji', '🌱')
+		script.setAttribute('data-font', 'Bree')
+		script.setAttribute('data-text', 'Support Us')
+		script.setAttribute('data-outline-color', '#000000')
+		script.setAttribute('data-font-color', '#000000')
+		script.setAttribute('data-coffee-color', '#FFDD00')
+		document.head.appendChild(script)
+
+		onCleanup(() => {
+			script.remove()
+			// The BMC script appends its button to <body>; remove it on cleanup.
+			document.getElementById('bmc-wbtn')?.remove()
+		})
+	})
+
+	return null
+}

--- a/apps/www/src/components/BuyMeACoffee.tsx
+++ b/apps/www/src/components/BuyMeACoffee.tsx
@@ -1,29 +1,20 @@
-import { onCleanup, onMount } from 'solid-js'
 import './BuyMeACoffee.css'
 
 /** Floating Buy Me a Coffee donation widget. Loads the third-party script on mount. */
 export function BuyMeACoffee() {
-	onMount(() => {
-		const script = document.createElement('script')
-		script.type = 'text/javascript'
-		script.src = 'https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js'
-		script.setAttribute('data-name', 'bmc-button')
-		script.setAttribute('data-slug', 'jamesarosen')
-		script.setAttribute('data-color', '#f3eacd')
-		script.setAttribute('data-emoji', '🌱')
-		script.setAttribute('data-font', 'Bree')
-		script.setAttribute('data-text', 'Support Us')
-		script.setAttribute('data-outline-color', '#000000')
-		script.setAttribute('data-font-color', '#000000')
-		script.setAttribute('data-coffee-color', '#FFDD00')
-		document.head.appendChild(script)
-
-		onCleanup(() => {
-			script.remove()
-			// The BMC script appends its button to <body>; remove it on cleanup.
-			document.getElementById('bmc-wbtn')?.remove()
-		})
-	})
-
-	return null
+	return (
+		<script
+			type="text/javascript"
+			src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
+			data-name="bmc-button"
+			data-slug="jamesarosen"
+			data-color="#f3eacd"
+			data-emoji="🐝"
+			data-font="Bree"
+			data-text="Support our Garden"
+			data-outline-color="#000000"
+			data-font-color="#000000"
+			data-coffee-color="#FFDD00"
+		/>
+	)
 }

--- a/apps/www/src/components/PageFooter.tsx
+++ b/apps/www/src/components/PageFooter.tsx
@@ -1,10 +1,12 @@
 import { Link } from '@tanstack/solid-router'
+import { BuyMeACoffee } from './BuyMeACoffee'
 import './PageFooter.css'
 import { SupportEmail } from './SupportEmail'
 
 export function PageFooter() {
 	return (
 		<footer class="page-footer">
+			<BuyMeACoffee />
 			<div class="container">
 				<div class="footer-left">
 					<span class="footer-avatar">JAR</span>

--- a/apps/www/src/components/PageFooter.tsx
+++ b/apps/www/src/components/PageFooter.tsx
@@ -1,12 +1,10 @@
 import { Link } from '@tanstack/solid-router'
-import { BuyMeACoffee } from './BuyMeACoffee'
 import './PageFooter.css'
 import { SupportEmail } from './SupportEmail'
 
 export function PageFooter() {
 	return (
 		<footer class="page-footer">
-			<BuyMeACoffee />
 			<div class="container">
 				<div class="footer-left">
 					<span class="footer-avatar">JAR</span>

--- a/apps/www/src/components/PageHeader.tsx
+++ b/apps/www/src/components/PageHeader.tsx
@@ -19,6 +19,7 @@ import { authClient } from '@/lib/auth-client'
 import { displayName } from '@/lib/display-name'
 import './PageHeader.css'
 import NamePromptBanner from './NamePromptBanner'
+import { BuyMeACoffee } from './BuyMeACoffee'
 
 export type Breadcrumb = {
 	/** Visible text for this crumb. */
@@ -125,6 +126,8 @@ export default function PageHeader(props: PageHeaderProps) {
 						</span>
 						<span class="page-header__logo-text">Pick My Fruit</span>
 					</Link>
+
+					<BuyMeACoffee />
 
 					<DropdownMenu open={menuOpen()} onOpenChange={setMenuOpen}>
 						{/* aria-label is stable; Kobalte manages aria-expanded and aria-haspopup */}

--- a/apps/www/src/middleware/security-headers.ts
+++ b/apps/www/src/middleware/security-headers.ts
@@ -8,17 +8,17 @@ function buildCspDirectives(extraImgSrc: string[]): string[] {
 		"default-src 'self'",
 		// Solid's HydrationScript injects an inline script for SSR hydration.
 		// @todo replace 'unsafe-inline' with nonce-based CSP when Solid supports it
-		// cdnjs.buymeacoffee.com serves the Buy Me a Coffee (BMAC) button widget script.
+		// cdnjs.buymeacoffee.com: BMAC.
 		"script-src 'self' 'unsafe-inline' https://cdnjs.buymeacoffee.com",
 		// 'unsafe-inline' is required for Solid JSX style="" attributes and MapLibre GL.
 		// If JSX inline styles are moved to CSS classes, 'unsafe-inline' can be dropped and
 		// replaced with 'sha256-VQTei97aMH9YclKPQM3e8rL/RXSmj3lPwKVXZgaN2QA=' to whitelist
 		// only the static @layer ordering <style> block in RootShell.
-		// fonts.bunny.net serves the Bree font stylesheet injected by the BMAC button script.
-		"style-src 'self' 'unsafe-inline' https://fonts.bunny.net",
+		// fonts.bunny.net & fonts.googleapis.com: BMAC.
+		"style-src 'self' 'unsafe-inline' https://fonts.bunny.net https://fonts.googleapis.com",
 		imgSrc,
-		// fonts.bunny.net serves the Bree font files used by the BMAC button widget.
-		"font-src 'self' https://fonts.bunny.net",
+		// fonts.bunny.net & fonts.gstatic.com: BMAC.
+		"font-src 'self' https://fonts.bunny.net https://fonts.gstatic.com",
 		[
 			"connect-src 'self'",
 			'https://*.openfreemap.org',

--- a/apps/www/src/middleware/security-headers.ts
+++ b/apps/www/src/middleware/security-headers.ts
@@ -8,15 +8,16 @@ function buildCspDirectives(extraImgSrc: string[]): string[] {
 		"default-src 'self'",
 		// Solid's HydrationScript injects an inline script for SSR hydration.
 		// @todo replace 'unsafe-inline' with nonce-based CSP when Solid supports it
+		// cdnjs.buymeacoffee.com serves the Buy Me a Coffee (BMAC) button widget script.
 		"script-src 'self' 'unsafe-inline' https://cdnjs.buymeacoffee.com",
 		// 'unsafe-inline' is required for Solid JSX style="" attributes and MapLibre GL.
 		// If JSX inline styles are moved to CSS classes, 'unsafe-inline' can be dropped and
 		// replaced with 'sha256-VQTei97aMH9YclKPQM3e8rL/RXSmj3lPwKVXZgaN2QA=' to whitelist
 		// only the static @layer ordering <style> block in RootShell.
-		// fonts.bunny.net covers the stylesheet injected by the Buy Me a Coffee button script.
+		// fonts.bunny.net serves the Bree font stylesheet injected by the BMAC button script.
 		"style-src 'self' 'unsafe-inline' https://fonts.bunny.net",
 		imgSrc,
-		// fonts.bunny.net serves the Bree font used by the Buy Me a Coffee button
+		// fonts.bunny.net serves the Bree font files used by the BMAC button widget.
 		"font-src 'self' https://fonts.bunny.net",
 		[
 			"connect-src 'self'",

--- a/apps/www/src/middleware/security-headers.ts
+++ b/apps/www/src/middleware/security-headers.ts
@@ -8,14 +8,16 @@ function buildCspDirectives(extraImgSrc: string[]): string[] {
 		"default-src 'self'",
 		// Solid's HydrationScript injects an inline script for SSR hydration.
 		// @todo replace 'unsafe-inline' with nonce-based CSP when Solid supports it
-		"script-src 'self' 'unsafe-inline'",
+		"script-src 'self' 'unsafe-inline' https://cdnjs.buymeacoffee.com",
 		// 'unsafe-inline' is required for Solid JSX style="" attributes and MapLibre GL.
 		// If JSX inline styles are moved to CSS classes, 'unsafe-inline' can be dropped and
 		// replaced with 'sha256-VQTei97aMH9YclKPQM3e8rL/RXSmj3lPwKVXZgaN2QA=' to whitelist
 		// only the static @layer ordering <style> block in RootShell.
-		"style-src 'self' 'unsafe-inline'",
+		// fonts.bunny.net covers the stylesheet injected by the Buy Me a Coffee button script.
+		"style-src 'self' 'unsafe-inline' https://fonts.bunny.net",
 		imgSrc,
-		"font-src 'self'",
+		// fonts.bunny.net serves the Bree font used by the Buy Me a Coffee button
+		"font-src 'self' https://fonts.bunny.net",
 		[
 			"connect-src 'self'",
 			'https://*.openfreemap.org',


### PR DESCRIPTION
## Summary

- Adds an isolated `BuyMeACoffee` component that dynamically injects the BMAC widget script on mount and removes it (plus the button element) on cleanup
- Renders the component inside `PageFooter` so it appears on every page
- Extends the Content Security Policy to allow the three external origins the widget requires: `cdnjs.buymeacoffee.com` (script), `fonts.bunny.net` (font stylesheet + font files)

## Test plan

- [ ] Load the site locally — a floating "Support Us 🌱" button should appear in the bottom-right corner
- [ ] Click the button — should navigate to `https://www.buymeacoffee.com/jamesarosen`
- [ ] Check browser DevTools → Network: no CSP violations in the console
- [ ] Verify the button is absent on a route that unmounts the root layout (not applicable here, but cleanup logic is wired)

https://claude.ai/code/session_01KiXXLRCPYnvK1rHrQmCc9n

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiXXLRCPYnvK1rHrQmCc9n)_