### PR TITLE
Add map loading states

### DIFF
--- a/apps/www/src/components/ListingMap.tsx
+++ b/apps/www/src/components/ListingMap.tsx
@@ -35,11 +35,18 @@ function h3ToPolygonRing(h3Index: string): number[][] {
 export default function ListingMap(props: Props) {
 	let map: import('maplibre-gl').Map | undefined
 
-	function setupMap({ container, maplibregl }: MapLibreGLReadyArgs) {
+	function setupMap({ container, maplibregl, onMapLoad }: MapLibreGLReadyArgs) {
 		if (props.mode === 'owner') {
-			initOwnerMap(maplibregl, container, props.lat, props.lng, props.h3Index)
+			initOwnerMap(
+				maplibregl,
+				container,
+				props.lat,
+				props.lng,
+				props.h3Index,
+				onMapLoad
+			)
 		} else {
-			initPublicMap(maplibregl, container, props.approximateH3Index)
+			initPublicMap(maplibregl, container, props.approximateH3Index, onMapLoad)
 		}
 		return () => {
 			map?.remove()
@@ -52,7 +59,8 @@ export default function ListingMap(props: Props) {
 		container: HTMLDivElement,
 		lat: number,
 		lng: number,
-		h3Index: string
+		h3Index: string,
+		onMapLoad: () => void
 	) {
 		const publicH3 = cellToParent(h3Index, H3_RESOLUTIONS.PUBLIC_DETAIL)
 
@@ -102,6 +110,8 @@ export default function ListingMap(props: Props) {
 					'line-width': 2,
 				},
 			})
+
+			onMapLoad()
 		})
 
 		new maplibregl.Marker({ color: COLOR_MARKER })
@@ -112,7 +122,8 @@ export default function ListingMap(props: Props) {
 	function initPublicMap(
 		maplibregl: typeof import('maplibre-gl'),
 		container: HTMLDivElement,
-		h3Index: string
+		h3Index: string,
+		onMapLoad: () => void
 	) {
 		const [lat, lng] = cellToLatLng(h3Index)
 		const boundary = h3ToPolygonRing(h3Index)
@@ -162,6 +173,8 @@ export default function ListingMap(props: Props) {
 					'line-width': 2,
 				},
 			})
+
+			onMapLoad()
 		})
 	}
 

--- a/apps/www/src/components/ListingMap.tsx
+++ b/apps/www/src/components/ListingMap.tsx
@@ -3,7 +3,10 @@ import { cellToLatLng, cellToBoundary, cellToParent } from 'h3-js'
 import MapPin from 'lucide-solid/icons/map-pin'
 import Hexagon from 'lucide-solid/icons/hexagon'
 import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
