### PR TITLE
Add notification preferences management page

### DIFF
--- a/apps/www/src/api/notifications.ts
+++ b/apps/www/src/api/notifications.ts
@@ -1,0 +1,119 @@
+import { createServerFn } from '@tanstack/solid-start'
+import { getRequestHeaders } from '@tanstack/solid-start/server'
+import { z } from 'zod'
+import { errorMiddleware, UserError } from '@/lib/server-error-middleware'
+
+/**
+ * A topic with the current user's effective subscription state. Combines
+ * Resend's topic catalog (`GET /topics`) with the user's per-topic prefs
+ * (`GET /contacts/{email}/topics`), falling back to each topic's
+ * `default_subscription` when the user has no explicit setting.
+ */
+export interface NotificationTopic {
+	id: string
+	name: string
+	description: string | null
+	subscribed: boolean
+}
+
+/**
+ * Page-load payload for the Manage Notifications form.
+ *
+ * `available` is false when the host is not configured for Resend (e.g. dev
+ * with `EMAIL_PROVIDER=console`), so the page can render an informative
+ * message instead of an empty form.
+ *
+ * NOTE: the response is assumed to contain ≤ 10 topics — Resend's `/topics`
+ * endpoint is unpaginated in our wrapper, and the form is designed for a
+ * short, scrollable-free list. Revisit pagination if the catalog grows.
+ */
+export interface NotificationsPayload {
+	available: boolean
+	topics: NotificationTopic[]
+}
+
+/** Loads the topic catalog merged with the signed-in user's subscriptions. */
+export const getNotifications = createServerFn({ method: 'GET' })
+	.middleware([errorMiddleware])
+	.handler(async (): Promise<NotificationsPayload> => {
+		const { auth } = await import('@/lib/auth.server')
+		const headers = getRequestHeaders()
+		const session = await auth.api.getSession({ headers })
+		if (!session?.user) {
+			throw new UserError('AUTH_REQUIRED', 'Authentication required')
+		}
+
+		const { serverEnv } = await import('@/lib/env.server')
+		if (serverEnv.email.PROVIDER !== 'resend') {
+			return { available: false, topics: [] }
+		}
+
+		const { listTopics, listContactTopics } =
+			await import('@/lib/resend-topics.server')
+
+		const [topics, contactTopics] = await Promise.all([
+			listTopics(),
+			listContactTopics(session.user.email).catch((error: unknown) => {
+				// A contact that has never been synced to Resend returns 404 here;
+				// treat that as "no explicit prefs" and fall back to topic defaults.
+				if (
+					error &&
+					typeof error === 'object' &&
+					'status' in error &&
+					(error as { status: number }).status === 404
+				) {
+					return []
+				}
+				throw error
+			}),
+		])
+
+		const subscriptionByTopicId = new Map(
+			contactTopics.map((t) => [t.id, t.subscription])
+		)
+
+		return {
+			available: true,
+			topics: topics.map((t) => ({
+				id: t.id,
+				name: t.name,
+				description: t.description ?? null,
+				subscribed:
+					(subscriptionByTopicId.get(t.id) ?? t.default_subscription) === 'opt_in',
+			})),
+		}
+	})
+
+const updateInputSchema = z.object({
+	topicId: z.string().min(1),
+	subscribed: z.boolean(),
+})
+
+/** Toggles the signed-in user's subscription for a single topic. */
+export const updateNotificationSubscription = createServerFn({ method: 'POST' })
+	.middleware([errorMiddleware])
+	.inputValidator((input: unknown) => updateInputSchema.parse(input))
+	.handler(async ({ data }) => {
+		const { auth } = await import('@/lib/auth.server')
+		const headers = getRequestHeaders()
+		const session = await auth.api.getSession({ headers })
+		if (!session?.user) {
+			throw new UserError('AUTH_REQUIRED', 'Authentication required')
+		}
+		const { serverEnv } = await import('@/lib/env.server')
+		if (serverEnv.email.PROVIDER !== 'resend') {
+			throw new UserError(
+				'NOTIFICATIONS_UNAVAILABLE',
+				'Notifications are not configured for this environment.'
+			)
+		}
+
+		const { updateContactTopics } = await import('@/lib/resend-topics.server')
+		await updateContactTopics(session.user.email, [
+			{
+				id: data.topicId,
+				subscription: data.subscribed ? 'opt_in' : 'opt_out',
+			},
+		])
+		return { ok: true as const }
+	})

