### PR TITLE
Replace vite-tsconfig-paths plugin with native Vite support

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -76,7 +76,6 @@
 		"vite": "^8.0.10",
 		"vite-node": "^6.0.0",
 		"vite-plugin-solid": "2.11.12",
-		"vite-tsconfig-paths": "^6.1.1",
 		"vitest": "^4.1.5"
 	}
 }

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, loadEnv } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { tanstackStart } from '@tanstack/solid-start/plugin/vite'
 import { nitro } from 'nitro/vite'
 import solid from 'vite-plugin-solid'
@@ -93,9 +92,11 @@ export default defineConfig(({ command, mode }) => {
 				build: { sourcemap: 'hidden' },
 			},
 		},
+		resolve: {
+			tsconfigPaths: true,
+		},
 		server: {},
 		plugins: [
-			tsconfigPaths(),
 			tanstackStart({
 				// Defense-in-depth: deny client-graph imports of server-only packages.
 				// File-level `*.server.*` protection is built in; this extends it to

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -1,12 +1,11 @@
 import { defineConfig } from 'vitest/config'
 import solid from 'vite-plugin-solid'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import path from 'node:path'
 
 const dbPath = path.resolve(__dirname, 'data', 'test.db')
 
 export default defineConfig({
-	plugins: [tsconfigPaths(), solid()],
+	plugins: [solid()],
 	test: {
 		environment: 'jsdom',
 		globals: true,
@@ -80,6 +79,7 @@ export default defineConfig({
 	},
 	resolve: {
 		conditions: ['development', 'browser'],
+		tsconfigPaths: true,
 		alias: {
 			// Mock TanStack Start server modules that require build environment
 			// More specific path must come first

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,9 +134,6 @@ importers:
       vite-plugin-solid:
         specifier: 2.11.12
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
@@ -3926,9 +3923,6 @@ packages:
     resolution: {integrity: sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ==}
     engines: {node: '>=20'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -5325,16 +5319,6 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -5615,11 +5599,6 @@ packages:
     peerDependenciesMeta:
       '@testing-library/jest-dom':
         optional: true
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -9799,8 +9778,6 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.4.0
 
-  globrex@0.1.2: {}
-
   graceful-fs@4.2.11: {}
 
   gzip-size@7.0.0:
@@ -11395,10 +11372,6 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
-  tsconfck@3.1.6(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
-
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -11694,16 +11667,6 @@ snapshots:
       '@testing-library/jest-dom': 6.9.1
     transitivePeerDependencies:
       - supports-color
-
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:


### PR DESCRIPTION
## Summary

- Vite 8 resolves tsconfig paths natively, so the `vite-tsconfig-paths` plugin is no longer needed
- Switch `vite.config.ts` and `vitest.config.ts` to `resolve.tsconfigPaths: true`
- Drop the `vite-tsconfig-paths` dependency from `apps/www/package.json`

This silences the `vite dev` warning recommending the native option.

## Test plan

- [x] `bash bin/after-turn.sh` passes (typecheck, lint, unit tests, formatting)
- [x] `bash bin/before-push.sh` passes (E2E tests)
- [x] `pnpm dev` no longer logs the `vite-tsconfig-paths` deprecation warning


---
_Generated by [Claude Code](https://claude.ai/code/session_01BffzHSRpaZj1LELc1YwnY3)_