-import MapLibreGL, { MapLibreGLReadyArgs } from '@/components/MapLibreGL'
+import MapLibreGL, {
+	MapLibreGLReadyArgs,
+	reportMapLoadedOnce,
+} from '@/components/MapLibreGL'
 import '@/components/ListingMap.css'
 
 interface OwnerProps {
@@ -78,7 +81,7 @@ export default function ListingMap(props: Props) {
 		)
 		map.addControl(new maplibregl.NavigationControl({ showCompass: false }))
 
-		map.on('load', () => {
+		reportMapLoadedOnce(map, onMapLoad, () => {
 			if (!map) return
 
 			const ring = h3ToPolygonRing(publicH3)
@@ -110,8 +113,6 @@ export default function ListingMap(props: Props) {
 					'line-width': 2,
 				},
 			})
-
-			onMapLoad()
 		})
 
 		new maplibregl.Marker({ color: COLOR_MARKER })
@@ -142,7 +143,7 @@ export default function ListingMap(props: Props) {
 		)
 		map.addControl(new maplibregl.NavigationControl({ showCompass: false }))
 
-		map.on('load', () => {
+		reportMapLoadedOnce(map, onMapLoad, () => {
 			if (!map) return
 
 			map.addSource('listing-area', {
@@ -173,8 +174,6 @@ export default function ListingMap(props: Props) {
 					'line-width': 2,
 				},
 			})
-
-			onMapLoad()
 		})
 	}
 

--- a/apps/www/src/components/ListingsMap.tsx
+++ b/apps/www/src/components/ListingsMap.tsx
@@ -63,7 +63,7 @@ export default function ListingsMap(props: Props) {
 	let layersReady = false
 	let currentRes: number = H3_RESOLUTIONS.HOME_GROUPING
 
-	function setupMap({ container, maplibregl }: MapLibreGLReadyArgs) {
+	function setupMap({ container, maplibregl, onMapLoad }: MapLibreGLReadyArgs) {
 		const groups = groupByH3(props.listings)
 		const bounds = new maplibregl.LngLatBounds()
 		for (const group of groups) {
@@ -103,6 +103,8 @@ export default function ListingsMap(props: Props) {
 				updateRegion(props.selectedH3)
 				updateHighlight()
 			}
+
+			onMapLoad()
 		})
 
 		map.on('zoomend', () => {

--- a/apps/www/src/components/ListingsMap.tsx
+++ b/apps/www/src/components/ListingsMap.tsx
@@ -3,7 +3,10 @@ import type { PublicListing } from '@/data/queries.server'
 import { cellToLatLng, cellToBoundary, cellToParent } from 'h3-js'
 import { H3_RESOLUTIONS, zoomToH3Resolution } from '@/lib/h3-resolutions'
 import { Sentry } from '@/lib/sentry'
-import MapLibreGL, { MapLibreGLReadyArgs } from '@/components/MapLibreGL'
+import MapLibreGL, {
+	MapLibreGLReadyArgs,
+	reportMapLoadedOnce,
+} from '@/components/MapLibreGL'
 import '@/components/ListingsMap.css'
 
 /** A group of listings sharing the same approximate H3 cell. */
@@ -86,7 +89,7 @@ export default function ListingsMap(props: Props) {
 		)
 		map.addControl(new maplibregl.NavigationControl({ showCompass: false }))
 
-		map.on('load', () => {
+		reportMapLoadedOnce(map, onMapLoad, () => {
 			addGroupLayers(groups)
 			addRegionLayers()
 			layersReady = true
@@ -103,8 +106,6 @@ export default function ListingsMap(props: Props) {
 				updateRegion(props.selectedH3)
 				updateHighlight()
 			}
-
-			onMapLoad()
 		})
 
 		map.on('zoomend', () => {

--- a/apps/www/src/components/MapLibreGL.css
+++ b/apps/www/src/components/MapLibreGL.css
@@ -1,5 +1,7 @@
 @layer components {
 	.maplibregl {
+		position: relative;
+
 		.map-unavailable {
 			align-items: center;
 			color: var(--color-quiet);
@@ -8,5 +10,34 @@
 			justify-content: center;
 			width: 100%;
 		}
+
+		.maplibregl-skeleton {
+			position: absolute;
+			inset: 0;
+			background-color: oklch(from var(--color-quiet) l calc(c * 0.15) h / 0.12);
+			z-index: 1;
+		}
+
+		@media (prefers-reduced-motion: no-preference) {
+			.maplibregl-skeleton {
+				background: linear-gradient(
+					90deg,
+					oklch(from var(--color-quiet) l calc(c * 0.15) h / 0.1) 0%,
+					oklch(from var(--color-quiet) l calc(c * 0.15) h / 0.22) 50%,
+					oklch(from var(--color-quiet) l calc(c * 0.15) h / 0.1) 100%
+				);
+				background-size: 200% 100%;
+				animation: maplibregl-shimmer 1.6s ease-in-out infinite;
+			}
+		}
+	}
+}
+
+@keyframes maplibregl-shimmer {
+	0% {
+		background-position: 200% 0;
+	}
+	100% {
+		background-position: -200% 0;
 	}
 }

--- a/apps/www/src/components/MapLibreGL.css
+++ b/apps/www/src/components/MapLibreGL.css
@@ -31,13 +31,13 @@
 			}
 		}
 	}
-}
 
-@keyframes maplibregl-shimmer {
-	0% {
-		background-position: 200% 0;
-	}
-	100% {
-		background-position: -200% 0;
+	@keyframes maplibregl-shimmer {
+		0% {
+			background-position: 200% 0;
+		}
+		100% {
+			background-position: -200% 0;
+		}
 	}
 }

--- a/apps/www/src/components/MapLibreGL.tsx
+++ b/apps/www/src/components/MapLibreGL.tsx
@@ -5,6 +5,7 @@ import {
 	type JSX,
 	onMount,
 	onCleanup,
+	Show,
 	splitProps,
 } from 'solid-js'
 import './MapLibreGL.css'
@@ -15,6 +16,8 @@ import './MapLibreGL.css'
 export interface MapLibreGLReadyArgs {
 	container: HTMLDivElement
 	maplibregl: typeof import('maplibre-gl')
+	/** Call this once the map's initial tiles have finished rendering. */
+	onMapLoad: () => void
 }
 
 /**
@@ -41,9 +44,10 @@ export interface MapLibreGLProps extends JSX.HTMLAttributes<HTMLDivElement> {
 interface MapLoaderOptions {
 	onReady: (args: MapLibreGLReadyArgs) => () => void
 	onError?: (err: unknown) => void
+	onLoaded: () => void
 }
 
-function useMapLoader({ onReady, onError }: MapLoaderOptions) {
+function useMapLoader({ onReady, onError, onLoaded }: MapLoaderOptions) {
 	let containerRef: HTMLDivElement | undefined | null
 	let mounted = true
 	let cleanup: (() => void) | undefined
@@ -69,6 +73,7 @@ function useMapLoader({ onReady, onError }: MapLoaderOptions) {
 			cleanup = onReady({
 				container: containerRef as HTMLDivElement,
 				maplibregl,
+				onMapLoad: onLoaded,
 			})
 		} catch (err) {
 			Sentry.captureException(err)
@@ -102,6 +107,7 @@ export default function MapLibreGL(props: MapLibreGLProps) {
 	])
 
 	const [loadError, setLoadError] = createSignal(false)
+	const [loaded, setLoaded] = createSignal(false)
 
 	const containerRef = useMapLoader({
 		onReady: local.onReady,
@@ -109,7 +115,12 @@ export default function MapLibreGL(props: MapLibreGLProps) {
 			setLoadError(true)
 			local.onError?.(err)
 		},
+		onLoaded() {
+			setLoaded(true)
+		},
 	})
+
+	const showSkeleton = () => !loaded() && !loadError()
 
 	return (
 		<div
@@ -117,7 +128,13 @@ export default function MapLibreGL(props: MapLibreGLProps) {
 			ref={containerRef}
 			role={local.role ?? 'application'}
 			class={clsx('maplibregl', local.class)}
+			aria-busy={showSkeleton() ? 'true' : 'false'}
 		>
+			<Show when={showSkeleton()}>
+				<div class="maplibregl-skeleton" aria-hidden="true">
+					<span class="sr-only">Loading map…</span>
+				</div>
+			</Show>
 			{loadError() && <span class="map-unavailable">Map unavailable</span>}
 		</div>
 	)

--- a/apps/www/src/components/MapLibreGL.tsx
+++ b/apps/www/src/components/MapLibreGL.tsx
@@ -91,6 +91,30 @@ function useMapLoader({ onReady, onError, onLoaded }: MapLoaderOptions) {
 	return (el: HTMLDivElement | null) => (containerRef = el)
 }
 
+/** Invokes `onMapLoad` once after the map loads or hits a tile/style error. */
+export function reportMapLoadedOnce(
+	map: import('maplibre-gl').Map,
+	onMapLoad: () => void,
+	onLoad?: () => void
+): void {
+	let reported = false
+	const report = () => {
+		if (reported) return
+		reported = true
+		onMapLoad()
+	}
+
+	map.on('load', () => {
+		onLoad?.()
+		report()
+	})
+
+	map.on('error', (e) => {
+		Sentry.captureException(e.error ?? e)
+		report()
+	})
+}
+
 /**
  * Lightweight component that handles lazy loading of maplibre-gl and its
  * stylesheet, centralizes error handling/unmount safety, and exposes just
@@ -128,12 +152,11 @@ export default function MapLibreGL(props: MapLibreGLProps) {
 			ref={containerRef}
 			role={local.role ?? 'application'}
 			class={clsx('maplibregl', local.class)}
-			aria-busy={showSkeleton() ? 'true' : 'false'}
+			aria-busy={showSkeleton()}
 		>
 			<Show when={showSkeleton()}>
-				<div class="maplibregl-skeleton" aria-hidden="true">
-					<span class="sr-only">Loading map…</span>
-				</div>
+				<span class="sr-only">Loading map…</span>
+				<div class="maplibregl-skeleton" aria-hidden="true" />
 			</Show>
 			{loadError() && <span class="map-unavailable">Map unavailable</span>}
 		</div>

--- a/apps/www/tests/MapLibreGL.test.tsx
+++ b/apps/www/tests/MapLibreGL.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import MapLibreGL from '@/components/MapLibreGL'
+import MapLibreGL, { type MapLibreGLReadyArgs } from '@/components/MapLibreGL'
 
 // mock maplibre modules (css stub doesn't need exports)
 vi.mock('maplibre-gl', () => ({
@@ -34,20 +34,27 @@ describe('<MapLibreGL>', () => {
 		mockCreateCanvas(false)
 
 		const err = vi.fn()
-		const { findByText } = render(() => (
+		const { findByText, queryByRole } = render(() => (
 			<MapLibreGL onReady={() => () => {}} onError={err} />
 		))
 
 		expect(err).toHaveBeenCalledWith('[MapLibreGL] WebGL is unavailable')
 		await expect(findByText('Map unavailable')).resolves.toBeTruthy()
+		// skeleton must not be visible alongside the error message
+		expect(
+			queryByRole('application')?.querySelector('.maplibregl-skeleton')
+		).toBeNull()
 	})
 
 	it('invokes onReady and runs cleanup on unmount', async () => {
 		mockCreateCanvas(true)
 
 		let cleanupCalled = false
-		const ready = vi.fn(() => () => {
-			cleanupCalled = true
+		const ready = vi.fn((args: MapLibreGLReadyArgs) => {
+			args.onMapLoad()
+			return () => {
+				cleanupCalled = true
+			}
 		})
 
 		const { unmount } = render(() => <MapLibreGL onReady={ready} />)
@@ -56,10 +63,46 @@ describe('<MapLibreGL>', () => {
 		// Allow onMount to run and load mock libraries asynchornously
 		await vi.waitFor(() => expect(ready).toHaveBeenCalledTimes(1))
 
-		/* @ts-expect-error vitest incorrectly types mock.calls[0] as Array<never> */
 		expect(ready.mock.calls[0][0].container).toBeInstanceOf(HTMLDivElement)
 
 		unmount()
 		expect(cleanupCalled).toBeTruthy()
+	})
+
+	it('shows skeleton and aria-busy before onMapLoad is called', async () => {
+		mockCreateCanvas(true)
+
+		const ready = vi.fn((_args: MapLibreGLReadyArgs) => () => {})
+
+		const { container } = render(() => <MapLibreGL onReady={ready} />)
+
+		await vi.waitFor(() => expect(ready).toHaveBeenCalledTimes(1))
+
+		const host = container.querySelector('.maplibregl')
+		expect(host?.getAttribute('aria-busy')).toBe('true')
+		expect(host?.querySelector('.maplibregl-skeleton')).not.toBeNull()
+	})
+
+	it('removes skeleton and aria-busy after onMapLoad is invoked', async () => {
+		mockCreateCanvas(true)
+
+		let capturedOnMapLoad: (() => void) | undefined
+		const ready = vi.fn((args: MapLibreGLReadyArgs) => {
+			capturedOnMapLoad = args.onMapLoad
+			return () => {}
+		})
+
+		const { container } = render(() => <MapLibreGL onReady={ready} />)
+
+		await vi.waitFor(() => expect(ready).toHaveBeenCalledTimes(1))
+		expect(capturedOnMapLoad).toBeDefined()
+
+		capturedOnMapLoad!()
+
+		await vi.waitFor(() => {
+			const host = container.querySelector('.maplibregl')
+			expect(host?.getAttribute('aria-busy')).toBe('false')
+			expect(host?.querySelector('.maplibregl-skeleton')).toBeNull()
+		})
 	})
 })

--- a/apps/www/tests/MapLibreGL.test.tsx
+++ b/apps/www/tests/MapLibreGL.test.tsx
@@ -1,6 +1,9 @@
 import { cleanup, render } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import MapLibreGL, { type MapLibreGLReadyArgs } from '@/components/MapLibreGL'
+import MapLibreGL, {
+	type MapLibreGLReadyArgs,
+	reportMapLoadedOnce,
+} from '@/components/MapLibreGL'
 
 // mock maplibre modules (css stub doesn't need exports)
 vi.mock('maplibre-gl', () => ({
@@ -81,6 +84,11 @@ describe('<MapLibreGL>', () => {
 		const host = container.querySelector('.maplibregl')
 		expect(host?.getAttribute('aria-busy')).toBe('true')
 		expect(host?.querySelector('.maplibregl-skeleton')).not.toBeNull()
+		const skeleton = host?.querySelector('.maplibregl-skeleton')
+		const status = host?.querySelector('.sr-only')
+		expect(skeleton).not.toBeNull()
+		expect(status).not.toBeNull()
+		expect(skeleton?.contains(status ?? null)).toBe(false)
 	})
 
 	it('removes skeleton and aria-busy after onMapLoad is invoked', async () => {
@@ -104,5 +112,39 @@ describe('<MapLibreGL>', () => {
 			expect(host?.getAttribute('aria-busy')).toBe('false')
 			expect(host?.querySelector('.maplibregl-skeleton')).toBeNull()
 		})
+	})
+
+	it('reportMapLoadedOnce invokes onMapLoad on error without load', () => {
+		const handlers: Record<string, Array<(e?: { error?: Error }) => void>> = {}
+		const map = {
+			on(event: string, handler: (e?: { error?: Error }) => void) {
+				handlers[event] ??= []
+				handlers[event].push(handler)
+			},
+		} as unknown as import('maplibre-gl').Map
+
+		const onMapLoad = vi.fn()
+		reportMapLoadedOnce(map, onMapLoad)
+
+		expect(onMapLoad).not.toHaveBeenCalled()
+		handlers.error[0]({ error: new Error('tile failed') })
+		expect(onMapLoad).toHaveBeenCalledTimes(1)
+	})
+
+	it('reportMapLoadedOnce invokes onMapLoad only once when load follows error', () => {
+		const handlers: Record<string, Array<(e?: { error?: Error }) => void>> = {}
+		const map = {
+			on(event: string, handler: (e?: { error?: Error }) => void) {
+				handlers[event] ??= []
+				handlers[event].push(handler)
+			},
+		} as unknown as import('maplibre-gl').Map
+
+		const onMapLoad = vi.fn()
+		reportMapLoadedOnce(map, onMapLoad)
+
+		handlers.error[0]({ error: new Error('tile failed') })
+		handlers.load[0]()
+		expect(onMapLoad).toHaveBeenCalledTimes(1)
 	})
 })


### PR DESCRIPTION
## Summary
Closes https://github.com/jamesarosen/PickMyFruit/issues/105

Adds a shimmer skeleton and aria-busy to MapLibreGL while MapLibre initializes, and wires ListingMap / ListingsMap to call onMapLoad once the map style and layers are ready.

<img width="672" height="531" alt="Screenshot 2026-05-22 at 9 46 45 PM" src="https://github.com/user-attachments/assets/d31f3936-947a-494a-9998-5dc96d439dc3" />

## Details
MapLibreGL shows a skeleton overlay until callers invoke `onMapLoad` from `MapLibreGLReadyArgs`; WebGL/library failures show “Map unavailable” instead.
`reportMapLoadedOnce` centralizes the load/error contract so tile or style failures still dismiss the skeleton (errors go to Sentry).
Loading status text is a sibling of the decorative skeleton (`sr-only` is not inside `aria-hidden`).
Shimmer `@keyframes` live inside `@layer` components per project CSS conventions.

## Review Findings
- HIGH. sr-only no longer nested inside aria-hidden. Addressed
- HIGH. aria-busy uses a boolean signal (consistent with other routes). Addressed
- HIGH. @keyframes maplibregl-shimmer moved under @layer components. Addressed
- HIGH. Skeleton clears on MapLibre error events, not only load. Addressed