### PR TITLE
Skip auto-formatting when no changes detected

### DIFF
--- a/bin/after-turn.sh
+++ b/bin/after-turn.sh
@@ -3,6 +3,11 @@ set -uo pipefail
 
 cd "$(dirname "$0")/.." || exit 2
 
+if [ -z "$(git status --porcelain)" ]; then
+	echo "[after-turn] No changes detected; skipping."
+	exit 0
+fi
+
 echo "[after-turn] Auto-formatting..."
 format_stderr=$(pnpm format:write 2>&1 >/dev/null)
 format_exit=$?


### PR DESCRIPTION
## Summary

Optimize the `after-turn.sh` script to skip the auto-formatting step when there are no staged changes, reducing unnecessary tool invocations.

## Changes

- Added an early exit check that detects if the working directory has any changes using `git status --porcelain`
- If no changes are detected, the script logs a message and exits cleanly without running `pnpm format:write`

## Implementation Details

The check is placed at the beginning of the script (after directory setup) to fail fast before any formatting operations are attempted. This is particularly useful in CI/CD pipelines or automated workflows where the script may be invoked even when there are no code changes to process.

https://claude.ai/code/session_01TFcxjKUoUYncWiDC7HpzN9