--- a/apps/www/src/components/PageHeader.tsx
+++ b/apps/www/src/components/PageHeader.tsx
@@ -164,6 +164,7 @@ export default function PageHeader(props: PageHeaderProps) {
 								<Show when={user()}>
 									<DropdownMenuLink to="/listings/mine">My Garden</DropdownMenuLink>
 									<DropdownMenuLink to="/profile">Profile</DropdownMenuLink>
+									<DropdownMenuLink to="/notifications">Notifications</DropdownMenuLink>
 									<DropdownMenu.Item
 										as="a"
 										href="/support?from=header"

--- a/apps/www/src/lib/resend-topics.server.ts
+++ b/apps/www/src/lib/resend-topics.server.ts
@@ -1,0 +1,124 @@
+/**
+ * Thin wrappers around Resend's Topics and Contact-Topics endpoints.
+ *
+ * - `GET  /topics`                              — organization-wide topic catalog
+ * - `GET  /contacts/{email|id}/topics`          — a contact's per-topic subscription
+ * - `PATCH /contacts/{email|id}/topics`         — update a contact's subscriptions
+ *
+ * Responses are validated with Zod. Resend may add new fields over time; the
+ * schemas use the default "passthrough" behavior so unknown fields are dropped
+ * but do not fail the parse.
+ *
+ * @see https://resend.com/docs/api-reference/topics/get-topic
+ * @see https://resend.com/docs/api-reference/contacts/get-contact-topics
+ * @see https://resend.com/docs/api-reference/contacts/update-contact-topics
+ */
+
+import { z } from 'zod'
+import { serverEnv } from '@/lib/env.server'
+
+const RESEND_BASE_URL = 'https://api.resend.com'
+
+const subscriptionSchema = z.enum(['opt_in', 'opt_out'])
+
+const topicSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	description: z.string().nullish(),
+	default_subscription: subscriptionSchema,
+})
+
+const listTopicsSchema = z.object({
+	data: z.array(topicSchema),
+})
+
+const contactTopicSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	description: z.string().nullish(),
+	subscription: subscriptionSchema,
+})
+
+const listContactTopicsSchema = z.object({
+	data: z.array(contactTopicSchema),
+})
+
+const topicUpdateSchema = z.object({
+	id: z.string(),
+	subscription: subscriptionSchema,
+})
+
+export type ResendTopic = z.infer<typeof topicSchema>
+export type ResendContactTopic = z.infer<typeof contactTopicSchema>
+export type ResendTopicUpdate = z.infer<typeof topicUpdateSchema>
+
+class ResendApiError extends Error {
+	readonly status: number
+	constructor(message: string, status: number) {
+		super(message)
+		this.name = 'ResendApiError'
+		this.status = status
+	}
+}
+
+function getApiKey(): string {
+	if (serverEnv.email.PROVIDER !== 'resend') {
+		throw new Error('Resend topics API called with EMAIL_PROVIDER != resend')
+	}
+	return serverEnv.email.RESEND_API_KEY
+}
+
+async function resendFetch(
+	method: 'GET' | 'PATCH',
+	path: string,
+	body?: unknown
+): Promise<unknown> {
+	const init: RequestInit = {
+		method,
+		headers: {
+			authorization: `Bearer ${getApiKey()}`,
+			'content-type': 'application/json',
+		},
+	}
+	if (body !== undefined) init.body = JSON.stringify(body)
+
+	const response = await fetch(`${RESEND_BASE_URL}${path}`, init)
+	if (!response.ok) {
+		const text = await response.text().catch(() => response.statusText)
+		throw new ResendApiError(
+			`Resend ${method} ${path} failed (${response.status}): ${text}`,
+			response.status
+		)
+	}
+	if (response.status === 204) return null
+	return response.json()
+}
+
+/** Fetches the full topic catalog. */
+export async function listTopics(): Promise<ResendTopic[]> {
+	const raw = await resendFetch('GET', '/topics')
+	return listTopicsSchema.parse(raw).data
+}
+
+/** Fetches per-topic subscription state for a contact, addressed by email. */
+export async function listContactTopics(
+	email: string
+): Promise<ResendContactTopic[]> {
+	const raw = await resendFetch(
+		'GET',
+		`/contacts/${encodeURIComponent(email)}/topics`
+	)
+	return listContactTopicsSchema.parse(raw).data
+}
+
+/** Updates a contact's subscription state for the given topics. */
+export async function updateContactTopics(
+	email: string,
+	topics: ResendTopicUpdate[]
+): Promise<void> {
+	await resendFetch(
+		'PATCH',
+		`/contacts/${encodeURIComponent(email)}/topics`,
+		topics.map((t) => topicUpdateSchema.parse(t))
+	)
+}

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as SupportRouteImport } from './routes/support'
 import { Route as ProfileRouteImport } from './routes/profile'
 import { Route as PrivacyPolicyRouteImport } from './routes/privacy-policy'
 import { Route as PrivacyRouteImport } from './routes/privacy'
