### PR TITLE
feat(storage): set Cache-Control on public Tigris uploads

### DIFF
--- a/apps/www/src/lib/storage.server.ts
+++ b/apps/www/src/lib/storage.server.ts
@@ -22,6 +22,15 @@ export type StorageBody = Readable
 const multipartUploadPartSize = 5 * 1024 * 1024
 
 /**
+ * Cache-Control for public image objects: 1 day fresh, 30 days stale-while-revalidate
+ * and stale-if-error. Treats keys as effectively immutable in app logic (new content
+ * = new key) while preserving a same-day window to invalidate URLs for urgent fixes
+ * (e.g. EXIF leakage).
+ */
+export const publicImageCacheControl =
+	'public, max-age=86400, stale-while-revalidate=2592000, stale-if-error=2592000'
+
+/**
  * Pass-through Transform that counts bytes flowing through it. Used to record
  * `storage.bytes_written` on upload spans without buffering or interfering
  * with downstream backpressure (a plain PassThrough with a 'data' listener
@@ -206,7 +215,9 @@ export class TigrisStorageAdapter implements StorageAdapter {
 			Key: key,
 			Body: counter.stream,
 			ContentType: opts.mimeType,
-			...(dir === 'pub' ? { ACL: 'public-read' } : {}),
+			...(dir === 'pub'
+				? { ACL: 'public-read', CacheControl: publicImageCacheControl }
+				: {}),
 		}
 		await Sentry.startSpan(
 			{

--- a/apps/www/tests/storage.server.test.ts
+++ b/apps/www/tests/storage.server.test.ts
@@ -9,6 +9,7 @@ import { text } from 'node:stream/consumers'
 import {
 	LocalStorageAdapter,
 	TigrisStorageAdapter,
+	publicImageCacheControl,
 } from '../src/lib/storage.server'
 
 describe(LocalStorageAdapter, () => {
@@ -236,6 +237,83 @@ describe(TigrisStorageAdapter, () => {
 	})
 
 	describe('upload', () => {
+		/**
+		 * Spins up a stub S3 endpoint that records every request, runs `fn` against
+		 * a TigrisStorageAdapter pointing at it, then returns the captured requests.
+		 */
+		async function withCapturingS3<T>(
+			fn: (adapter: TigrisStorageAdapter) => Promise<T>
+		): Promise<{
+			result: T
+			requests: { method: string; url: string; headers: Record<string, string> }[]
+		}> {
+			const requests: {
+				method: string
+				url: string
+				headers: Record<string, string>
+			}[] = []
+			const server = createServer((req, res) => {
+				requests.push({
+					method: req.method ?? '',
+					url: req.url ?? '',
+					headers: Object.fromEntries(
+						Object.entries(req.headers).map(([k, v]) => [
+							k,
+							Array.isArray(v) ? v.join(',') : (v ?? ''),
+						])
+					),
+				})
+				req.resume()
+				req.on('end', () => {
+					res.writeHead(200)
+					res.end()
+				})
+			})
+			await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+			try {
+				const { port } = server.address() as AddressInfo
+				const localAdapter = new TigrisStorageAdapter({
+					bucketName: 'test-bucket',
+					accessKeyId: 'fake',
+					secretAccessKey: 'fake',
+					endpointUrl: `http://127.0.0.1:${port}`,
+					mediaOrigin: defaultMediaOrigin,
+				})
+				const result = await fn(localAdapter)
+				return { result, requests }
+			} finally {
+				await new Promise<void>((resolve, reject) =>
+					server.close((err) => (err ? reject(err) : resolve()))
+				)
+			}
+		}
+
+		it('sends Cache-Control on pub uploads', async () => {
+			const { requests } = await withCapturingS3((adapter) =>
+				adapter.upload(
+					'pub',
+					'listings/1/uuid.jpg',
+					Readable.from(Buffer.from('hello')),
+					{ mimeType: 'image/jpeg' }
+				)
+			)
+			const put = requests.find((r) => r.method === 'PUT')
+			expect(put?.headers['cache-control']).toBe(publicImageCacheControl)
+		})
+
+		it('does not send Cache-Control on raw uploads', async () => {
+			const { requests } = await withCapturingS3((adapter) =>
+				adapter.upload(
+					'raw',
+					'listings/1/uuid.jpg',
+					Readable.from(Buffer.from('hello')),
+					{ mimeType: 'image/jpeg' }
+				)
+			)
+			const put = requests.find((r) => r.method === 'PUT')
+			expect(put?.headers['cache-control']).toBeUndefined()
+		})
+
 		it('uploads a Readable stream without throwing x-amz-decoded-content-length error', async () => {
 			// Regression: AWS SDK v3 defaults to WHEN_SUPPORTED for requestChecksumCalculation,
 			// which requires x-amz-decoded-content-length for streaming bodies. That header is


### PR DESCRIPTION
## Summary

- Tigris was returning `cache-control: no-cache` on public image objects. We set an explicit `Cache-Control` on `pub/` `PutObject` requests so repeat viewers benefit from browser caching while preserving a same-day window to invalidate URLs for urgent fixes (e.g. EXIF leakage).
- Header value: `public, max-age=86400, stale-while-revalidate=2592000, stale-if-error=2592000` (1 day fresh, 30 days SWR, 30 days SIE).
- Raw (private) uploads are unchanged.
- Treats keys as effectively immutable in app logic — new content should always go to a new key. If we ever decide caching is a real bottleneck, flipping to `public, max-age=31536000, immutable` is a one-line change with no migration.

## Why these numbers (vs. `public, immutable`)

We're pre-MVP with no shared cache (no [Tigris Acceleration Gateway](https://www.tigrisdata.com/docs/acceleration-gateway/), no CDN), so the audience is just browsers of repeat viewers. `immutable` would force a blob migration to roll out a fix; `max-age=86400` + long SWR keeps the recovery window tight without sacrificing repeat-view performance.

## Test plan

- [x] Added unit tests asserting `Cache-Control` is set on `pub` uploads and absent on `raw` uploads (uses a stub HTTP server to capture the S3 PUT headers)
- [x] `pnpm --filter @pickmyfruit/www test:run storage.server` passes (20/20)
- [x] `bash bin/after-turn.sh` passes (typecheck, lint, tests, format)
- [ ] After merge: verify a freshly uploaded listing photo on Tigris returns the expected `cache-control` header

## Why `no-cache` today

Tigris's [docs](https://www.tigrisdata.com/docs/objects/caching/#public-buckets) say images in public buckets default to `public, max-age=3600`. We observe `no-cache` for these files. The cause is almost certainly that they are public objects in a default-private bucket.

https://claude.ai/code/session_01K8iGJ8ofnkJDuPA8XwJMU4

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8iGJ8ofnkJDuPA8XwJMU4)_