### PR TITLE
Fix resend-sync worker resolution in production Docker image

### DIFF
--- a/apps/resend-sync/package.json
+++ b/apps/resend-sync/package.json
@@ -24,13 +24,13 @@
 	"dependencies": {
 		"@sentry/node": "^10.51.0",
 		"pino": "^10.3.1",
+		"pino-pretty": "^13.1.3",
 		"undici": "^7.16.0",
 		"zod": "^4.4.1"
 	},
 	"devDependencies": {
 		"@types/node": "25.6.0",
 		"oxlint": "^1.62.0",
-		"pino-pretty": "^13.1.3",
 		"prettier": "3.8.3",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.5"

--- a/apps/www/Dockerfile
+++ b/apps/www/Dockerfile
@@ -120,6 +120,16 @@ RUN find apps/www/.output/server/node_modules/@img -name '*.node' | grep -q . ||
 # (not VITE_SENTRY_DSN) at runtime.
 RUN cd apps/resend-sync && pnpm build
 
+# Materialize the worker as a self-contained deployable: pnpm's normal
+# install layout uses symlinks back into the workspace-root virtual store
+# (apps/resend-sync/node_modules/undici → ../../../node_modules/.pnpm/...),
+# which would dangle in the runner image. `pnpm deploy` dereferences those
+# into a flat node_modules under /tmp/resend-sync-deploy, including dist/
+# from the build above. --legacy because the workspace does not opt into
+# inject-workspace-packages (pnpm 10 default).
+RUN pnpm --filter @pickmyfruit/resend-sync deploy \
+    --prod --legacy /tmp/resend-sync-deploy
+
 # Production stage
 FROM node:24-slim AS runner
 
@@ -129,10 +139,37 @@ WORKDIR /app
 COPY --from=builder /app/apps/www/.output ./.output
 COPY --from=builder /app/apps/www/package.json ./package.json
 
-# resend-sync worker bundle and a minimal node_modules slice for its deps.
-COPY --from=builder /app/apps/resend-sync/dist ./apps/resend-sync/dist
-COPY --from=builder /app/apps/resend-sync/package.json ./apps/resend-sync/package.json
-COPY --from=builder /app/apps/resend-sync/node_modules ./apps/resend-sync/node_modules
+# resend-sync worker: self-contained deploy layout produced above. Brings
+# dist/, package.json, and a flat node_modules (no dangling symlinks into
+# the workspace virtual store, which the runner image does not carry).
+COPY --from=builder /tmp/resend-sync-deploy ./apps/resend-sync
+# Worker entrypoint path is pinned alongside the COPY above so it cannot drift.
+# The runner image does not carry pnpm's virtual store, so spawn-resend-sync
+# cannot fall back to `require.resolve('@pickmyfruit/resend-sync')` and reads
+# this env instead. See PICKMYFRUIT-1N.
+ENV RESEND_SYNC_WORKER_PATH=/app/apps/resend-sync/dist/main.js
+
+# Build-time smoke test: with the kill switch off, apps/resend-sync/src/main.ts
+# short-circuits at the gate check before opening the poll loop or any HTTP
+# connection — but all imports (undici, pino, pino-pretty, @sentry/node, zod)
+# run first, and the logger initializes its transport. So any module-resolution
+# failure (a dangling symlink, a missing dep, a moved RESEND_SYNC_WORKER_PATH
+# target) surfaces here at `docker build` time instead of at first prod deploy.
+#
+# NODE_ENV=development is intentional: it exercises the pino-pretty transport
+# branch in logger.ts, which is the path docker-compose.yml and fly.preview.toml
+# take at runtime. Without it, this smoke would not have caught pino-pretty
+# being absent from the deploy. The INTERNAL_API_*, RESEND_API_KEY, and cursor
+# path are throwaway placeholders chosen only to satisfy parseWorkerEnv's zod
+# schema; the worker exits 0 before reading any of them.
+RUN NODE_ENV=development \
+    RESEND_SYNC_WORKER_ENABLED=false \
+    INTERNAL_API_URL=http://smoke-test.invalid \
+    INTERNAL_API_SECRET=build-time-smoke-test-placeholder-1234 \
+    RESEND_SYNC_CURSOR_PATH=/tmp/smoke.json \
+    RESEND_API_KEY=smoke \
+    timeout 5 node "$RESEND_SYNC_WORKER_PATH" \
+    || (echo "ERROR: resend-sync worker failed to load at build time" >&2 && exit 1)
 
 # Migration SQL files are read from disk at runtime by drizzle-orm/libsql/migrator.
 # They must be at ./drizzle relative to the working directory (/app/drizzle).

--- a/apps/www/src/lib/spawn-resend-sync.server.ts
+++ b/apps/www/src/lib/spawn-resend-sync.server.ts
@@ -79,7 +79,20 @@ export interface SpawnResendSyncDeps {
 	supervisionDeps?: AttachSupervisionDeps
 }
 
-const defaultResolveWorkerPath = (): string => {
+/**
+ * Resolves the absolute path to the resend-sync worker entrypoint.
+ *
+ * Production (Fly) sets `RESEND_SYNC_WORKER_PATH` because the runner image
+ * does not ship pnpm's virtual store, so `require.resolve` of the workspace
+ * package name has nothing to find. Dev and tests rely on the fallback, which
+ * works because pnpm hoists workspace packages into
+ * `node_modules/.pnpm/node_modules/`. See PICKMYFRUIT-1N.
+ */
+export const defaultResolveWorkerPath = (): string => {
+	const explicit = process.env.RESEND_SYNC_WORKER_PATH
+	if (explicit) {
+		return explicit
+	}
 	const require = createRequire(import.meta.url)
 	return require.resolve('@pickmyfruit/resend-sync')
 }

--- a/apps/www/tests/spawn-resend-sync.server.test.ts
+++ b/apps/www/tests/spawn-resend-sync.server.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import { EventEmitter } from 'node:events'
 import {
 	attachWorkerSupervision,
+	defaultResolveWorkerPath,
 	shouldSpawnResendSyncWorker,
 	spawnResendSyncWorkerIfEnabled,
 	type SupervisedChild,
@@ -25,12 +26,14 @@ describe(shouldSpawnResendSyncWorker, () => {
 		[{ RESEND_SYNC_WORKER_ENABLED: '1' }, false],
 		[{}, false],
 	])('shouldSpawn(%j) → %s', (env, expected) => {
+		expect.hasAssertions()
 		expect(shouldSpawnResendSyncWorker(env)).toBe(expected)
 	})
 })
 
 describe(attachWorkerSupervision, () => {
 	it('captures non-zero exits via the injected Sentry hook', () => {
+		expect.hasAssertions()
 		const child = new FakeChild()
 		const captureException = vi.fn()
 		attachWorkerSupervision(child, {
@@ -48,6 +51,7 @@ describe(attachWorkerSupervision, () => {
 	})
 
 	it('does not capture a clean exit (code 0)', () => {
+		expect.hasAssertions()
 		const child = new FakeChild()
 		const captureException = vi.fn()
 		attachWorkerSupervision(child, {
@@ -59,6 +63,7 @@ describe(attachWorkerSupervision, () => {
 	})
 
 	it('treats SIGTERM/SIGINT termination as clean (operator-driven)', () => {
+		expect.hasAssertions()
 		const child = new FakeChild()
 		const captureException = vi.fn()
 		attachWorkerSupervision(child, {
@@ -71,6 +76,7 @@ describe(attachWorkerSupervision, () => {
 	})
 
 	it('forwards parent SIGTERM and SIGINT to the child', () => {
+		expect.hasAssertions()
 		const child = new FakeChild()
 		const handlers = new Map<string, () => void>()
 		attachWorkerSupervision(child, {
@@ -95,8 +101,85 @@ describe(attachWorkerSupervision, () => {
 	})
 })
 
+describe(defaultResolveWorkerPath, () => {
+	afterEach(() => {
+		vi.unstubAllEnvs()
+	})
+
+	// PICKMYFRUIT-1N: in the production Docker runner image the bundled file
+	// lives at /app/.output/server/_ssr/spawn-resend-sync.server-*.mjs. None
+	// of its node_modules ancestors contain @pickmyfruit/resend-sync — the
+	// package is not a declared www dependency and the Dockerfile runner
+	// stage does not copy pnpm's virtual store. The fix lets the runtime
+	// supply an explicit, absolute worker path via RESEND_SYNC_WORKER_PATH
+	// so resolution does not depend on Node's node_modules walk.
+	it('honors RESEND_SYNC_WORKER_PATH when set (PICKMYFRUIT-1N)', () => {
+		expect.hasAssertions()
+		const sentinel = '/app/apps/resend-sync/dist/main.js'
+		vi.stubEnv('RESEND_SYNC_WORKER_PATH', sentinel)
+		expect(defaultResolveWorkerPath()).toBe(sentinel)
+	})
+
+	// Pins the dev/test fallback: when no env override is set, the function
+	// must delegate to Node's resolver (`createRequire(...).resolve(...)`).
+	// Asserting on the resolved path is environment-dependent because the
+	// resolver verifies the package's `main` file exists, which requires
+	// `apps/resend-sync/dist/main.js` to have been built. CI runs tests
+	// before any build, so we instead assert that the function attempts
+	// the package-name resolution — either it returns a path that lives
+	// under apps/resend-sync (built locally) or it throws MODULE_NOT_FOUND
+	// (CI). Both prove the fallback is intact; a future refactor that
+	// short-circuits past `require.resolve` would fail this test by
+	// returning some other value or throwing a different error.
+	it('falls back to require.resolve when RESEND_SYNC_WORKER_PATH is unset', () => {
+		expect.hasAssertions()
+		vi.stubEnv('RESEND_SYNC_WORKER_PATH', '')
+		// CI (no dist built) throws MODULE_NOT_FOUND; dev (dist built) returns
+		// a path under apps/resend-sync/. Capture either outcome as a string,
+		// then assert once — both signals prove require.resolve was reached.
+		let outcome: string
+		try {
+			outcome = defaultResolveWorkerPath()
+		} catch (err) {
+			outcome = (err as NodeJS.ErrnoException).code ?? 'UNKNOWN'
+		}
+		expect(outcome).toMatch(/(?:apps[/\\]resend-sync[/\\])|^MODULE_NOT_FOUND$/)
+	})
+
+	// End-to-end guard: the env var must flow all the way through
+	// spawnResendSyncWorkerIfEnabled to the spawned child's argv, not just
+	// through the helper. Catches regressions where the caller wires its own
+	// resolver instead of going through defaultResolveWorkerPath.
+	it('propagates RESEND_SYNC_WORKER_PATH into the spawned child argv', () => {
+		expect.hasAssertions()
+		const sentinel = '/app/apps/resend-sync/dist/main.js'
+		vi.stubEnv('RESEND_SYNC_WORKER_PATH', sentinel)
+		const fakeChild = new FakeChild()
+		const spawn = vi.fn<
+			(
+				cmd: string,
+				args: readonly string[],
+				opts: Record<string, unknown>
+			) => SupervisedChild
+		>(() => fakeChild)
+		spawnResendSyncWorkerIfEnabled(
+			{ RESEND_SYNC_WORKER_ENABLED: 'true' },
+			{
+				spawn: spawn as unknown as typeof import('node:child_process').spawn,
+				supervisionDeps: {
+					captureException: vi.fn(),
+					onParentSignal: () => undefined,
+				},
+			}
+		)
+		const [, args] = spawn.mock.calls[0]
+		expect(args).toStrictEqual([sentinel])
+	})
+})
+
 describe(spawnResendSyncWorkerIfEnabled, () => {
 	it('returns null and never spawns when the gate is off', () => {
+		expect.hasAssertions()
 		const spawn = vi.fn()
 		const result = spawnResendSyncWorkerIfEnabled(
 			{ RESEND_SYNC_WORKER_ENABLED: 'false' },
@@ -110,6 +193,7 @@ describe(spawnResendSyncWorkerIfEnabled, () => {
 	})
 
 	it('spawns with the worker path + inherited stdio when the gate is on', () => {
+		expect.hasAssertions()
 		const fakeChild = new FakeChild()
 		const spawn = vi.fn<
 			(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       BETTER_AUTH_URL: http://localhost:3000
       NODE_ENV: development
       DATABASE_URL: file:/app/data/development.db
+      INTERNAL_API_URL: http://localhost:3000
       # V8 heap capped at ~75% of the VM so GC fires before the OS OOM-kills,
       # leaving headroom for libvips native allocations.
       NODE_OPTIONS: --max-old-space-size=384

--- a/fly.toml
+++ b/fly.toml
@@ -96,6 +96,8 @@ primary_region = 'sjc'
   RESEND_SYNC_CURSOR_PATH = '/app/data/resend-sync/cursor.json'
   RESEND_SYNC_POLL_MS = '60000'
   RESEND_SYNC_WORKER_ENABLED = 'true'
+  # RESEND_SYNC_WORKER_PATH is set in apps/www/Dockerfile next to the COPY
+  # that determines it (single source of truth, no preview-toml drift).
   RESEND_API_RATE_PER_SEC = '4'
   RESEND_API_BUCKET_CAPACITY = '4'
   SENTRY_ENABLED = 'true'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
       undici:
         specifier: ^7.16.0
         version: 7.25.0
@@ -29,9 +32,6 @@ importers:
       oxlint:
         specifier: ^1.62.0
         version: 1.62.0
-      pino-pretty:
-        specifier: ^13.1.3
-        version: 13.1.3
       prettier:
         specifier: 3.8.3
         version: 3.8.3


### PR DESCRIPTION
## Summary

Three cascading bugs in the resend-sync worker spawn path, all rooted in the production Docker image's runtime layout diverging from the workspace layout that pnpm + Node's resolver assume:

1. **PICKMYFRUIT-1N**: `require.resolve('@pickmyfruit/resend-sync')` from the bundled www server threw `MODULE_NOT_FOUND`. The runner image does not carry pnpm's virtual store.
2. Worker spawned but crashed on `ERR_MODULE_NOT_FOUND` for `undici`. `apps/resend-sync/node_modules/undici` was a pnpm symlink to `../../../node_modules/.pnpm/...` dangling in the runner image.
3. Latent: `pino-pretty` was a `devDep` but `docker-compose.yml` and `fly.preview.toml` set `NODE_ENV=development`, so the worker would have crashed at logger init in those environments if the gate were on.

## Fixes

- `apps/www/Dockerfile` sets `RESEND_SYNC_WORKER_PATH` alongside the `COPY` that pins it (single source of truth, no `fly.toml` drift). `defaultResolveWorkerPath` honors the env first and falls back to `require.resolve` for dev/test where pnpm's virtual store is on the resolver path.
- Three hand-rolled `apps/resend-sync` `COPY`s are replaced with a single `COPY` from `pnpm --filter @pickmyfruit/resend-sync deploy --prod --legacy /tmp/resend-sync-deploy`, producing a flat self-contained `node_modules` with dereferenced dependency symlinks.
- `pino-pretty` promoted from `devDependencies` to `dependencies` of `apps/resend-sync`. It is a runtime dep whenever the `NODE_ENV=development` transport branch fires.
- Build-time smoke test in the runner stage runs the worker with `NODE_ENV=development` and `RESEND_SYNC_WORKER_ENABLED=false`. Imports load and the logger initializes its transport; the gate fires before any HTTP connection or Resend call. Future module-resolution failures surface at `docker build` time instead of at first prod deploy.
- `docker-compose.yml` sets `INTERNAL_API_URL` so the local Docker dev path can exercise the worker end-to-end.
- Tests cover `defaultResolveWorkerPath`'s env-honoring contract, the dev fallback, and end-to-end argv propagation through `spawnResendSyncWorkerIfEnabled`.

## Test plan

- [x] `bash bin/after-turn.sh` passes (typecheck, lint, unit tests, format)
- [x] `bash bin/before-push.sh` passes (full E2E suite via Playwright)
- [x] Locally rebuilt `pnpm deploy` bundle includes `undici`, `pino`, `pino-pretty`, `@sentry/node`, `zod` with no dangling symlinks
- [x] Smoke command with `NODE_ENV=development` and gate off exits 0 with colored pino-pretty INFO output (transport active)
- [x] Hiding `undici` from the deploy makes node exit 1 — the `RUN` line fails the build with the full `ERR_MODULE_NOT_FOUND` stack visible