+import { Route as NotificationsRouteImport } from './routes/notifications'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as CssTestRouteImport } from './routes/css-test'
 import { Route as AboutRouteImport } from './routes/about'
@@ -52,6 +53,11 @@ const PrivacyPolicyRoute = PrivacyPolicyRouteImport.update({
 const PrivacyRoute = PrivacyRouteImport.update({
   id: '/privacy',
   path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NotificationsRoute = NotificationsRouteImport.update({
+  id: '/notifications',
+  path: '/notifications',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -131,6 +137,7 @@ export interface FileRoutesByFullPath {
   '/about': typeof AboutRoute
   '/css-test': typeof CssTestRoute
   '/login': typeof LoginRoute
+  '/notifications': typeof NotificationsRoute
   '/privacy': typeof PrivacyRoute
   '/privacy-policy': typeof PrivacyPolicyRoute
   '/profile': typeof ProfileRoute
@@ -152,6 +159,7 @@ export interface FileRoutesByTo {
   '/about': typeof AboutRoute
   '/css-test': typeof CssTestRoute
   '/login': typeof LoginRoute
+  '/notifications': typeof NotificationsRoute
   '/privacy': typeof PrivacyRoute
   '/privacy-policy': typeof PrivacyPolicyRoute
   '/profile': typeof ProfileRoute
@@ -174,6 +182,7 @@ export interface FileRoutesById {
   '/about': typeof AboutRoute
   '/css-test': typeof CssTestRoute
   '/login': typeof LoginRoute
+  '/notifications': typeof NotificationsRoute
   '/privacy': typeof PrivacyRoute
   '/privacy-policy': typeof PrivacyPolicyRoute
   '/profile': typeof ProfileRoute
@@ -197,6 +206,7 @@ export interface FileRouteTypes {
     | '/about'
     | '/css-test'
     | '/login'
+    | '/notifications'
     | '/privacy'
     | '/privacy-policy'
     | '/profile'
@@ -218,6 +228,7 @@ export interface FileRouteTypes {
     | '/about'
     | '/css-test'
     | '/login'
+    | '/notifications'
     | '/privacy'
     | '/privacy-policy'
     | '/profile'
@@ -239,6 +250,7 @@ export interface FileRouteTypes {
     | '/about'
     | '/css-test'
     | '/login'
+    | '/notifications'
     | '/privacy'
     | '/privacy-policy'
     | '/profile'
@@ -261,6 +273,7 @@ export interface RootRouteChildren {
   AboutRoute: typeof AboutRoute
   CssTestRoute: typeof CssTestRoute
   LoginRoute: typeof LoginRoute
+  NotificationsRoute: typeof NotificationsRoute
   PrivacyRoute: typeof PrivacyRoute
   PrivacyPolicyRoute: typeof PrivacyPolicyRoute
   ProfileRoute: typeof ProfileRoute
@@ -311,6 +324,13 @@ declare module '@tanstack/solid-router' {
       path: '/privacy'
       fullPath: '/privacy'
       preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/notifications': {
+      id: '/notifications'
+      path: '/notifications'
+      fullPath: '/notifications'
+      preLoaderRoute: typeof NotificationsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -442,6 +462,7 @@ const rootRouteChildren: RootRouteChildren = {
   AboutRoute: AboutRoute,
   CssTestRoute: CssTestRoute,
   LoginRoute: LoginRoute,
+  NotificationsRoute: NotificationsRoute,
   PrivacyRoute: PrivacyRoute,
   PrivacyPolicyRoute: PrivacyPolicyRoute,
   ProfileRoute: ProfileRoute,

--- a/apps/www/src/routes/notifications.css
+++ b/apps/www/src/routes/notifications.css
@@ -1,0 +1,103 @@
+@layer page {
+	.notifications-page {
+		max-width: 600px;
+		margin: 0 auto;
+		padding: 40px 20px 80px;
+
+		& h1 {
+			font-size: 32px;
+			font-weight: 700;
+			color: var(--color-foreground);
+			margin: 0 0 32px 0;
+		}
+
+		& .notifications-page__unavailable,
+		& .notifications-page__empty {
+			color: var(--color-quiet);
+			margin: 0;
+		}
+
+		& .notifications-form {
+			display: flex;
+			flex-direction: column;
+			gap: 20px;
+		}
+
+		& .notification-topic {
+			display: flex;
+			flex-direction: column;
+			gap: 4px;
+			padding: 16px;
+			border: 1px solid oklch(from var(--color-quiet) l calc(c * 0.3) h);
+			border-radius: 8px;
+			background: var(--color-background);
+		}
+
+		& .notification-topic__row {
+			display: flex;
+			align-items: center;
+			gap: 12px;
+		}
+
+		& .notification-topic__label {
+			flex: 1;
+			font-size: 16px;
+			font-weight: 500;
+			color: var(--color-foreground);
+			cursor: pointer;
+		}
+
+		/* Visually-hide the native input but keep it focusable / accessible. */
+		& .notification-topic__input {
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0, 0, 0, 0);
+			white-space: nowrap;
+			border: 0;
+		}
+
+		& .notification-topic__control {
+			display: inline-flex;
+			align-items: center;
+			width: 40px;
+			height: 22px;
+			border-radius: 999px;
+			background: oklch(from var(--color-quiet) l calc(c * 0.3) h);
+			padding: 2px;
+			cursor: pointer;
+			transition: background-color 0.2s;
+			flex-shrink: 0;
+		}
+
+		& .notification-topic__control[data-checked] {
+			background: var(--color-primary);
+		}
+
+		& .notification-topic__control[data-disabled] {
+			cursor: not-allowed;
+			opacity: 0.6;
+		}
+
+		& .notification-topic__thumb {
+			display: block;
+			width: 18px;
+			height: 18px;
+			border-radius: 999px;
+			background: var(--color-background);
+			transition: transform 0.2s;
+		}
+
+		& .notification-topic__control[data-checked] .notification-topic__thumb {
+			transform: translateX(18px);
+		}
+
+		& .notification-topic__description {
+			font-size: 13px;
+			color: var(--color-quiet);
+		}
+	}
+}

--- a/apps/www/src/routes/notifications.tsx
+++ b/apps/www/src/routes/notifications.tsx
@@ -1,0 +1,121 @@
+import { createFileRoute } from '@tanstack/solid-router'
+import { Switch as KSwitch } from '@kobalte/core/switch'
+import { createSignal, For, Show } from 'solid-js'
+import Layout from '@/components/Layout'
+import PageHeader from '@/components/PageHeader'
+import { createErrorSignal, ErrorMessage } from '@/components/ErrorMessage'
+import { authMiddleware } from '@/middleware/auth'
+import {
+	getNotifications,
+	updateNotificationSubscription,
+	type NotificationTopic,
+} from '@/api/notifications'
+import { Sentry } from '@/lib/sentry'
+import '@/routes/notifications.css'
+
+export const Route = createFileRoute('/notifications')({
+	loader: () => getNotifications(),
+	pendingComponent: () => (
+		<Layout title="Notifications - Pick My Fruit">
+			<PageHeader breadcrumbs={[{ label: 'Notifications' }]} />
+			<main id="main-content" class="notifications-page">
+				<p>Loading…</p>
+			</main>
+		</Layout>
+	),
+	component: NotificationsPage,
+	server: {
+		middleware: [authMiddleware],
+	},
+})
+
+function NotificationsPage() {
+	const data = Route.useLoaderData()
+
+	return (
+		<Layout title="Notifications - Pick My Fruit">
+			<PageHeader breadcrumbs={[{ label: 'Notifications' }]} />
+			<main id="main-content" class="notifications-page">
+				<h1>Manage Notifications</h1>
+				<Show
+					when={data().available}
+					fallback={
+						<p class="notifications-page__unavailable">
+							Email notifications are not configured for this environment.
+						</p>
+					}
+				>
+					<Show
+						when={data().topics.length > 0}
+						fallback={
+							<p class="notifications-page__empty">
+								There are no notification topics to manage right now.
+							</p>
+						}
+					>
+						<form class="notifications-form">
+							<For each={data().topics}>
+								{(topic) => <TopicSwitch topic={topic} />}
+							</For>
+						</form>
+					</Show>
+				</Show>
+			</main>
+		</Layout>
+	)
+}
+
+function TopicSwitch(props: { topic: NotificationTopic }) {
+	const [checked, setChecked] = createSignal(props.topic.subscribed)
+	const [pending, setPending] = createSignal(false)
+	const [error, setError] = createErrorSignal()
+
+	async function handleChange(next: boolean) {
+		const previous = checked()
+		setChecked(next)
+		setPending(true)
+		setError(null)
+		try {
+			await updateNotificationSubscription({
+				data: { topicId: props.topic.id, subscribed: next },
+			})
+		} catch (err) {
+			setChecked(previous)
+			Sentry.captureException(err)
+			setError(
+				err instanceof Error
+					? err.message
+					: 'Could not update this notification preference.'
+			)
+		} finally {
+			setPending(false)
+		}
+	}
+
+	return (
+		<KSwitch
+			class="notification-topic"
+			checked={checked()}
+			onChange={handleChange}
+			disabled={pending()}
+		>
+			<div class="notification-topic__row">
+				<KSwitch.Label class="notification-topic__label">
+					{props.topic.name}
+				</KSwitch.Label>
+				<KSwitch.Input class="notification-topic__input" />
+				<KSwitch.Control class="notification-topic__control">
+					<KSwitch.Thumb class="notification-topic__thumb" />
+				</KSwitch.Control>
+			</div>
+			<Show when={props.topic.description}>
+				{(description) => (
+					<KSwitch.Description class="notification-topic__description">
+						{description()}
+					</KSwitch.Description>
+				)}
+			</Show>
+			<ErrorMessage error={error()} />
+		</KSwitch>
+	)
+}


### PR DESCRIPTION
Adds a new `/notifications` route that allows authenticated users to manage their email notification subscriptions via Resend's Topics API.

## Changes

- **New server module** (`resend-topics.server.ts`): Thin wrappers around Resend's Topics and Contact-Topics endpoints with Zod validation. Provides `listTopics()`, `listContactTopics()`, and `updateContactTopics()` functions.

- **New API layer** (`api/notifications.ts`): Two server functions:
  - `getNotifications()`: Loads the topic catalog merged with the signed-in user's subscriptions, falling back to topic defaults for users with no explicit preferences. Returns `NotificationsPayload` with `available` flag (false when `EMAIL_PROVIDER !== 'resend'`) and topic list.
  - `updateNotificationSubscription()`: Toggles a user's subscription for a single topic.

- **New route** (`routes/notifications.tsx`): Page component with:
  - Authentication middleware via `authMiddleware`
  - Pending state showing "Loading…"
  - Conditional rendering for unavailable/empty states
  - `TopicSwitch` component using Kobalte's switch control for each topic
  - Optimistic UI updates with rollback on error
  - Error handling via Sentry

- **Styling** (`routes/notifications.css`): Page layout with max-width container, form grid, and custom switch control styling using CSS variables and layers.

- **Route registration**: Updated `routeTree.gen.ts` to register the new `/notifications` route.

- **Navigation**: Added "Notifications" link to user dropdown menu in `PageHeader.tsx`.

## Implementation Details

- Handles 404 responses from Resend gracefully (new contacts with no explicit preferences)
- Uses `encodeURIComponent()` for email addresses in API paths
- Validates all Resend responses with Zod schemas using passthrough behavior to tolerate future API additions
- Follows project conventions: server-only code in `.server.ts`, error handling via Sentry, semantic CSS with variables and layers

https://claude.ai/code/session_01H2jqFKLQA1CLyCLUQEQUaD