### PR TITLE
fix(listings): invalid id param uses NotFoundError (PICKMYFRUIT-Z)

### DIFF
--- a/apps/www/src/api/listings.ts
+++ b/apps/www/src/api/listings.ts
@@ -2,6 +2,7 @@ import { createServerFn } from '@tanstack/solid-start'
 import { getRequestHeaders } from '@tanstack/solid-start/server'
 import { z } from 'zod'
 import { errorMiddleware, UserError } from '@/lib/server-error-middleware'
+import { NotFoundError } from '@/lib/user-error'
 import { Sentry } from '@/lib/sentry'
 import { updateListingSchema } from '@/lib/validation'
 import type { AddressFields, Listing } from '@/data/schema'
@@ -72,12 +73,24 @@ export const getNearbyListings = createServerFn({ method: 'GET' })
 		return query(data.lat, data.lng, data.limit)
 	})
 
-const getListingByIdValidator = z.coerce.number().int().positive()
+/**
+ * Strict positive integer listing id from route params or RPC input; `.parse`
+ * throws {@link NotFoundError} when the value is malformed (TanStack-compatible
+ * not-found; see `notFound()` in Router docs).
+ */
+export const listingIdParamSchema = z.coerce
+	.string()
+	.regex(/^\d+$/)
+	.transform((s) => Number.parseInt(s, 10))
+	.pipe(z.number().int().positive())
+	.catch(() => {
+		throw new NotFoundError('Listing not found')
+	})
 
 /** Fetches a single listing by ID, omitting sensitive fields. Excludes private listings. */
 export const getPublicListingById = createServerFn({ method: 'GET' })
 	.middleware([errorMiddleware])
