### PR TITLE
fix(e2e): fix Kobalte SSR hydration issues causing flaky E2E tests

### DIFF
--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -7,6 +7,7 @@ const testDbPath = resolve(__dirname, 'data/test.db')
 
 export default defineConfig({
 	testDir: './tests/e2e',
+	globalSetup: './tests/e2e/global-setup.ts',
 	fullyParallel: false,
 	forbidOnly: Boolean(process.env.CI),
 	retries: process.env.CI ? 2 : 0,

--- a/apps/www/src/components/FormField.tsx
+++ b/apps/www/src/components/FormField.tsx
@@ -10,6 +10,7 @@ import {
 import {
 	children,
 	type ComponentProps,
+	createUniqueId,
 	For,
 	type JSX,
 	Show,
@@ -21,6 +22,7 @@ type TextFieldProps = {
 	children: JSX.Element
 	errors?: string[]
 	hint?: JSX.Element
+	inputId: string
 	label: JSX.Element
 	note?: JSX.Element
 } & Pick<
@@ -33,6 +35,7 @@ const FIELD_PROPS = [
 	'defaultValue',
 	'errors',
 	'hint',
+	'inputId',
 	'label',
 	'name',
 	'note',
@@ -70,7 +73,7 @@ export function TextField(props: TextFieldProps) {
 			validationState={(props.errors?.length ?? 0) === 0 ? 'valid' : 'invalid'}
 			value={props.value}
 		>
-			<Label class="form-field__label">
+			<Label class="form-field__label" for={props.inputId}>
 				<Show when={renderedLabel()}>{renderedLabel()}</Show>
 				<Show when={props.required}>
 					&nbsp;
@@ -95,28 +98,36 @@ export function TextField(props: TextFieldProps) {
 	)
 }
 
-type InputFieldProps = Omit<TextFieldProps, 'children'> &
+type InputFieldProps = Omit<TextFieldProps, 'children' | 'inputId'> &
 	ComponentProps<typeof KInput>
 
 /** A single-line text input with label, hint, note, and error support. */
 export function Input(props: InputFieldProps) {
 	const [fieldProps, rest] = splitProps(props, FIELD_PROPS)
+	// Kobalte skips the `for`/`id` association in SSR because it registers the
+	// field ID inside a `createEffect`, which SolidJS doesn't run on the server.
+	// Generating stable IDs here and passing them explicitly to both the Label
+	// (via `inputId` → `for`) and the Input (`id`) keeps the association intact
+	// in the server-rendered HTML. https://github.com/kobaltedev/kobalte/issues/652
+	const inputId = createUniqueId()
 	return (
-		<TextField {...fieldProps}>
-			<KInput class="form-field__control" {...rest} />
+		<TextField {...fieldProps} inputId={inputId}>
+			<KInput class="form-field__control" {...rest} id={inputId} />
 		</TextField>
 	)
 }
 
-type TextareaFieldProps = Omit<TextFieldProps, 'children'> &
+type TextareaFieldProps = Omit<TextFieldProps, 'children' | 'inputId'> &
 	ComponentProps<typeof KTextArea>
 
 /** A multi-line textarea with label, hint, note, and error support. */
 export function Textarea(props: TextareaFieldProps) {
 	const [fieldProps, rest] = splitProps(props, FIELD_PROPS)
+	// Same workaround as Input above. https://github.com/kobaltedev/kobalte/issues/652
+	const inputId = createUniqueId()
 	return (
-		<TextField {...fieldProps}>
-			<KTextArea class="form-field__control" {...rest} />
+		<TextField {...fieldProps} inputId={inputId}>
+			<KTextArea class="form-field__control" {...rest} id={inputId} />
 		</TextField>
 	)
 }

--- a/apps/www/src/components/ListingForm.tsx
+++ b/apps/www/src/components/ListingForm.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal, on, Show } from 'solid-js'
+import { createEffect, createSignal, on, onMount, Show } from 'solid-js'
 import { Link, useNavigate, useRouteContext } from '@tanstack/solid-router'
 import { z } from 'zod'
 import { Input, Textarea } from '@/components/FormField'
@@ -42,6 +42,11 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 
 	const isAuthenticated = () => Boolean(context().session?.user)
 	const isSubmitting = () => formState() === 'submitting'
+	// Kobalte's Combobox generates IDs internally; SSR and CSR counters diverge,
+	// causing silent hydration failure that strips all event handlers from the
+	// trigger. Render the selector fresh on the client only to sidestep this.
+	const [clientMounted, setClientMounted] = createSignal(false)
+	onMount(() => setClientMounted(true))
 
 	async function submitListing(data: Record<string, unknown>) {
 		setFormState('submitting')
@@ -130,13 +135,19 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 		if (isAuthenticated()) {
 			await submitListing(listingData)
 		} else {
-			// Validate email before triggering the magic-link flow
-			const emailParsed = emailSchema.safeParse(email().trim())
+			// Read the email from the native form element rather than the signal.
+			// Kobalte's controlled TextField onChange may not fire if the component
+			// fails to hydrate, leaving the signal stale while the native value is correct.
+			const emailFromForm = ((formData.get('email') as string) ?? '').trim()
+			if (emailFromForm) setEmail(emailFromForm)
+
+			const emailParsed = emailSchema.safeParse(emailFromForm)
 			if (!emailParsed.success) {
 				setEmailError(
 					z.treeifyError(emailParsed.error).errors[0] ??
 						'Please enter a valid email address'
 				)
+				setFormState('initial')
 				return
 			}
 
@@ -248,6 +259,7 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 						disabled={isSubmitting()}
 						errors={emailError() ? [emailError()!] : undefined}
 						label="Your email"
+						name="email"
 						onChange={(v) => {
 							setEmail(v)
 							setEmailError(null)
@@ -261,12 +273,14 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 				<fieldset>
 					<legend>What are you sharing?</legend>
 					<div class="form-row">
-						<ProduceTypeSelector
-							errorMessage={fieldErrors().properties?.type?.errors?.[0]}
-							name="type"
-							onChange={setSelectedType}
-							value={selectedType()}
-						/>
+						<Show when={clientMounted()}>
+							<ProduceTypeSelector
+								errorMessage={fieldErrors().properties?.type?.errors?.[0]}
+								name="type"
+								onChange={setSelectedType}
+								value={selectedType()}
+							/>
+						</Show>
 
 						<Input
 							errors={fieldErrors().properties?.harvestWindow?.errors}

--- a/apps/www/tests/e2e/global-setup.ts
+++ b/apps/www/tests/e2e/global-setup.ts
@@ -1,0 +1,40 @@
+import { chromium, type FullConfig } from '@playwright/test'
+
+/**
+ * Runs after the webServer starts but before any test. Warms up three things:
+ * 1. Client bundles — browser visit to /login and /listings/new triggers Vite
+ *    lazy compilation so the first real test doesn't exhaust its timeout.
+ * 2. Auth SSR handler — clicking "Send sign-in link" in the browser exercises
+ *    the exact same code path the first test uses, including all SSR module
+ *    loading that a bare fetch POST does not cover.
+ * 3. /listings/new SSR path — browser visit triggers that route's SSR bundle.
+ */
+export default async function globalSetup(config: FullConfig) {
+	const baseURL = config.projects[0]?.use?.baseURL ?? 'http://localhost:5174'
+
+	const browser = await chromium.launch()
+	try {
+		// Warm up /login and trigger the auth SSR handler via the full browser flow.
+		const loginPage = await browser.newPage()
+		await loginPage.goto(`${baseURL}/login`, { waitUntil: 'networkidle' })
+		await loginPage.getByLabel(/email/i).fill('warmup@example.com')
+		const authResponse = loginPage.waitForResponse(
+			(r) => r.url().includes('/api/auth/sign-in/magic-link'),
+			{ timeout: 90_000 }
+		)
+		await loginPage.getByRole('button', { name: /send sign-in link/i }).click()
+		const res = await authResponse
+		console.log(
+			`[global-setup] browser warm-up of /login + auth complete (${res.status()})`
+		)
+		await loginPage.close()
+
+		// Warm up /listings/new SSR bundle separately.
+		const newPage = await browser.newPage()
+		await newPage.goto(`${baseURL}/listings/new`, { waitUntil: 'networkidle' })
+		console.log('[global-setup] browser warm-up of /listings/new complete')
+		await newPage.close()
+	} finally {
+		await browser.close()
+	}
+}

--- a/apps/www/tests/e2e/listing-new.test.ts
+++ b/apps/www/tests/e2e/listing-new.test.ts
@@ -20,9 +20,11 @@ test.describe('New Listing', () => {
 		// Email field is shown for unauthenticated users
 		await page.getByLabel(/Your email/i).fill(testUser.email)
 
-		// Produce type — Kobalte Combobox (use role to avoid matching the trigger button)
-		await page.getByRole('combobox', { name: /Produce Type/i }).fill('Avocado')
-		await page.getByRole('option', { name: 'Avocado' }).click()
+		// Open the produce-type combobox and select Avocado.
+		// Kobalte opens on pointerdown (not click) for mouse; Playwright's
+		// locator.click() dispatches the full pointer sequence including pointerdown.
+		await page.locator('.combobox__trigger').click()
+		await page.locator('.combobox__item').filter({ hasText: 'Avocado' }).click()
 
 		// Other required fields (City and State default to 'Napa' / 'CA')
 		await page.getByLabel(/When to Pick/i).fill('July–September')


### PR DESCRIPTION
Kobalte registers the label–input association (`for`/`id`) inside a
`createEffect`, which SolidJS skips during SSR. Every `<TextField.Label>`
is therefore missing its `for` attribute in server-rendered HTML, so
`getByLabel()` locators fail when a test runs before hydration completes.
([kobaltedev/kobalte#652](https://github.com/kobaltedev/kobalte/issues/652))

## Changes

**`FormField.tsx`** — generate stable IDs via `createUniqueId()` and pass
them explicitly to both `<Label for>` and `<input id>`, keeping the
association intact in the initial HTML independent of when hydration runs.

**`ListingForm.tsx`** — Kobalte's Combobox has the same root cause but a
more severe consequence: SSR/CSR ID divergence causes SolidJS to silently
abandon hydration for the entire component subtree, leaving the DOM without
any event handlers.

- `ProduceTypeSelector`: wrapped in `Show when={clientMounted()}` so it
  always renders fresh after `onMount`, bypassing the hydration failure.
  The trigger's `onPointerDown` (how Kobalte opens the dropdown) now fires
  correctly.
- Email field: Kobalte's `TextField.onChange` never fired after Playwright
  `fill()` when the field failed to hydrate. Fixed by adding `name="email"`
  and reading the value from native `FormData` in `handleSubmit`. Also
  fixed a bug where `formState` was left as `'submitting'` after email
  validation failure.

**`global-setup.ts`** — warm up `/listings/new` (in addition to `/login`)
before tests run, avoiding cold-start Vite SSR compile delays.

## Test plan

- [x] All 36 E2E tests pass (`pnpm test:e2e` from `apps/www`)
- [x] `address-autofill` tests pass consistently across multiple runs
- [x] `listing-new` test passes: unauthenticated user can select a produce
  type, fill the form, receive a magic link, enter the token, and land on
  the new listing detail page

https://claude.ai/code/session_01Ui8A7YfeHRjunRSX12uLGS