-	.inputValidator((id: number) => getListingByIdValidator.parse(id))
+	.inputValidator((id: unknown) => listingIdParamSchema.parse(id))
 	.handler(async ({ data: id }) => {
 		const { getPublicListingById: query } = await import('@/data/queries.server')
 		return query(id)
@@ -86,7 +99,7 @@ export const getPublicListingById = createServerFn({ method: 'GET' })
 /** Fetches a listing for the current viewer — owners see full data, others see public fields. */
 export const getListingForViewer = createServerFn({ method: 'GET' })
 	.middleware([errorMiddleware])
-	.inputValidator((id: number) => getListingByIdValidator.parse(id))
+	.inputValidator((id: unknown) => listingIdParamSchema.parse(id))
 	.handler(async ({ data: id }) => {
 		const headers = getRequestHeaders()
 		const { auth } = await import('@/lib/auth.server')

--- a/apps/www/src/lib/server-error-middleware.ts
+++ b/apps/www/src/lib/server-error-middleware.ts
@@ -1,8 +1,8 @@
 import { createMiddleware } from '@tanstack/solid-start'
 import { setResponseStatus } from '@tanstack/solid-start/server'
 import { Sentry } from './sentry'
-export { UserError } from './user-error'
-import { UserError } from './user-error'
+export { isNotFoundError, NotFoundError, UserError } from './user-error'
+import { isNotFoundError, UserError } from './user-error'
 
 /**
  * Middleware that captures exceptions server-side and converts them
@@ -20,6 +20,10 @@ export const errorMiddleware = createMiddleware({ type: 'function' }).server(
 				if (error.status) {
 					setResponseStatus(error.status)
 				}
+				throw error
+			}
+
+			if (isNotFoundError(error)) {
 				throw error
 			}
 

--- a/apps/www/src/lib/user-error.ts
+++ b/apps/www/src/lib/user-error.ts
@@ -14,3 +14,34 @@ export class UserError extends Error {
 		this.status = status
 	}
 }
+
+/**
+ * Thrown to trigger TanStack Router / Start not-found handling; matches the
+ * object shape produced by `notFound()` (`isNotFound` in `@tanstack/router-core`
+ * is true when `value.isNotFound === true`).
+ *
+ * @see https://tanstack.com/router/latest/docs/framework/react/api/router/notFoundFunction
+ */
+export class NotFoundError extends Error {
+	public readonly isNotFound = true as const
+
+	constructor(message = 'Not found') {
+		super(message)
+		this.name = 'NotFoundError'
+	}
+}
+
+/**
+ * Whether `value` is a TanStack Router / Start not-found throw (including
+ * {@link NotFoundError}); matches `@tanstack/router-core`’s `isNotFound`, which
+ * is true when `value?.isNotFound === true`.
+ *
+ * @see https://tanstack.com/router/latest/docs/framework/react/api/router/notFoundFunction
+ */
+export function isNotFoundError(value: unknown): boolean {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as { isNotFound?: unknown }).isNotFound === true
+	)
+}

--- a/apps/www/src/routes/listings.$id.tsx
+++ b/apps/www/src/routes/listings.$id.tsx
@@ -16,7 +16,11 @@ import {
 import { ListingStatus, type ListingStatusValue } from '@/lib/validation'
 import { buildListingMeta } from '@/lib/listing-meta'
 import { Sentry } from '@/lib/sentry'
-import { getListingForViewer, updateListing } from '@/api/listings'
+import {
+	getListingForViewer,
+	listingIdParamSchema,
+	updateListing,
+} from '@/api/listings'
 import type { Listing } from '@/data/schema'
 import type { PublicListing } from '@/data/queries.server'
 import type { OwnerListingView, PublicPhoto } from '@/data/listing'
@@ -27,6 +31,23 @@ const listingSearchSchema = z.object({
 	created: z.boolean().optional(),
 	marked: z.enum(['unavailable']).optional(),
 })
+
+function ListingNotFoundFallback() {
+	return (
+		<Layout title="Listing Not Found - Pick My Fruit">
+			<PageHeader breadcrumbs={[{ label: 'Listing' }]} />
+			<main id="main-content" class="listing-show">
+				<div class="listing-not-found">
+					<h1>Listing Not Found</h1>
+					<p>This listing may have been removed or doesn't exist.</p>
+					<Link to="/" class="back-link">
+						Back to Home
+					</Link>
+				</div>
+			</main>
+		</Layout>
+	)
+}
 
 /**
  * Fallback embed image used when a listing has no cover photo. Matches the
@@ -42,7 +63,9 @@ const PLACEHOLDER_EMBED = {
 
 export const Route = createFileRoute('/listings/$id')({
 	validateSearch: listingSearchSchema,
-	loader: ({ params }) => getListingForViewer({ data: Number(params.id) }),
+	loader: ({ params }) =>
+		getListingForViewer({ data: listingIdParamSchema.parse(params.id) }),
+	notFoundComponent: ListingNotFoundFallback,
 	head: ({ loaderData }) => {
 		// TODO: generate richer embed images for listings. Open Graph / Twitter /
 		// Slack crawlers prefer different aspect ratios and resolutions (e.g.
@@ -614,23 +637,7 @@ function ListingDetailPage() {
 		Math.floor((liveUpdatedAt()?.getTime() ?? 0) / 1000)
 
 	return (
-		<Show
-			when={listing()}
-			fallback={
-				<Layout title="Listing Not Found - Pick My Fruit">
-					<PageHeader breadcrumbs={[{ label: 'Listing' }]} />
-					<main id="main-content" class="listing-show">
-						<div class="listing-not-found">
-							<h1>Listing Not Found</h1>
-							<p>This listing may have been removed or doesn't exist.</p>
-							<Link to="/" class="back-link">
-								Back to Home
-							</Link>
-						</div>
-					</main>
-				</Layout>
-			}
-		>
+		<Show when={listing()} fallback={<ListingNotFoundFallback />}>
 			{(l) => (
 				<Layout title={`${displayTitle()} - Pick My Fruit`}>
 					<PageHeader breadcrumbs={[{ label: displayTitle() }]} />

--- a/apps/www/tests/listing-id-param.test.ts
+++ b/apps/www/tests/listing-id-param.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { listingIdParamSchema } from '../src/api/listings'
+import { NotFoundError } from '../src/lib/user-error'
+
+describe('Listing id param parsing', () => {
+	it.each([
+		['1', 1],
+		['42', 42],
+		[42, 42],
+		['009', 9],
+	])('accepts %s → %s', (input, expected) => {
+		expect.hasAssertions()
+		expect(listingIdParamSchema.parse(input)).toBe(expected)
+	})
+
+	it.each([
+		'#main-content',
+		'%23main-content',
+		'12abc',
+		'-1',
+		'0',
+		0,
+		Number.NaN,
+		'',
+		{},
+		null,
+		undefined,
+	])('rejects %s with NotFoundError', (input) => {
+		expect.hasAssertions()
+		expect(() => listingIdParamSchema.parse(input)).toThrow(NotFoundError)
+	})
+})

--- a/apps/www/tests/not-found-error.test.ts
+++ b/apps/www/tests/not-found-error.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { isNotFoundError, NotFoundError } from '../src/lib/user-error'
+
+describe('NotFoundError', () => {
+	it('is an Error subclass with name NotFoundError', () => {
+		expect.hasAssertions()
+		const err = new NotFoundError()
+		expect(err).toBeInstanceOf(Error)
+		expect(err).toBeInstanceOf(NotFoundError)
+		expect(err.name).toBe('NotFoundError')
+	})
+
+	it('defaults message to "Not found"', () => {
+		expect.hasAssertions()
+		expect(new NotFoundError().message).toBe('Not found')
+	})
+
+	it('accepts a custom message', () => {
+		expect.hasAssertions()
+		expect(new NotFoundError('Missing resource').message).toBe('Missing resource')
+	})
+
+	it('sets isNotFound so TanStack isNotFound() recognizes it', () => {
+		expect.hasAssertions()
+		const err = new NotFoundError()
+		expect(err.isNotFound).toBe(true)
+	})
+})
+
+describe('isNotFoundError', () => {
+	it('returns true for new NotFoundError()', () => {
+		expect.hasAssertions()
+		expect(isNotFoundError(new NotFoundError())).toBe(true)
+	})
+
+	it('returns true for a plain TanStack-style not-found object', () => {
+		expect.hasAssertions()
+		expect(isNotFoundError({ isNotFound: true })).toBe(true)
+	})
+
+	it('returns false for an ordinary Error', () => {
+		expect.hasAssertions()
+		expect(isNotFoundError(new Error('oops'))).toBe(false)
+	})
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Malformed /listings/:id values (e.g. %23main-content) no longer coerce to NaN and trigger ZodError → Sentry.

- listingIdParamSchema: strict decimal id + Zod .catch throws NotFoundError
- NotFoundError and isNotFoundError in user-error.ts (TanStack not-found contract)
- errorMiddleware rethrows not-found errors before Sentry.captureException
- listings.$id route: single-expression loader + notFoundComponent for consistent UX
- Unit tests: listing-id-param, not-found-error

Fixes PICKMYFRUIT-Z
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fad934bb-c950-4abb-aae3-bf998ac35800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fad934bb-c950-4abb-aae3-bf998ac35800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

