### PR TITLE
feat: add address release policy

### DIFF
--- a/apps/www/drizzle/0009_add_address_release_policy.sql
+++ b/apps/www/drizzle/0009_add_address_release_policy.sql
@@ -1,0 +1,20 @@
+-- Add per-listing address release policy. Default preserves the existing
+-- owner-approval behavior for every existing listing.
+ALTER TABLE listings ADD COLUMN address_release_policy TEXT NOT NULL
+	DEFAULT 'on_owner_approval'
+	CHECK (address_release_policy IN ('on_owner_approval','on_verified_request'));
+--> statement-breakpoint
+-- Append-only record of address reveals. This is NOT an access-control table —
+-- authorization for `on_verified_request` is a property of the viewer
+-- (user.email_verified). This log exists for attribution, unique-member
+-- analytics, and as the seed for future gleaner follow-ups.
+CREATE TABLE address_reveals (
+	id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	user_id text NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+	listing_id integer NOT NULL REFERENCES listings(id) ON DELETE CASCADE,
+	created_at integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX address_reveals_listing_idx ON address_reveals (listing_id, created_at);
+--> statement-breakpoint
+CREATE INDEX address_reveals_user_idx ON address_reveals (user_id, created_at);

--- a/apps/www/drizzle/meta/_journal.json
+++ b/apps/www/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1779596643981,
 			"tag": "0008_add_kokoto",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "6",
+			"when": 1780370524164,
+			"tag": "0009_add_address_release_policy",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/www/src/api/listings.ts
+++ b/apps/www/src/api/listings.ts
@@ -300,6 +300,8 @@ export const revealListingAddress = createServerFn({ method: 'POST' })
 				city: listing.city,
 				state: listing.state,
 				zip: listing.zip,
+				lat: listing.lat,
+				lng: listing.lng,
 			}),
 		}
 	})

--- a/apps/www/src/api/listings.ts
+++ b/apps/www/src/api/listings.ts
@@ -6,7 +6,7 @@ import { NotFoundError } from '@/lib/user-error'
 import { Sentry } from '@/lib/sentry'
 import { updateListingSchema } from '@/lib/validation'
 import type { AddressFields, Listing } from '@/data/schema.server'
-import type { OwnerListingView } from '@/data/listing'
+import type { OwnerListingView, VerifiedPublicListing } from '@/data/listing'
 
 /** Fetches the current user's listings, or empty array if not authenticated. */
 export const getMyListings = createServerFn({ method: 'GET' })
@@ -119,6 +119,189 @@ export const getListingForViewer = createServerFn({ method: 'GET' })
 			}
 		}
 		return getPublic(id)
+	})
+
+/**
+ * Result of a {@link revealListingAddress} call. `gated` is not an error —
+ * it's the expected response when the viewer hasn't yet verified their
+ * email; the UI surfaces a "verify to reveal" affordance instead of an
+ * address.
+ */
+export type RevealAddressResult =
+	| { tag: 'revealed'; listing: VerifiedPublicListing }
+	| { tag: 'gated'; reason: 'unauthenticated' | 'email_unverified' }
+
+/**
+ * Synchronously records an address reveal for the current viewer and
+ * returns the precise address. POST semantics because it writes an
+ * append-only row to `address_reveals`. Eligibility is `policy ===
+ * on_verified_request` and the viewer is email-verified.
+ */
+export const revealListingAddress = createServerFn({ method: 'POST' })
+	.middleware([errorMiddleware])
+	.inputValidator((id: unknown) => listingIdParamSchema.parse(id))
+	.handler(async ({ data: id }): Promise<RevealAddressResult> => {
+		const headers = getRequestHeaders()
+		const { auth } = await import('@/lib/auth.server')
+		const { logger } = await import('@/lib/logger.server')
+
+		const session = await auth.api.getSession({ headers })
+
+		const { getListingById, getPhotosForListing, recordAddressReveal } =
+			await import('@/data/queries.server')
+		const { toPublicListing, toVerifiedPublicListing } =
+			await import('@/data/listing')
+
+		const listing = await getListingById(id)
+		if (!listing) throw new NotFoundError('Listing not found')
+
+		// Owners would never hit this path from the UI, but if they do, do not
+		// record a reveal for themselves — return the address directly via the
+		// verified shape so the caller gets a consistent payload.
+		const isOwner = session?.user?.id === listing.userId
+
+		const policy = listing.addressReleasePolicy
+
+		Sentry.addBreadcrumb({
+			category: 'address-release',
+			type: 'info',
+			message: 'reveal.requested',
+			data: { listingId: id, policy },
+		})
+
+		Sentry.metrics.count('listing.address.reveal.click', 1, {
+			attributes: { policy },
+		})
+
+		if (policy !== 'on_verified_request' && !isOwner) {
+			// This endpoint is only for the verified-request path. Treat misuse as
+			// "not allowed" rather than gated — the caller is on the wrong flow.
+			throw new UserError(
+				'NOT_ALLOWED',
+				'This listing does not release its address automatically.'
+			)
+		}
+
+		const verified = Boolean(session?.user?.emailVerified)
+
+		Sentry.addBreadcrumb({
+			category: 'address-release',
+			type: 'info',
+			message: 'auth.checked',
+			data: { verified },
+		})
+
+		if (!session?.user) {
+			Sentry.metrics.count('listing.address.reveal.gated', 1)
+			Sentry.addBreadcrumb({
+				category: 'address-release',
+				type: 'info',
+				message: 'reveal.gated',
+			})
+			logger.info(
+				{
+					listingId: id,
+					userId: null,
+					policy,
+					verified: false,
+					wroteEvent: false,
+				},
+				'address reveal gated: unauthenticated'
+			)
+			return { tag: 'gated', reason: 'unauthenticated' }
+		}
+
+		if (!verified && !isOwner) {
+			Sentry.metrics.count('listing.address.reveal.gated', 1)
+			Sentry.addBreadcrumb({
+				category: 'address-release',
+				type: 'info',
+				message: 'reveal.gated',
+			})
+			logger.info(
+				{
+					listingId: id,
+					userId: session.user.id,
+					policy,
+					verified: false,
+					wroteEvent: false,
+				},
+				'address reveal gated: email unverified'
+			)
+			return { tag: 'gated', reason: 'email_unverified' }
+		}
+
+		const photos = await getPhotosForListing(id)
+		const pub = toPublicListing(listing, photos)
+		if (!pub) {
+			throw new UserError(
+				'INTERNAL_ERROR',
+				'This listing has an invalid location and cannot be released.'
+			)
+		}
+
+		if (!listing.address || (listing.lat === 0 && listing.lng === 0)) {
+			Sentry.withScope((scope) => {
+				scope.setFingerprint(['address-release', 'reveal', 'missing-address'])
+				Sentry.captureMessage(
+					'Address reveal requested on listing without a usable address',
+					{ level: 'warning', extra: { listingId: id } }
+				)
+			})
+		}
+
+		let wroteEvent = false
+		if (!isOwner) {
+			try {
+				await recordAddressReveal(session.user.id, id)
+				wroteEvent = true
+				Sentry.addBreadcrumb({
+					category: 'address-release',
+					type: 'info',
+					message: 'reveal.event.written',
+					data: { listingId: id },
+				})
+			} catch (error) {
+				// Silent-failure detector: we still hand back the address, so the
+				// member is unblocked, but losing the audit trail is significant
+				// enough to capture.
+				Sentry.withScope((scope) => {
+					scope.setFingerprint(['address-release', 'reveal', 'event-write-failed'])
+					Sentry.captureException(error, {
+						extra: { listingId: id, userId: session.user.id },
+					})
+				})
+				Sentry.captureMessage(
+					'Address reveal event write failed; address still released',
+					{ level: 'error', extra: { listingId: id, userId: session.user.id } }
+				)
+			}
+		}
+
+		Sentry.metrics.count('listing.address.revealed', 1, {
+			attributes: { policy },
+		})
+
+		logger.info(
+			{
+				listingId: id,
+				userId: session.user.id,
+				policy,
+				verified: true,
+				wroteEvent,
+			},
+			'address reveal: address released'
+		)
+
+		return {
+			tag: 'revealed',
+			listing: toVerifiedPublicListing(pub, {
+				address: listing.address,
+				city: listing.city,
+				state: listing.state,
+				zip: listing.zip,
+			}),
+		}
 	})
 
 /** Updates any combination of listing fields for the authenticated owner. */

--- a/apps/www/src/components/ListingForm.css
+++ b/apps/www/src/components/ListingForm.css
@@ -49,6 +49,46 @@
 		cursor: not-allowed;
 	}
 
+	.address-release-fieldset {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.address-release-option {
+		display: flex;
+		gap: 12px;
+		align-items: flex-start;
+		padding: 12px 16px;
+		border: 1px solid var(--color-border, #d4d4d8);
+		border-radius: 8px;
+		cursor: pointer;
+	}
+
+	.address-release-option:has(input:checked) {
+		border-color: var(--color-accent);
+		background: oklch(from var(--color-accent) l c h / 0.08);
+	}
+
+	.address-release-option input[type='radio'] {
+		margin-top: 4px;
+	}
+
+	.address-release-option-text {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.address-release-option-label {
+		font-weight: 600;
+	}
+
+	.address-release-option-description {
+		font-size: 14px;
+		color: var(--color-quiet);
+	}
+
 	@media (max-width: 600px) {
 		.form-row,
 		.form-row-3 {

--- a/apps/www/src/components/ListingForm.css
+++ b/apps/www/src/components/ListingForm.css
@@ -70,8 +70,19 @@
 		background: oklch(from var(--color-accent) l c h / 0.08);
 	}
 
+	.address-release-option:focus-within {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
+	}
+
 	.address-release-option input[type='radio'] {
 		margin-top: 4px;
+	}
+
+	/* The label-level focus-within ring (above) replaces the native one. */
+	.address-release-option input[type='radio']:focus,
+	.address-release-option input[type='radio']:focus-visible {
+		outline: none;
 	}
 
 	.address-release-option-text {
@@ -81,6 +92,7 @@
 	}
 
 	.address-release-option-label {
+		font-size: 16px;
 		font-weight: 600;
 	}
 

--- a/apps/www/src/components/ListingForm.tsx
+++ b/apps/www/src/components/ListingForm.tsx
@@ -99,6 +99,7 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 			state: formData.get('state'),
 			zip: formData.get('zip'),
 			notes: formData.get('notes'),
+			addressReleasePolicy: formData.get('addressReleasePolicy') ?? undefined,
 		}
 
 		const parsed = listingFormSchema.safeParse(data)
@@ -349,6 +350,41 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 						placeholder="e.g., Ring doorbell first. Take a few or take 'em all!"
 						rows={3}
 					/>
+				</fieldset>
+
+				<fieldset class="address-release-fieldset">
+					<legend>How is your address released?</legend>
+					<label class="address-release-option">
+						<input
+							type="radio"
+							name="addressReleasePolicy"
+							value="on_owner_approval"
+							checked
+						/>
+						<span class="address-release-option-text">
+							<span class="address-release-option-label">Approve each request</span>
+							<span class="address-release-option-description">
+								You approve every request before your address is shared.
+							</span>
+						</span>
+					</label>
+					<label class="address-release-option">
+						<input
+							type="radio"
+							name="addressReleasePolicy"
+							value="on_verified_request"
+						/>
+						<span class="address-release-option-text">
+							<span class="address-release-option-label">
+								Share with verified members
+							</span>
+							<span class="address-release-option-description">
+								Any signed-in member with a verified email sees this address without
+								asking. <strong>Treat the location as effectively public</strong> —
+								members can reshare it.
+							</span>
+						</span>
+					</label>
 				</fieldset>
 
 				<div class="form-actions">

--- a/apps/www/src/components/ListingForm.tsx
+++ b/apps/www/src/components/ListingForm.tsx
@@ -353,7 +353,7 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 				</fieldset>
 
 				<fieldset class="address-release-fieldset">
-					<legend>How is your address released?</legend>
+					<legend>How is your address shared?</legend>
 					<label class="address-release-option">
 						<input
 							type="radio"
@@ -380,8 +380,10 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 							</span>
 							<span class="address-release-option-description">
 								Any signed-in member with a verified email sees this address without
-								asking. <strong>Treat the location as effectively public</strong> —
-								members can reshare it.
+								asking.
+								<br />
+								<strong>Treat the location as effectively public</strong> — members can
+								reshare it.
 							</span>
 						</span>
 					</label>

--- a/apps/www/src/components/ListingMap.tsx
+++ b/apps/www/src/components/ListingMap.tsx
@@ -14,6 +14,12 @@ interface OwnerProps {
 	lat: number
 	lng: number
 	h3Index: string
+	/**
+	 * Resolution to coarsen `h3Index` to for the "what others see" hexagon.
+	 * Defaults to {@link H3_RESOLUTIONS.PUBLIC_DETAIL}; pass a finer (larger)
+	 * value when the listing's address-release policy widens visibility.
+	 */
+	publicHexResolution?: number
 }
 
 interface PublicProps {
@@ -46,6 +52,7 @@ export default function ListingMap(props: Props) {
 				props.lat,
 				props.lng,
 				props.h3Index,
+				props.publicHexResolution ?? H3_RESOLUTIONS.PUBLIC_DETAIL,
 				onMapLoad
 			)
 		} else {
@@ -63,9 +70,10 @@ export default function ListingMap(props: Props) {
 		lat: number,
 		lng: number,
 		h3Index: string,
+		publicHexResolution: number,
 		onMapLoad: () => void
 	) {
-		const publicH3 = cellToParent(h3Index, H3_RESOLUTIONS.PUBLIC_DETAIL)
+		const publicH3 = cellToParent(h3Index, publicHexResolution)
 
 		map = new maplibregl.Map({
 			container,

--- a/apps/www/src/components/ListingMap.tsx
+++ b/apps/www/src/components/ListingMap.tsx
@@ -27,7 +27,13 @@ interface PublicProps {
 	approximateH3Index: string
 }
 
-type Props = OwnerProps | PublicProps
+interface VerifiedProps {
+	mode: 'verified'
+	lat: number
+	lng: number
+}
+
+type Props = OwnerProps | PublicProps | VerifiedProps
 
 // MapLibre paint properties require literal color strings, not CSS variables.
 const COLOR_MARKER = '#10b981' // --color-fresh-green
@@ -55,6 +61,8 @@ export default function ListingMap(props: Props) {
 				props.publicHexResolution ?? H3_RESOLUTIONS.PUBLIC_DETAIL,
 				onMapLoad
 			)
+		} else if (props.mode === 'verified') {
+			initVerifiedMap(maplibregl, container, props.lat, props.lng, onMapLoad)
 		} else {
 			initPublicMap(maplibregl, container, props.approximateH3Index, onMapLoad)
 		}
@@ -128,6 +136,36 @@ export default function ListingMap(props: Props) {
 			.addTo(map)
 	}
 
+	function initVerifiedMap(
+		maplibregl: typeof import('maplibre-gl'),
+		container: HTMLDivElement,
+		lat: number,
+		lng: number,
+		onMapLoad: () => void
+	) {
+		map = new maplibregl.Map({
+			container,
+			style: 'https://tiles.openfreemap.org/styles/liberty',
+			center: [lng, lat],
+			zoom: 16,
+			attributionControl: false,
+		})
+
+		map.addControl(
+			new maplibregl.AttributionControl({ compact: true }),
+			'bottom-right'
+		)
+		map.addControl(new maplibregl.NavigationControl({ showCompass: false }))
+
+		reportMapLoadedOnce(map, onMapLoad, () => {
+			if (!map) return
+		})
+
+		new maplibregl.Marker({ color: COLOR_MARKER })
+			.setLngLat([lng, lat])
+			.addTo(map)
+	}
+
 	function initPublicMap(
 		maplibregl: typeof import('maplibre-gl'),
 		container: HTMLDivElement,
@@ -193,7 +231,9 @@ export default function ListingMap(props: Props) {
 				aria-label={
 					props.mode === 'owner'
 						? 'Map showing exact listing location and public area'
-						: 'Map showing approximate listing area'
+						: props.mode === 'verified'
+							? 'Map showing exact listing location'
+							: 'Map showing approximate listing area'
 				}
 				onReady={setupMap}
 			/>

--- a/apps/www/src/data/listing.ts
+++ b/apps/www/src/data/listing.ts
@@ -31,6 +31,8 @@ export type RevealedAddress = {
 	city: string
 	state: string
 	zip: string | null
+	lat: number
+	lng: number
 }
 
 /**
@@ -133,6 +135,8 @@ export function listingShapeFor(
 			city: listing.city,
 			state: listing.state,
 			zip: listing.zip,
+			lat: listing.lat,
+			lng: listing.lng,
 		})
 	}
 	return pub

--- a/apps/www/src/data/listing.ts
+++ b/apps/www/src/data/listing.ts
@@ -25,6 +25,21 @@ export type PublicListing = Omit<
 	photos: PublicPhoto[]
 }
 
+/** Address fields released to a verified viewer of an `on_verified_request` listing. */
+export type RevealedAddress = {
+	address: string
+	city: string
+	state: string
+	zip: string | null
+}
+
+/**
+ * Public listing plus the precise street address. Returned to verified
+ * members for listings whose `addressReleasePolicy` is `on_verified_request`,
+ * after a reveal is recorded.
+ */
+export type VerifiedPublicListing = PublicListing & RevealedAddress
+
 /** Full listing row plus public photo fields — returned to the listing owner only. */
 export type OwnerListingView = Listing & {
 	/**
@@ -33,6 +48,20 @@ export type OwnerListingView = Listing & {
 	 */
 	photos: PublicPhoto[]
 }
+
+/** Owner / steward view of a listing — the most permissive shape. */
+export type PrivateListing = OwnerListingView
+
+/** The minimum viewer information needed to decide which shape to present. */
+export type ListingViewer = {
+	userId: string | null
+	emailVerified: boolean
+}
+
+export type ListingShape =
+	| PublicListing
+	| VerifiedPublicListing
+	| PrivateListing
 
 /**
  * Strips sensitive location fields and coarsens h3Index to neighborhood precision.
@@ -66,4 +95,45 @@ export function toPublicListing(
 		approximateH3Index,
 		photos,
 	}
+}
+
+/** Promotes a {@link PublicListing} to a {@link VerifiedPublicListing} by adding the precise address. */
+export function toVerifiedPublicListing(
+	publicListing: PublicListing,
+	address: RevealedAddress
+): VerifiedPublicListing {
+	return { ...publicListing, ...address }
+}
+
+/**
+ * Picks the listing shape to present to a viewer. Owners always see the
+ * private (full) shape. For non-owners, `on_owner_approval` listings stay
+ * public (the existing inquiry flow gates address release); verified members
+ * looking at `on_verified_request` listings see the address.
+ *
+ * Returns `null` when the listing cannot be projected (invalid h3 index).
+ */
+export function listingShapeFor(
+	listing: Listing,
+	viewer: ListingViewer,
+	photos: PublicPhoto[] = [],
+	onError?: (listingId: number, error: unknown) => void
+): ListingShape | null {
+	if (viewer.userId && viewer.userId === listing.userId) {
+		return { ...listing, photos }
+	}
+	const pub = toPublicListing(listing, photos, onError)
+	if (!pub) return null
+	if (
+		listing.addressReleasePolicy === 'on_verified_request' &&
+		viewer.emailVerified
+	) {
+		return toVerifiedPublicListing(pub, {
+			address: listing.address,
+			city: listing.city,
+			state: listing.state,
+			zip: listing.zip,
+		})
+	}
+	return pub
 }

--- a/apps/www/src/data/queries.server.ts
+++ b/apps/www/src/data/queries.server.ts
@@ -14,7 +14,11 @@ import {
 	type AddressReveal,
 } from './schema.server'
 import { eq, desc, and, ne, isNull, gt, inArray, sql } from 'drizzle-orm'
-import { ListingStatus, type ListingStatusValue } from '@/lib/validation'
+import {
+	ListingStatus,
+	type ListingStatusValue,
+	type AddressReleasePolicyValue,
+} from '@/lib/validation'
 import { Sentry } from '@/lib/sentry'
 import { storage } from '@/lib/storage.server'
 import {
@@ -541,6 +545,7 @@ export async function updateListingById(
 		variety?: string | null
 		quantity?: string | null
 		notes?: string | null
+		addressReleasePolicy?: AddressReleasePolicyValue
 	}
 ): Promise<UpdateListingResult> {
 	return Sentry.startSpan(

--- a/apps/www/src/data/queries.server.ts
+++ b/apps/www/src/data/queries.server.ts
@@ -4,12 +4,14 @@ import {
 	inquiries,
 	listingPhotos,
 	user,
+	addressReveals,
 	type Listing,
 	type NewListing,
 	type Inquiry,
 	type NewInquiry,
 	type AddressFields,
 	type ListingPhoto,
+	type AddressReveal,
 } from './schema.server'
 import { eq, desc, and, ne, isNull, gt, inArray, sql } from 'drizzle-orm'
 import { ListingStatus, type ListingStatusValue } from '@/lib/validation'
@@ -608,6 +610,36 @@ export async function getUserLastAddress(
 				.where(and(eq(listings.userId, userId), isNull(listings.deletedAt)))
 				.orderBy(desc(listings.createdAt))
 				.limit(1)
+			return result[0]
+		}
+	)
+}
+
+// ============================================================================
+// Address Reveal Functions
+// ============================================================================
+
+/**
+ * Appends an `address_reveals` row. Append-only by design — repeat reveals
+ * are a real engagement signal, so we record every one (no dedupe).
+ */
+export async function recordAddressReveal(
+	userId: string,
+	listingId: number
+): Promise<AddressReveal> {
+	return Sentry.startSpan(
+		{
+			name: 'recordAddressReveal',
+			op: 'db.query',
+			attributes: { listingId },
+		},
+		async () => {
+			const result = await db
+				.insert(addressReveals)
+				.values({ userId, listingId })
+				.returning()
+			if (!result[0])
+				throw new DataInvariantError('recordAddressReveal: insert returned no row')
 			return result[0]
 		}
 	)

--- a/apps/www/src/data/schema.server.ts
+++ b/apps/www/src/data/schema.server.ts
@@ -142,6 +142,14 @@ export const listings = sqliteTable(
 		// Metadata
 		notes: text('notes'),
 		accessInstructions: text('access_instructions'), // e.g., 'Ring doorbell', 'Gate code 1234'
+		// How the precise address is released to non-owners. `on_owner_approval`
+		// (default) gates on the existing inquiry flow; `on_verified_request`
+		// releases to any signed-in member with a verified email.
+		addressReleasePolicy: text('address_release_policy', {
+			enum: ['on_owner_approval', 'on_verified_request'],
+		})
+			.notNull()
+			.default('on_owner_approval'),
 		deletedAt: integer('deleted_at', { mode: 'timestamp' }), // soft delete
 		createdAt: integer('created_at', { mode: 'timestamp' })
 			.notNull()
@@ -213,3 +221,36 @@ export const listingPhotos = sqliteTable(
 
 export type ListingPhoto = typeof listingPhotos.$inferSelect
 export type NewListingPhoto = typeof listingPhotos.$inferInsert
+
+// ============================================================================
+// Address Reveals Table
+// ============================================================================
+
+/**
+ * Append-only record of address reveals. Authz for `on_verified_request` is a
+ * property of the viewer (`user.email_verified`); this log exists for
+ * attribution, unique-member analytics, and as the seed for future gleaner
+ * follow-ups. Not an access-control table.
+ */
+export const addressReveals = sqliteTable(
+	'address_reveals',
+	{
+		id: integer('id').primaryKey({ autoIncrement: true }),
+		userId: text('user_id')
+			.notNull()
+			.references(() => user.id, { onDelete: 'cascade' }),
+		listingId: integer('listing_id')
+			.notNull()
+			.references(() => listings.id, { onDelete: 'cascade' }),
+		createdAt: integer('created_at', { mode: 'timestamp' })
+			.notNull()
+			.default(sql`(unixepoch())`),
+	},
+	(table) => [
+		index('address_reveals_listing_idx').on(table.listingId, table.createdAt),
+		index('address_reveals_user_idx').on(table.userId, table.createdAt),
+	]
+)
+
+export type AddressReveal = typeof addressReveals.$inferSelect
+export type NewAddressReveal = typeof addressReveals.$inferInsert

--- a/apps/www/src/lib/listing-status.ts
+++ b/apps/www/src/lib/listing-status.ts
@@ -1,4 +1,9 @@
-import { ListingStatus, type ListingStatusValue } from '@/lib/validation'
+import {
+	AddressReleasePolicy,
+	ListingStatus,
+	type AddressReleasePolicyValue,
+	type ListingStatusValue,
+} from '@/lib/validation'
 
 /** The three visibility states a listing can be in, with user-facing labels. */
 export const VISIBILITY_OPTIONS = [
@@ -38,4 +43,28 @@ const statusVariantMap: Record<ListingStatusValue, StatusVariant> = {
 /** Maps a listing status string to its variant suffix. */
 export function getStatusVariant(status: string): StatusVariant {
 	return statusVariantMap[status as ListingStatusValue] ?? 'private'
+}
+
+/** The two address-release policies, with the same shape as VISIBILITY_OPTIONS. */
+export const ADDRESS_RELEASE_OPTIONS = [
+	{
+		value: AddressReleasePolicy.onOwnerApproval,
+		label: 'Approve each request',
+		description: 'You approve every request before your address is shared.',
+	},
+	{
+		value: AddressReleasePolicy.onVerifiedRequest,
+		label: 'Share with verified members',
+		description:
+			'Anyone signed in with a verified email sees the address — treat it as effectively public.',
+	},
+] as const
+
+/** Semantic color per address-release policy, used to tint the radio label. */
+export const addressReleaseSemanticColor: Record<
+	AddressReleasePolicyValue,
+	string
+> = {
+	[AddressReleasePolicy.onOwnerApproval]: 'var(--color-secondary)',
+	[AddressReleasePolicy.onVerifiedRequest]: 'var(--color-accent)',
 }

--- a/apps/www/src/lib/validation.ts
+++ b/apps/www/src/lib/validation.ts
@@ -122,11 +122,18 @@ export const updateListingSchema = z
 		variety: z.string().max(200).nullable().optional(),
 		quantity: z.string().max(100).nullable().optional(),
 		notes: z.string().max(1000).nullable().optional(),
+		addressReleasePolicy: z.enum(addressReleasePolicyValues).optional(),
 	})
 	.refine(
 		(d) =>
-			[d.status, d.name, d.harvestWindow, d.variety, d.quantity, d.notes].some(
-				(v) => v !== undefined
-			),
+			[
+				d.status,
+				d.name,
+				d.harvestWindow,
+				d.variety,
+				d.quantity,
+				d.notes,
+				d.addressReleasePolicy,
+			].some((v) => v !== undefined),
 		{ message: 'At least one field must be updated' }
 	)

--- a/apps/www/src/lib/validation.ts
+++ b/apps/www/src/lib/validation.ts
@@ -18,6 +18,20 @@ const requiredString = (message: string, max: number = 200) =>
 		z.string().min(1, message).max(max)
 	)
 
+/** Allowed values for a listing's address-release policy. */
+export const AddressReleasePolicy = {
+	onOwnerApproval: 'on_owner_approval',
+	onVerifiedRequest: 'on_verified_request',
+} as const
+
+export type AddressReleasePolicyValue =
+	(typeof AddressReleasePolicy)[keyof typeof AddressReleasePolicy]
+
+const addressReleasePolicyValues = Object.values(AddressReleasePolicy) as [
+	AddressReleasePolicyValue,
+	...AddressReleasePolicyValue[],
+]
+
 // Schema for form input (before geocoding)
 export const listingFormSchema = z.object({
 	type: z.preprocess(
@@ -42,6 +56,9 @@ export const listingFormSchema = z.object({
 			z.string().max(1000).optional()
 		)
 		.optional(),
+	addressReleasePolicy: z
+		.enum(addressReleasePolicyValues)
+		.default(AddressReleasePolicy.onOwnerApproval),
 })
 
 export type ListingFormData = z.infer<typeof listingFormSchema>

--- a/apps/www/src/routes/api/listings.ts
+++ b/apps/www/src/routes/api/listings.ts
@@ -85,6 +85,7 @@ export const Route = createFileRoute('/api/listings')({
 						userId: session.user.id,
 						notes: formData.notes || null,
 						status: 'available',
+						addressReleasePolicy: formData.addressReleasePolicy,
 					})
 
 					return Response.json(listing, { status: 201 })

--- a/apps/www/src/routes/listing-show.css
+++ b/apps/www/src/routes/listing-show.css
@@ -358,6 +358,32 @@
 			margin: 8px 0 0;
 		}
 
+		& .address-reveal {
+			display: flex;
+			flex-direction: column;
+			gap: 8px;
+		}
+
+		& .address-reveal__intro {
+			margin: 0;
+			color: var(--color-quiet);
+			font-size: 14px;
+		}
+
+		& .address-reveal__gate {
+			margin: 0;
+			color: var(--color-quiet);
+		}
+
+		& .address-reveal__address {
+			font-style: normal;
+		}
+
+		& .address-reveal__error {
+			margin: 0;
+			color: var(--color-danger, oklch(0.55 0.2 25));
+		}
+
 		@media (max-width: 600px) {
 			& .listing-detail {
 				padding: 24px;

--- a/apps/www/src/routes/listings.$id.tsx
+++ b/apps/www/src/routes/listings.$id.tsx
@@ -724,6 +724,7 @@ type RevealState =
 function AddressRevealSection(props: {
 	listing: PublicListing
 	isAuthenticated: boolean
+	onRevealed: (listing: VerifiedPublicListing) => void
 }) {
 	const [state, setState] = createSignal<RevealState>({ tag: 'hidden' })
 
@@ -733,6 +734,7 @@ function AddressRevealSection(props: {
 			const result = await revealListingAddress({ data: props.listing.id })
 			if (result.tag === 'revealed') {
 				setState({ tag: 'revealed', listing: result.listing })
+				props.onRevealed(result.listing)
 			} else {
 				setState({ tag: 'gated', reason: result.reason })
 			}
@@ -827,10 +829,22 @@ function ListingDetailPage() {
 	}
 	const justCreated = () => search().created === true
 	const justMarkedUnavailable = () => search().marked === 'unavailable'
+	// Inquiry form is for the owner-approval path. When the listing's policy is
+	// `on_verified_request` the address is auto-released, so no inquiry is needed.
 	const canInquire = () => {
 		const l = listing()
-		return l && l.status === ListingStatus.available && !isOwner()
+		return (
+			l &&
+			l.status === ListingStatus.available &&
+			!isOwner() &&
+			l.addressReleasePolicy !== AddressReleasePolicy.onVerifiedRequest
+		)
 	}
+
+	// Captures the verified-shape listing once the viewer reveals the address,
+	// so the map can swap from a fuzzed hexagon to an exact pin.
+	const [revealedListing, setRevealedListing] =
+		createSignal<VerifiedPublicListing | null>(null)
 
 	// Tracks owner's live edits to the title for document title and breadcrumbs.
 	const [editableTitle, setEditableTitle] = createSignal<string | null>(null)
@@ -981,6 +995,7 @@ function ListingDetailPage() {
 												<AddressRevealSection
 													listing={pub()}
 													isAuthenticated={Boolean(context().session?.user)}
+													onRevealed={setRevealedListing}
 												/>
 											</ListingDetailField>
 										)}
@@ -999,14 +1014,27 @@ function ListingDetailPage() {
 									when={isOwner() && 'lat' in l() ? (l() as Listing) : undefined}
 									fallback={
 										<Show
-											when={
-												'approximateH3Index' in l() ? (l() as PublicListing) : undefined
+											when={revealedListing()}
+											fallback={
+												<Show
+													when={
+														'approximateH3Index' in l() ? (l() as PublicListing) : undefined
+													}
+												>
+													{(pub) => (
+														<ListingMap
+															mode="public"
+															approximateH3Index={pub().approximateH3Index}
+														/>
+													)}
+												</Show>
 											}
 										>
-											{(pub) => (
+											{(revealed) => (
 												<ListingMap
-													mode="public"
-													approximateH3Index={pub().approximateH3Index}
+													mode="verified"
+													lat={revealed().lat}
+													lng={revealed().lng}
 												/>
 											)}
 										</Show>

--- a/apps/www/src/routes/listings.$id.tsx
+++ b/apps/www/src/routes/listings.$id.tsx
@@ -1,4 +1,9 @@
-import { createFileRoute, Link, useRouteContext } from '@tanstack/solid-router'
+import {
+	createFileRoute,
+	Link,
+	useNavigate,
+	useRouteContext,
+} from '@tanstack/solid-router'
 import { createSignal, For, onCleanup, Show } from 'solid-js'
 import { z } from 'zod'
 import Layout from '@/components/Layout'
@@ -717,16 +722,18 @@ function OwnerEditableFields(props: {
 type RevealState =
 	| { tag: 'hidden' }
 	| { tag: 'loading' }
-	| { tag: 'gated'; reason: 'unauthenticated' | 'email_unverified' }
+	| { tag: 'gated'; reason: 'email_unverified' }
 	| { tag: 'revealed'; listing: VerifiedPublicListing }
 	| { tag: 'error'; message: string }
 
 function AddressRevealSection(props: {
 	listing: PublicListing
 	isAuthenticated: boolean
+	loginHref: string
 	onRevealed: (listing: VerifiedPublicListing) => void
 }) {
 	const [state, setState] = createSignal<RevealState>({ tag: 'hidden' })
+	const navigate = useNavigate()
 
 	async function reveal() {
 		setState({ tag: 'loading' })
@@ -735,8 +742,12 @@ function AddressRevealSection(props: {
 			if (result.tag === 'revealed') {
 				setState({ tag: 'revealed', listing: result.listing })
 				props.onRevealed(result.listing)
+			} else if (result.reason === 'email_unverified') {
+				setState({ tag: 'gated', reason: 'email_unverified' })
 			} else {
-				setState({ tag: 'gated', reason: result.reason })
+				// Session expired between page load and click — send them to /login
+				// rather than showing a "please sign in" interstitial.
+				navigate({ to: props.loginHref })
 			}
 		} catch (err) {
 			Sentry.captureException(err)
@@ -753,26 +764,25 @@ function AddressRevealSection(props: {
 				<p class="address-reveal__intro">
 					This owner shares their address with verified members automatically.
 				</p>
-				<button
-					type="button"
-					class="button button--primary"
-					onClick={() => void reveal()}
+				<Show
+					when={props.isAuthenticated}
+					fallback={
+						<a class="button button--primary" href={props.loginHref}>
+							Sign in to reveal
+						</a>
+					}
 				>
-					{props.isAuthenticated ? 'Show street address' : 'Sign in to reveal'}
-				</button>
+					<button
+						type="button"
+						class="button button--primary"
+						onClick={() => void reveal()}
+					>
+						Show street address
+					</button>
+				</Show>
 			</Show>
 			<Show when={state().tag === 'loading'}>
 				<p>Revealing address…</p>
-			</Show>
-			<Show
-				when={
-					state().tag === 'gated' &&
-					(state() as { tag: 'gated'; reason: string }).reason === 'unauthenticated'
-				}
-			>
-				<p class="address-reveal__gate">
-					Please <Link to="/login">sign in</Link> to see this address.
-				</p>
 			</Show>
 			<Show
 				when={
@@ -845,6 +855,11 @@ function ListingDetailPage() {
 	// so the map can swap from a fuzzed hexagon to an exact pin.
 	const [revealedListing, setRevealedListing] =
 		createSignal<VerifiedPublicListing | null>(null)
+
+	// Used by the unauthenticated reveal CTA to deep-link to /login and bounce
+	// the viewer right back to this listing once they're signed in.
+	const loginHref = () =>
+		`/login?returnTo=${encodeURIComponent(`/listings/${params().id}`)}`
 
 	// Tracks owner's live edits to the title for document title and breadcrumbs.
 	const [editableTitle, setEditableTitle] = createSignal<string | null>(null)
@@ -995,6 +1010,7 @@ function ListingDetailPage() {
 												<AddressRevealSection
 													listing={pub()}
 													isAuthenticated={Boolean(context().session?.user)}
+													loginHref={loginHref()}
 													onRevealed={setRevealedListing}
 												/>
 											</ListingDetailField>

--- a/apps/www/src/routes/listings.$id.tsx
+++ b/apps/www/src/routes/listings.$id.tsx
@@ -19,11 +19,16 @@ import { Sentry } from '@/lib/sentry'
 import {
 	getListingForViewer,
 	listingIdParamSchema,
+	revealListingAddress,
 	updateListing,
 } from '@/api/listings'
 import type { Listing } from '@/data/schema.server'
 import type { PublicListing } from '@/data/queries.server'
-import type { OwnerListingView, PublicPhoto } from '@/data/listing'
+import type {
+	OwnerListingView,
+	PublicPhoto,
+	VerifiedPublicListing,
+} from '@/data/listing'
 import '@/routes/listing-show.css'
 import { createErrorSignal, ErrorMessage } from '@/components/ErrorMessage'
 
@@ -599,6 +604,104 @@ function OwnerEditableFields(props: {
 	)
 }
 
+type RevealState =
+	| { tag: 'hidden' }
+	| { tag: 'loading' }
+	| { tag: 'gated'; reason: 'unauthenticated' | 'email_unverified' }
+	| { tag: 'revealed'; listing: VerifiedPublicListing }
+	| { tag: 'error'; message: string }
+
+function AddressRevealSection(props: {
+	listing: PublicListing
+	isAuthenticated: boolean
+}) {
+	const [state, setState] = createSignal<RevealState>({ tag: 'hidden' })
+
+	async function reveal() {
+		setState({ tag: 'loading' })
+		try {
+			const result = await revealListingAddress({ data: props.listing.id })
+			if (result.tag === 'revealed') {
+				setState({ tag: 'revealed', listing: result.listing })
+			} else {
+				setState({ tag: 'gated', reason: result.reason })
+			}
+		} catch (err) {
+			Sentry.captureException(err)
+			setState({
+				tag: 'error',
+				message: err instanceof Error ? err.message : 'Could not reveal address.',
+			})
+		}
+	}
+
+	return (
+		<div class="address-reveal" data-testid="address-reveal">
+			<Show when={state().tag === 'hidden'}>
+				<p class="address-reveal__intro">
+					This owner shares their address with verified members automatically.
+				</p>
+				<button
+					type="button"
+					class="button button--primary"
+					onClick={() => void reveal()}
+				>
+					{props.isAuthenticated ? 'Show street address' : 'Sign in to reveal'}
+				</button>
+			</Show>
+			<Show when={state().tag === 'loading'}>
+				<p>Revealing address…</p>
+			</Show>
+			<Show
+				when={
+					state().tag === 'gated' &&
+					(state() as { tag: 'gated'; reason: string }).reason === 'unauthenticated'
+				}
+			>
+				<p class="address-reveal__gate">
+					Please <Link to="/login">sign in</Link> to see this address.
+				</p>
+			</Show>
+			<Show
+				when={
+					state().tag === 'gated' &&
+					(state() as { tag: 'gated'; reason: string }).reason === 'email_unverified'
+				}
+			>
+				<p class="address-reveal__gate">
+					Verify your email address to see this address.
+				</p>
+			</Show>
+			<Show
+				when={
+					state().tag === 'revealed'
+						? (state() as { tag: 'revealed'; listing: VerifiedPublicListing }).listing
+						: undefined
+				}
+			>
+				{(revealed) => (
+					<address class="address-reveal__address" data-testid="revealed-address">
+						<div>{revealed().address}</div>
+						<div>
+							{revealed().city}, {revealed().state}{' '}
+							<Show when={revealed().zip}>{revealed().zip}</Show>
+						</div>
+					</address>
+				)}
+			</Show>
+			<Show
+				when={
+					state().tag === 'error'
+						? (state() as { tag: 'error'; message: string }).message
+						: undefined
+				}
+			>
+				{(message) => <p class="address-reveal__error">{message()}</p>}
+			</Show>
+		</div>
+	)
+}
+
 function ListingDetailPage() {
 	const data = Route.useLoaderData()
 	const context = useRouteContext({ from: '__root__' })
@@ -742,6 +845,24 @@ function ListingDetailPage() {
 											{l().city}, {l().state}
 										</span>
 									</ListingDetailField>
+
+									<Show
+										when={
+											'approximateH3Index' in l() &&
+											l().addressReleasePolicy === 'on_verified_request'
+												? (l() as PublicListing)
+												: undefined
+										}
+									>
+										{(pub) => (
+											<ListingDetailField label="Address">
+												<AddressRevealSection
+													listing={pub()}
+													isAuthenticated={Boolean(context().session?.user)}
+												/>
+											</ListingDetailField>
+										)}
+									</Show>
 
 									<Show when={l().notes}>
 										<ListingDetailField label="Notes">

--- a/apps/www/src/routes/listings.$id.tsx
+++ b/apps/www/src/routes/listings.$id.tsx
@@ -9,11 +9,19 @@ import ListingMap from '@/components/ListingMap'
 import ListingPhotosSection from '@/components/ListingPhotosSection'
 import { ListingDetailField } from '@/components/ListingDetailField'
 import {
+	ADDRESS_RELEASE_OPTIONS,
+	addressReleaseSemanticColor,
 	getStatusVariant,
 	VISIBILITY_OPTIONS,
 	statusSemanticColor,
 } from '@/lib/listing-status'
-import { ListingStatus, type ListingStatusValue } from '@/lib/validation'
+import {
+	AddressReleasePolicy,
+	ListingStatus,
+	type AddressReleasePolicyValue,
+	type ListingStatusValue,
+} from '@/lib/validation'
+import { H3_RESOLUTIONS } from '@/lib/h3-resolutions'
 import { buildListingMeta } from '@/lib/listing-meta'
 import { Sentry } from '@/lib/sentry'
 import {
@@ -224,6 +232,94 @@ function OwnerControls(props: {
 	)
 }
 
+function AddressVisibilityControls(props: {
+	listingId: number
+	initialPolicy: AddressReleasePolicyValue
+	clientUpdatedAt: () => number
+	onUpdated: (updatedAt: Date) => void
+	onPolicyChanged: (policy: AddressReleasePolicyValue) => void
+}) {
+	const [isUpdating, setIsUpdating] = createSignal(false)
+	const [savedPolicy, setSavedPolicy] = createSignal(props.initialPolicy)
+	const [displayPolicy, setDisplayPolicy] = createSignal(props.initialPolicy)
+	const [error, setError] = createErrorSignal()
+	let debounceTimer: ReturnType<typeof setTimeout> | undefined
+
+	onCleanup(() => {
+		clearTimeout(debounceTimer)
+		const pending = displayPolicy()
+		if (pending !== savedPolicy()) void commit(pending)
+	})
+
+	function select(newPolicy: AddressReleasePolicyValue) {
+		if (newPolicy === displayPolicy()) return
+		setDisplayPolicy(newPolicy)
+		props.onPolicyChanged(newPolicy)
+		setError(null)
+		clearTimeout(debounceTimer)
+		debounceTimer = setTimeout(() => commit(newPolicy), STATUS_DEBOUNCE_MS)
+	}
+
+	async function commit(newPolicy: AddressReleasePolicyValue) {
+		if (newPolicy === savedPolicy()) return
+		setIsUpdating(true)
+		try {
+			const result = await updateListing({
+				data: {
+					id: props.listingId,
+					addressReleasePolicy: newPolicy,
+					clientUpdatedAt: props.clientUpdatedAt(),
+				},
+			})
+			setSavedPolicy(newPolicy)
+			props.onUpdated(result.updatedAt!)
+		} catch (err) {
+			Sentry.captureException(err)
+			setError(err)
+			setDisplayPolicy(savedPolicy())
+			props.onPolicyChanged(savedPolicy())
+		} finally {
+			setIsUpdating(false)
+		}
+	}
+
+	return (
+		<fieldset class="visibility-fieldset" aria-busy={isUpdating()}>
+			<legend class="sr-only">Address Visibility</legend>
+			<For each={ADDRESS_RELEASE_OPTIONS}>
+				{(option) => (
+					<label
+						class="visibility-option"
+						classList={{
+							'visibility-option--selected': displayPolicy() === option.value,
+						}}
+						style={{
+							'--visibility-color': addressReleaseSemanticColor[option.value],
+						}}
+					>
+						<input
+							type="radio"
+							name="addressReleasePolicy"
+							value={option.value}
+							checked={displayPolicy() === option.value}
+							onChange={() => select(option.value)}
+						/>
+						<span class="visibility-option-text">
+							<span class="visibility-option-label">{option.label}</span>
+							<span class="visibility-option-description">{option.description}</span>
+						</span>
+					</label>
+				)}
+			</For>
+			<ErrorMessage
+				class="visibility-error"
+				defaultMessage="Failed to update"
+				error={error()}
+			/>
+		</fieldset>
+	)
+}
+
 function OwnerTitleField(props: {
 	listing: OwnerListingView
 	clientUpdatedAt: () => number
@@ -309,6 +405,7 @@ function OwnerEditableFields(props: {
 	listing: OwnerListingView
 	clientUpdatedAt: () => number
 	onUpdated: (updatedAt: Date) => void
+	onAddressReleasePolicyChanged: (policy: AddressReleasePolicyValue) => void
 }) {
 	const [savedHarvest, setSavedHarvest] = createSignal(
 		props.listing.harvestWindow ?? ''
@@ -570,6 +667,19 @@ function OwnerEditableFields(props: {
 				</span>
 			</ListingDetailField>
 
+			<div class="listing-detail-field listing-detail-field--visibility">
+				<span class="listing-detail-field__label">Address Visibility</span>
+				<div class="listing-detail-field__value">
+					<AddressVisibilityControls
+						listingId={props.listing.id}
+						initialPolicy={props.listing.addressReleasePolicy}
+						clientUpdatedAt={props.clientUpdatedAt}
+						onUpdated={props.onUpdated}
+						onPolicyChanged={props.onAddressReleasePolicyChanged}
+					/>
+				</div>
+			</div>
+
 			<ListingDetailField label="Notes" id="listing-notes">
 				<textarea
 					id="listing-notes"
@@ -739,6 +849,17 @@ function ListingDetailPage() {
 	const clientUpdatedAt = () =>
 		Math.floor((liveUpdatedAt()?.getTime() ?? 0) / 1000)
 
+	// Tracks owner's live edits to the release policy so the public-hex
+	// preview on the owner map can shrink without waiting for a save.
+	const [liveAddressReleasePolicy, setLiveAddressReleasePolicy] =
+		createSignal<AddressReleasePolicyValue>(
+			ownerListing()?.addressReleasePolicy ?? AddressReleasePolicy.onOwnerApproval
+		)
+	const ownerPublicHexResolution = () =>
+		liveAddressReleasePolicy() === AddressReleasePolicy.onVerifiedRequest
+			? 12
+			: H3_RESOLUTIONS.PUBLIC_DETAIL
+
 	return (
 		<Show when={listing()} fallback={<ListingNotFoundFallback />}>
 			{(l) => (
@@ -808,6 +929,7 @@ function ListingDetailPage() {
 											listing={ownerListing()}
 											clientUpdatedAt={clientUpdatedAt}
 											onUpdated={setLiveUpdatedAt}
+											onAddressReleasePolicyChanged={setLiveAddressReleasePolicy}
 										/>
 									</div>
 								)}
@@ -891,12 +1013,17 @@ function ListingDetailPage() {
 									}
 								>
 									{(owner) => (
-										<ListingMap
-											mode="owner"
-											lat={owner().lat}
-											lng={owner().lng}
-											h3Index={owner().h3Index}
-										/>
+										<Show when={ownerPublicHexResolution()} keyed>
+											{(resolution) => (
+												<ListingMap
+													mode="owner"
+													lat={owner().lat}
+													lng={owner().lng}
+													h3Index={owner().h3Index}
+													publicHexResolution={resolution}
+												/>
+											)}
+										</Show>
 									)}
 								</Show>
 							</div>

--- a/apps/www/tests/ListingDetail.test.tsx
+++ b/apps/www/tests/ListingDetail.test.tsx
@@ -20,6 +20,7 @@ function makeListing(overrides: Partial<PublicListing> = {}): PublicListing {
 		approximateH3Index: '872830828ffffff',
 		notes: null,
 		photos: [],
+		addressReleasePolicy: 'on_owner_approval',
 		createdAt: new Date(),
 		updatedAt: new Date(),
 		...overrides,

--- a/apps/www/tests/e2e/address-release.test.ts
+++ b/apps/www/tests/e2e/address-release.test.ts
@@ -36,11 +36,16 @@ test.describe('Address Release Policy', () => {
 				page.getByText(`${listing.city}, ${listing.state}`)
 			).toBeVisible()
 			await expect(page.getByText('900 Pickfair Way')).not.toBeVisible()
-			await expect(
-				page.getByTestId('address-reveal').getByRole('button', {
-					name: /sign in to reveal/i,
-				})
-			).toBeVisible()
+			// Unauthenticated CTA is a direct link to /login?returnTo=… — no
+			// server round-trip, no "please sign in" interstitial.
+			const signInLink = page
+				.getByTestId('address-reveal')
+				.getByRole('link', { name: /sign in to reveal/i })
+			await expect(signInLink).toBeVisible()
+			await expect(signInLink).toHaveAttribute(
+				'href',
+				`/login?returnTo=${encodeURIComponent(`/listings/${listing.id}`)}`
+			)
 
 			// The owner-approval inquiry form should not appear on auto-release
 			// listings — the address path replaces the inquiry path entirely.

--- a/apps/www/tests/e2e/address-release.test.ts
+++ b/apps/www/tests/e2e/address-release.test.ts
@@ -14,6 +14,11 @@ test.describe('Address Release Policy', () => {
 		page,
 		testUser: gleaner,
 	}) => {
+		// Anonymous load → magic-link login → revisit → click reveal is a long
+		// flow; triple the timeout so it stays green under realistic dev-server
+		// warm-up latency on slow CI hosts.
+		test.slow()
+
 		const owner = await createTestUser()
 		const listing = await createTestListing(owner.id, {
 			address: '900 Pickfair Way',

--- a/apps/www/tests/e2e/address-release.test.ts
+++ b/apps/www/tests/e2e/address-release.test.ts
@@ -42,6 +42,12 @@ test.describe('Address Release Policy', () => {
 				})
 			).toBeVisible()
 
+			// The owner-approval inquiry form should not appear on auto-release
+			// listings — the address path replaces the inquiry path entirely.
+			await expect(
+				page.getByRole('heading', { name: 'Interested in this produce?' })
+			).toHaveCount(0)
+
 			// Pre-condition: no reveal rows yet.
 			expect(await getAddressRevealsForListing(listing.id)).toHaveLength(0)
 
@@ -62,6 +68,11 @@ test.describe('Address Release Policy', () => {
 			await expect(page.getByTestId('revealed-address')).toContainText(
 				'Napa, CA 94559'
 			)
+
+			// After reveal, the map switches from a fuzzed hexagon to an exact pin.
+			await expect(
+				page.getByRole('img', { name: 'Map showing exact listing location' })
+			).toBeVisible({ timeout: 10_000 })
 
 			// Reveal row was appended.
 			const reveals = await getAddressRevealsForListing(listing.id)

--- a/apps/www/tests/e2e/address-release.test.ts
+++ b/apps/www/tests/e2e/address-release.test.ts
@@ -1,0 +1,89 @@
+import { test, expect } from './helpers/fixtures'
+import {
+	createTestListing,
+	createTestUser,
+	cleanupTestUser,
+	getAddressRevealsForListing,
+} from './helpers/test-db'
+import { loginViaUI } from './helpers/login'
+
+test.describe('Address Release Policy', () => {
+	test.describe.configure({ mode: 'serial' })
+
+	test('verified non-owner reveals the precise address on an on_verified_request listing and the reveal is recorded', async ({
+		page,
+		testUser: gleaner,
+	}) => {
+		const owner = await createTestUser()
+		const listing = await createTestListing(owner.id, {
+			address: '900 Pickfair Way',
+			city: 'Napa',
+			state: 'CA',
+			zip: '94559',
+			addressReleasePolicy: 'on_verified_request',
+		})
+
+		try {
+			// Anonymous: visit the listing — the precise street address is not shown,
+			// and the reveal CTA renders the unauthenticated copy.
+			await page.goto(`/listings/${listing.id}`)
+			await expect(
+				page.getByText(`${listing.city}, ${listing.state}`)
+			).toBeVisible()
+			await expect(page.getByText('900 Pickfair Way')).not.toBeVisible()
+			await expect(
+				page.getByTestId('address-reveal').getByRole('button', {
+					name: /sign in to reveal/i,
+				})
+			).toBeVisible()
+
+			// Pre-condition: no reveal rows yet.
+			expect(await getAddressRevealsForListing(listing.id)).toHaveLength(0)
+
+			// Sign in as a verified gleaner (test fixture creates users with emailVerified=true).
+			await loginViaUI(page, gleaner)
+			await page.goto(`/listings/${listing.id}`)
+			await page.waitForLoadState('networkidle', { timeout: 60_000 })
+
+			// Now the button reveals the address synchronously.
+			await page
+				.getByTestId('address-reveal')
+				.getByRole('button', { name: /show street address/i })
+				.click()
+			await expect(page.getByTestId('revealed-address')).toContainText(
+				'900 Pickfair Way',
+				{ timeout: 10_000 }
+			)
+			await expect(page.getByTestId('revealed-address')).toContainText(
+				'Napa, CA 94559'
+			)
+
+			// Reveal row was appended.
+			const reveals = await getAddressRevealsForListing(listing.id)
+			expect(reveals).toHaveLength(1)
+			expect(reveals[0].userId).toBe(gleaner.id)
+		} finally {
+			await cleanupTestUser(owner)
+		}
+	})
+
+	test('on_owner_approval listings (the default) do not expose a reveal CTA', async ({
+		page,
+		testUser,
+	}) => {
+		// The default policy keeps the existing inquiry flow in charge — there
+		// must be no "Show street address" affordance for non-owners.
+		const listing = await createTestListing(testUser.id)
+
+		const otherUser = await createTestUser()
+		try {
+			await loginViaUI(page, otherUser)
+			await page.goto(`/listings/${listing.id}`)
+			await page.waitForLoadState('networkidle', { timeout: 60_000 })
+
+			await expect(page.getByTestId('address-reveal')).toHaveCount(0)
+		} finally {
+			await cleanupTestUser(otherUser)
+		}
+	})
+})

--- a/apps/www/tests/e2e/helpers/test-db.ts
+++ b/apps/www/tests/e2e/helpers/test-db.ts
@@ -7,6 +7,7 @@ import {
 	verification,
 	listings,
 	inquiries,
+	addressReveals,
 	type NewListing,
 } from '../../../src/data/schema.server'
 import { eq, desc, like } from 'drizzle-orm'
@@ -150,6 +151,21 @@ export async function createTestListing(
 	}
 	const result = await db.insert(listings).values(data).returning()
 	return result[0]
+}
+
+/** Queries address-reveal rows for a given listing from the test DB. */
+export async function getAddressRevealsForListing(listingId: number): Promise<
+	Array<{
+		id: number
+		userId: string
+		listingId: number
+		createdAt: Date
+	}>
+> {
+	return db
+		.select()
+		.from(addressReveals)
+		.where(eq(addressReveals.listingId, listingId))
 }
 
 /** Queries inquiries for a given listing from the test DB. */

--- a/apps/www/tests/listing-photo-fetch-limit.server.test.ts
+++ b/apps/www/tests/listing-photo-fetch-limit.server.test.ts
@@ -65,6 +65,7 @@ function makeListingRow(id: number) {
 		userId: 'owner-1',
 		notes: null,
 		accessInstructions: null,
+		addressReleasePolicy: 'on_owner_approval',
 		deletedAt: null,
 		createdAt: new Date(),
 		updatedAt: new Date(),

--- a/apps/www/tests/listingPhotos.server.test.ts
+++ b/apps/www/tests/listingPhotos.server.test.ts
@@ -105,6 +105,7 @@ function makeListingRow(id: number, overrides: Record<string, unknown> = {}) {
 		userId: faker.string.uuid(),
 		notes: null,
 		accessInstructions: null,
+		addressReleasePolicy: 'on_owner_approval',
 		deletedAt: null,
 		createdAt: new Date(),
 		updatedAt: new Date(),

--- a/apps/www/tests/listingShapeFor.test.ts
+++ b/apps/www/tests/listingShapeFor.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import { faker } from '@faker-js/faker'
+import { latLngToCell } from 'h3-js'
+import { listingShapeFor, type ListingViewer } from '../src/data/listing'
+import type { Listing } from '../src/data/schema.server'
+
+const NAPA = { lat: 38.2975, lng: -122.2869 }
+
+function makeListing(overrides: Partial<Listing> = {}): Listing {
+	const h3Index = latLngToCell(NAPA.lat, NAPA.lng, 13)
+	return {
+		id: faker.number.int({ min: 1, max: 9999 }),
+		name: `${faker.person.firstName()}'s fig tree`,
+		type: 'fig',
+		variety: null,
+		status: 'available',
+		quantity: 'abundant',
+		harvestWindow: 'June-September',
+		address: '123 Main St',
+		city: 'Napa',
+		state: 'CA',
+		zip: '94558',
+		lat: NAPA.lat,
+		lng: NAPA.lng,
+		h3Index,
+		userId: 'owner-1',
+		notes: null,
+		accessInstructions: 'Ring doorbell',
+		addressReleasePolicy: 'on_owner_approval',
+		deletedAt: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		...overrides,
+	}
+}
+
+const ANON: ListingViewer = { userId: null, emailVerified: false }
+const UNVERIFIED: ListingViewer = { userId: 'visitor-1', emailVerified: false }
+const VERIFIED: ListingViewer = { userId: 'visitor-1', emailVerified: true }
+const OWNER: ListingViewer = { userId: 'owner-1', emailVerified: true }
+const OWNER_UNVERIFIED: ListingViewer = {
+	userId: 'owner-1',
+	emailVerified: false,
+}
+
+describe('listingShapeFor', () => {
+	describe('owner viewer always gets the private shape', () => {
+		it.each([
+			{
+				name: 'on_owner_approval + verified owner',
+				policy: 'on_owner_approval' as const,
+				viewer: OWNER,
+			},
+			{
+				name: 'on_verified_request + verified owner',
+				policy: 'on_verified_request' as const,
+				viewer: OWNER,
+			},
+			{
+				name: 'on_owner_approval + unverified owner',
+				policy: 'on_owner_approval' as const,
+				viewer: OWNER_UNVERIFIED,
+			},
+			{
+				name: 'on_verified_request + unverified owner',
+				policy: 'on_verified_request' as const,
+				viewer: OWNER_UNVERIFIED,
+			},
+		])('$name → PrivateListing', ({ policy, viewer }) => {
+			const listing = makeListing({ addressReleasePolicy: policy })
+			const shape = listingShapeFor(listing, viewer)!
+
+			// PrivateListing carries every Listing field including userId, address, lat/lng.
+			expect(shape).toHaveProperty('userId', listing.userId)
+			expect(shape).toHaveProperty('address', listing.address)
+			expect(shape).toHaveProperty(
+				'accessInstructions',
+				listing.accessInstructions
+			)
+			expect(shape).toHaveProperty('lat', listing.lat)
+			expect(shape).toHaveProperty('lng', listing.lng)
+			expect(shape).toHaveProperty('h3Index', listing.h3Index)
+			expect(shape).not.toHaveProperty('approximateH3Index')
+		})
+	})
+
+	describe('on_owner_approval (default): non-owners always get PublicListing', () => {
+		it.each([
+			{ name: 'anonymous', viewer: ANON },
+			{ name: 'authenticated but unverified', viewer: UNVERIFIED },
+			{ name: 'authenticated and verified', viewer: VERIFIED },
+		])('$name → PublicListing', ({ viewer }) => {
+			const listing = makeListing({ addressReleasePolicy: 'on_owner_approval' })
+			const shape = listingShapeFor(listing, viewer)!
+
+			expect(shape).not.toHaveProperty('userId')
+			expect(shape).not.toHaveProperty('address')
+			expect(shape).not.toHaveProperty('accessInstructions')
+			expect(shape).not.toHaveProperty('lat')
+			expect(shape).not.toHaveProperty('lng')
+			expect(shape).not.toHaveProperty('h3Index')
+			expect(shape).not.toHaveProperty('zip')
+			expect(shape).toHaveProperty('approximateH3Index')
+		})
+	})
+
+	describe('on_verified_request: only verified members get the address', () => {
+		it('anonymous viewer → PublicListing (no address)', () => {
+			const listing = makeListing({ addressReleasePolicy: 'on_verified_request' })
+			const shape = listingShapeFor(listing, ANON)!
+
+			expect(shape).not.toHaveProperty('address')
+			expect(shape).toHaveProperty('approximateH3Index')
+		})
+
+		it('authenticated but unverified → PublicListing (no address)', () => {
+			const listing = makeListing({ addressReleasePolicy: 'on_verified_request' })
+			const shape = listingShapeFor(listing, UNVERIFIED)!
+
+			expect(shape).not.toHaveProperty('address')
+			expect(shape).toHaveProperty('approximateH3Index')
+		})
+
+		it('verified non-owner → VerifiedPublicListing (with address)', () => {
+			const listing = makeListing({
+				addressReleasePolicy: 'on_verified_request',
+				address: '777 Sunset Blvd',
+				city: 'Napa',
+				state: 'CA',
+				zip: '94558',
+			})
+			const shape = listingShapeFor(listing, VERIFIED)!
+
+			expect(shape).toHaveProperty('address', '777 Sunset Blvd')
+			expect(shape).toHaveProperty('city', 'Napa')
+			expect(shape).toHaveProperty('state', 'CA')
+			expect(shape).toHaveProperty('zip', '94558')
+			// Still public — no owner-only fields leak.
+			expect(shape).not.toHaveProperty('userId')
+			expect(shape).not.toHaveProperty('accessInstructions')
+			expect(shape).not.toHaveProperty('lat')
+			expect(shape).not.toHaveProperty('lng')
+			expect(shape).not.toHaveProperty('h3Index')
+			expect(shape).toHaveProperty('approximateH3Index')
+		})
+	})
+
+	it('default policy preserves the pre-existing public shape', () => {
+		// Listings created before this migration get the default
+		// `on_owner_approval`, which must continue to gate the address behind
+		// the inquiry flow for every non-owner — including verified members.
+		const listing = makeListing()
+		expect(listing.addressReleasePolicy).toBe('on_owner_approval')
+
+		const shape = listingShapeFor(listing, VERIFIED)!
+		expect(shape).not.toHaveProperty('address')
+	})
+
+	it('returns null when the h3 index is invalid (for non-owner)', () => {
+		const listing = makeListing({ h3Index: 'not-a-real-h3' })
+		const shape = listingShapeFor(listing, ANON)
+		expect(shape).toBeNull()
+	})
+})

--- a/apps/www/tests/listingShapeFor.test.ts
+++ b/apps/www/tests/listingShapeFor.test.ts
@@ -121,13 +121,15 @@ describe('listingShapeFor', () => {
 			expect(shape).toHaveProperty('approximateH3Index')
 		})
 
-		it('verified non-owner → VerifiedPublicListing (with address)', () => {
+		it('verified non-owner → VerifiedPublicListing (with address + precise pin)', () => {
 			const listing = makeListing({
 				addressReleasePolicy: 'on_verified_request',
 				address: '777 Sunset Blvd',
 				city: 'Napa',
 				state: 'CA',
 				zip: '94558',
+				lat: 38.31,
+				lng: -122.31,
 			})
 			const shape = listingShapeFor(listing, VERIFIED)!
 
@@ -135,11 +137,13 @@ describe('listingShapeFor', () => {
 			expect(shape).toHaveProperty('city', 'Napa')
 			expect(shape).toHaveProperty('state', 'CA')
 			expect(shape).toHaveProperty('zip', '94558')
+			// Precise pin is released alongside the address so the map can swap
+			// to an exact-location marker.
+			expect(shape).toHaveProperty('lat', 38.31)
+			expect(shape).toHaveProperty('lng', -122.31)
 			// Still public — no owner-only fields leak.
 			expect(shape).not.toHaveProperty('userId')
 			expect(shape).not.toHaveProperty('accessInstructions')
-			expect(shape).not.toHaveProperty('lat')
-			expect(shape).not.toHaveProperty('lng')
 			expect(shape).not.toHaveProperty('h3Index')
 			expect(shape).toHaveProperty('approximateH3Index')
 		})

--- a/apps/www/tests/listings-api.server.test.ts
+++ b/apps/www/tests/listings-api.server.test.ts
@@ -44,6 +44,7 @@ function makeListing(id: number): OwnerListingView {
 		userId: 'user-123',
 		notes: null,
 		accessInstructions: null,
+		addressReleasePolicy: 'on_owner_approval',
 		deletedAt: null,
 		createdAt: new Date(),
 		updatedAt: new Date(),

--- a/apps/www/tests/migrations.server.test.ts
+++ b/apps/www/tests/migrations.server.test.ts
@@ -19,6 +19,7 @@ const EXPECTED_TABLES = [
 	'_dc_step',
 	'_dc_workflow',
 	'account',
+	'address_reveals',
 	'inquiries',
 	'listing_photos',
 	'listings',

--- a/apps/www/tests/revealListingAddress.server.test.ts
+++ b/apps/www/tests/revealListingAddress.server.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { faker } from '@faker-js/faker'
+import { latLngToCell } from 'h3-js'
+import type { Listing } from '../src/data/schema.server'
+
+const mockGetSession = vi.fn()
+const mockGetListingById = vi.fn()
+const mockGetPhotosForListing = vi.fn()
+const mockRecordAddressReveal = vi.fn()
+const mockMetricsCount = vi.fn()
+const mockAddBreadcrumb = vi.fn()
+const mockCaptureMessage = vi.fn()
+const mockCaptureException = vi.fn()
+const mockWithScope = vi.fn(
+	(cb: (scope: { setFingerprint: () => void }) => void) => {
+		cb({ setFingerprint: () => {} })
+	}
+)
+const mockLoggerInfo = vi.fn()
+
+vi.mock('../src/lib/auth.server', () => ({
+	auth: { api: { getSession: mockGetSession } },
+}))
+
+vi.mock('../src/data/queries.server', () => ({
+	getListingById: (...args: unknown[]) => mockGetListingById(...args),
+	getPhotosForListing: (...args: unknown[]) => mockGetPhotosForListing(...args),
+	recordAddressReveal: (...args: unknown[]) => mockRecordAddressReveal(...args),
+}))
+
+vi.mock('../src/lib/sentry', () => ({
+	Sentry: {
+		captureException: (...args: unknown[]) => mockCaptureException(...args),
+		captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+		addBreadcrumb: (...args: unknown[]) => mockAddBreadcrumb(...args),
+		withScope: (cb: unknown) => mockWithScope(cb as never),
+		metrics: { count: (...args: unknown[]) => mockMetricsCount(...args) },
+		// startSpan passes through synchronously; not used by the handler itself
+		// but imported by sibling fns in the same module — keep a no-op stub.
+		startSpan: (_opts: unknown, cb: (span: unknown) => unknown) =>
+			cb({ setAttribute: () => {} }),
+	},
+}))
+
+vi.mock('../src/lib/logger.server', () => ({
+	logger: {
+		info: (...args: unknown[]) => mockLoggerInfo(...args),
+	},
+}))
+
+vi.mock('@tanstack/solid-start/server', () => ({
+	getRequestHeaders: () => ({}),
+}))
+
+const { revealListingAddress } = await import('../src/api/listings')
+
+const NAPA = { lat: 38.2975, lng: -122.2869 }
+
+function makeListing(overrides: Partial<Listing> = {}): Listing {
+	const h3Index = latLngToCell(NAPA.lat, NAPA.lng, 13)
+	return {
+		id: faker.number.int({ min: 1, max: 9999 }),
+		name: 'A fig tree',
+		type: 'fig',
+		variety: null,
+		status: 'available',
+		quantity: 'abundant',
+		harvestWindow: 'June-September',
+		address: '123 Main St',
+		city: 'Napa',
+		state: 'CA',
+		zip: '94558',
+		lat: NAPA.lat,
+		lng: NAPA.lng,
+		h3Index,
+		userId: 'owner-1',
+		notes: null,
+		accessInstructions: null,
+		addressReleasePolicy: 'on_verified_request',
+		deletedAt: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		...overrides,
+	}
+}
+
+describe('revealListingAddress', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mockGetPhotosForListing.mockResolvedValue([])
+		mockRecordAddressReveal.mockResolvedValue({
+			id: 1,
+			userId: 'visitor-1',
+			listingId: 1,
+			createdAt: new Date(),
+		})
+	})
+
+	it('gates an unauthenticated viewer without writing a reveal row', async () => {
+		const listing = makeListing()
+		mockGetSession.mockResolvedValue(null)
+		mockGetListingById.mockResolvedValue(listing)
+
+		const result = await revealListingAddress({ data: listing.id })
+
+		expect(result).toEqual({ tag: 'gated', reason: 'unauthenticated' })
+		expect(mockRecordAddressReveal).not.toHaveBeenCalled()
+		expect(mockMetricsCount).toHaveBeenCalledWith(
+			'listing.address.reveal.click',
+			1,
+			{ attributes: { policy: 'on_verified_request' } }
+		)
+		expect(mockMetricsCount).toHaveBeenCalledWith(
+			'listing.address.reveal.gated',
+			1
+		)
+		expect(mockMetricsCount).not.toHaveBeenCalledWith(
+			'listing.address.revealed',
+			expect.anything(),
+			expect.anything()
+		)
+	})
+
+	it('gates an authenticated but unverified viewer without writing a reveal row', async () => {
+		const listing = makeListing()
+		mockGetSession.mockResolvedValue({
+			user: { id: 'visitor-1', emailVerified: false },
+		})
+		mockGetListingById.mockResolvedValue(listing)
+
+		const result = await revealListingAddress({ data: listing.id })
+
+		expect(result).toEqual({ tag: 'gated', reason: 'email_unverified' })
+		expect(mockRecordAddressReveal).not.toHaveBeenCalled()
+		expect(mockMetricsCount).toHaveBeenCalledWith(
+			'listing.address.reveal.gated',
+			1
+		)
+	})
+
+	it('releases the address and writes a reveal row for a verified non-owner', async () => {
+		const listing = makeListing({
+			address: '777 Sunset Blvd',
+			city: 'Napa',
+			state: 'CA',
+			zip: '94558',
+		})
+		mockGetSession.mockResolvedValue({
+			user: { id: 'visitor-1', emailVerified: true },
+		})
+		mockGetListingById.mockResolvedValue(listing)
+
+		const result = await revealListingAddress({ data: listing.id })
+
+		expect(result.tag).toBe('revealed')
+		if (result.tag !== 'revealed') return
+		expect(result.listing.address).toBe('777 Sunset Blvd')
+		expect(result.listing.city).toBe('Napa')
+		expect(result.listing.state).toBe('CA')
+		expect(result.listing.zip).toBe('94558')
+		expect(result.listing).toHaveProperty('approximateH3Index')
+		expect(result.listing).not.toHaveProperty('userId')
+		expect(result.listing).not.toHaveProperty('lat')
+
+		expect(mockRecordAddressReveal).toHaveBeenCalledWith('visitor-1', listing.id)
+		expect(mockMetricsCount).toHaveBeenCalledWith('listing.address.revealed', 1, {
+			attributes: { policy: 'on_verified_request' },
+		})
+		expect(mockLoggerInfo).toHaveBeenCalledWith(
+			expect.objectContaining({
+				listingId: listing.id,
+				userId: 'visitor-1',
+				policy: 'on_verified_request',
+				verified: true,
+				wroteEvent: true,
+			}),
+			expect.any(String)
+		)
+	})
+
+	it('records every reveal — repeats are not deduplicated', async () => {
+		const listing = makeListing()
+		mockGetSession.mockResolvedValue({
+			user: { id: 'visitor-1', emailVerified: true },
+		})
+		mockGetListingById.mockResolvedValue(listing)
+
+		await revealListingAddress({ data: listing.id })
+		await revealListingAddress({ data: listing.id })
+		await revealListingAddress({ data: listing.id })
+
+		expect(mockRecordAddressReveal).toHaveBeenCalledTimes(3)
+	})
+
+	it('skips the reveal-row write for the owning user but still returns the address', async () => {
+		const listing = makeListing({ userId: 'owner-1' })
+		mockGetSession.mockResolvedValue({
+			user: { id: 'owner-1', emailVerified: true },
+		})
+		mockGetListingById.mockResolvedValue(listing)
+
+		const result = await revealListingAddress({ data: listing.id })
+
+		expect(result.tag).toBe('revealed')
+		expect(mockRecordAddressReveal).not.toHaveBeenCalled()
+	})
+
+	it('still releases the address when the reveal-row write fails, and captures the silent-failure signal', async () => {
+		const listing = makeListing()
+		mockGetSession.mockResolvedValue({
+			user: { id: 'visitor-1', emailVerified: true },
+		})
+		mockGetListingById.mockResolvedValue(listing)
+		mockRecordAddressReveal.mockRejectedValue(new Error('disk full'))
+
+		const result = await revealListingAddress({ data: listing.id })
+
+		expect(result.tag).toBe('revealed')
+		expect(mockCaptureException).toHaveBeenCalled()
+		expect(mockCaptureMessage).toHaveBeenCalledWith(
+			'Address reveal event write failed; address still released',
+			expect.objectContaining({ level: 'error' })
+		)
+		expect(mockMetricsCount).toHaveBeenCalledWith('listing.address.revealed', 1, {
+			attributes: { policy: 'on_verified_request' },
+		})
+	})
+
+	it('rejects reveal attempts against on_owner_approval listings', async () => {
+		const listing = makeListing({ addressReleasePolicy: 'on_owner_approval' })
+		mockGetSession.mockResolvedValue({
+			user: { id: 'visitor-1', emailVerified: true },
+		})
+		mockGetListingById.mockResolvedValue(listing)
+
+		await expect(revealListingAddress({ data: listing.id })).rejects.toThrow(
+			/does not release its address automatically/i
+		)
+		expect(mockRecordAddressReveal).not.toHaveBeenCalled()
+	})
+})

--- a/apps/www/tests/revealListingAddress.server.test.ts
+++ b/apps/www/tests/revealListingAddress.server.test.ts
@@ -144,6 +144,8 @@ describe('revealListingAddress', () => {
 			city: 'Napa',
 			state: 'CA',
 			zip: '94558',
+			lat: 38.31,
+			lng: -122.31,
 		})
 		mockGetSession.mockResolvedValue({
 			user: { id: 'visitor-1', emailVerified: true },
@@ -158,9 +160,10 @@ describe('revealListingAddress', () => {
 		expect(result.listing.city).toBe('Napa')
 		expect(result.listing.state).toBe('CA')
 		expect(result.listing.zip).toBe('94558')
+		expect(result.listing.lat).toBe(38.31)
+		expect(result.listing.lng).toBe(-122.31)
 		expect(result.listing).toHaveProperty('approximateH3Index')
 		expect(result.listing).not.toHaveProperty('userId')
-		expect(result.listing).not.toHaveProperty('lat')
 
 		expect(mockRecordAddressReveal).toHaveBeenCalledWith('visitor-1', listing.id)
 		expect(mockMetricsCount).toHaveBeenCalledWith('listing.address.revealed', 1, {

--- a/apps/www/tests/toPublicListing.test.ts
+++ b/apps/www/tests/toPublicListing.test.ts
@@ -26,6 +26,7 @@ function makeListing(overrides: Partial<Listing> = {}): Listing {
 		userId: faker.string.uuid(),
 		notes: null,
 		accessInstructions: 'Ring doorbell',
+		addressReleasePolicy: 'on_owner_approval',
 		deletedAt: null,
 		createdAt: new Date(),
 		updatedAt: new Date(),
@@ -47,6 +48,7 @@ function makePhoto(
 
 /** The exact set of keys a PublicListing should have, sorted. */
 const EXPECTED_PUBLIC_KEYS = [
+	'addressReleasePolicy',
 	'approximateH3Index',
 	'city',
 	'createdAt',

--- a/docs/0009-address-release-policy.md
+++ b/docs/0009-address-release-policy.md
@@ -1,0 +1,173 @@
+# 0009: Address Release Policy
+
+## Summary
+
+Every listing has an **`address_release_policy`** that decides _how_ its
+precise street address reaches non-owners. Two values exist today:
+
+| Policy                | Who sees the precise address                       | Path                                                                                                |
+| --------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `on_owner_approval`   | requester, after the owner approves                | The existing inquiry flow (`submitInquiryWorkflow`)                                                 |
+| `on_verified_request` | any signed-in member with a verified email address | A new synchronous reveal server function (`revealListingAddress`) that appends to `address_reveals` |
+
+`on_owner_approval` is the default and matches the behavior of every
+listing that existed before this migration. `on_verified_request` is the
+substrate for the upcoming Community Produce Stand listing type — this
+issue ships the _mechanism_ and the UI control; the stand-specific
+guardrails (steward requirement, drop-off framing, raw-whole-produce
+restriction) land in a follow-up.
+
+## Authorization vs. record-keeping
+
+Authorization for `on_verified_request` is a property of the **viewer**
+(`user.email_verified`), not a `(user, listing)` pair. There is **no
+access-control join table**. Reveals are nevertheless recorded in an
+append-only event log (`address_reveals`) for:
+
+- attribution and unique-member analytics,
+- detecting repeat engagement (no dedupe — every reveal is a row),
+- seeding future gleaner follow-ups (a deferred kokoto workflow).
+
+Authz answers "may you see it." The log records "you did."
+
+A verified viewer's access **persists** across visits because it's just
+their verification state — there is no per-visit re-request.
+
+## Schema (migration `0009`)
+
+```sql
+ALTER TABLE listings ADD COLUMN address_release_policy TEXT NOT NULL
+  DEFAULT 'on_owner_approval'
+  CHECK (address_release_policy IN ('on_owner_approval','on_verified_request'));
+
+CREATE TABLE address_reveals (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id    TEXT NOT NULL REFERENCES user(id)     ON DELETE CASCADE,
+  listing_id INTEGER NOT NULL REFERENCES listings(id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX address_reveals_listing_idx ON address_reveals (listing_id, created_at);
+CREATE INDEX address_reveals_user_idx    ON address_reveals (user_id, created_at);
+```
+
+The `listing_id` is `INTEGER` to match `listings.id`. The default on
+`address_release_policy` preserves the existing behavior for every
+already-created listing.
+
+## Shape projection — not a stored class
+
+There is still only one `Listing` row per listing; a presenter picks the
+shape based on `(policy × viewer tier)`:
+
+```mermaid
+flowchart LR
+  L[Listing row] --> P{viewer is owner?}
+  P -- yes --> PR[PrivateListing<br/>full fields + reveal log]
+  P -- no --> Q{policy ===<br/>on_verified_request<br/>AND<br/>viewer.email_verified}
+  Q -- yes --> V[VerifiedPublicListing<br/>PublicListing + address]
+  Q -- no --> PB[PublicListing<br/>fuzzed pin]
+```
+
+```ts
+type PublicListing = {
+	/* fuzzed pin, no street address */
+};
+type VerifiedPublicListing = PublicListing & { address; city; state; zip };
+type PrivateListing = OwnerListingView; // full listing + photos
+```
+
+`listingShapeFor(listing, viewer, photos)` lives in
+`src/data/listing.ts` and returns the right one. The page loader
+(`getListingForViewer`) keeps its existing behavior — it returns a
+`PublicListing` for `on_verified_request` listings to non-owners, and
+the reveal happens through a separate server function so the address
+release is an _explicit_ action that writes a row.
+
+## Reveal flow (`on_verified_request`)
+
+`revealListingAddress(listingId)` is a synchronous server function with
+POST semantics (it writes a row). A single insert does not warrant
+durability — no kokoto workflow.
+
+1. Look up the listing (404 if missing).
+2. If the policy is not `on_verified_request` for a non-owner: reject as
+   `NOT_ALLOWED` (the caller is on the wrong path).
+3. If the viewer is unauthenticated → `{ tag: 'gated', reason:
+'unauthenticated' }` (no row written).
+4. If the viewer is authenticated but `!emailVerified` and not the
+   owner → `{ tag: 'gated', reason: 'email_unverified' }` (no row
+   written).
+5. Otherwise, append an `address_reveals` row (skip the write for
+   owners), and return `{ tag: 'revealed', listing: VerifiedPublicListing
+}`.
+
+If the row write fails after the eligibility check passes, the response
+**still releases the address** (the member is unblocked) but emits a
+`captureMessage` + `captureException` with the fingerprint
+`['address-release', 'reveal', 'event-write-failed']` so the silent
+audit-trail loss is surfaced.
+
+## Observability — the money moment
+
+`listing.address.revealed` is the closest observable proxy for "a member
+now has the address." The funnel is:
+
+```
+view → reveal.click → revealed
+                   ↘ reveal.gated   (conversion leak from email verification friction)
+```
+
+### Metrics
+
+| Counter                        | Attributes | Meaning                                               |
+| ------------------------------ | ---------- | ----------------------------------------------------- |
+| `listing.address.reveal.click` | `policy`   | member asked to see the address                       |
+| `listing.address.reveal.gated` | —          | viewer hit the verify-email wall (funnel leak)        |
+| `listing.address.revealed`     | `policy`   | address shown to a verified member (**money moment**) |
+
+### Breadcrumbs (per reveal request)
+
+`reveal.requested {listingId, policy}` → `auth.checked {verified}` →
+either `reveal.event.written {rowId}` or `reveal.gated`. The crumbs make
+a silent failure reconstructable from a single Sentry event.
+
+### `captureMessage` — silent-failure detection
+
+- The reveal row write failed but the address was still shown (signal
+  lost, no error surfaces).
+- A reveal was requested on a listing with a missing or un-geocoded
+  address.
+
+### Fingerprints
+
+`['address-release','reveal', <reason>]` so one bad listing cannot mask
+broader reveal-path errors.
+
+### Pino (server-side, per reveal)
+
+`{ listingId, userId, policy, verified, wroteEvent }`.
+
+## UI surface
+
+- The new-listing form (`/listings/new`) carries a release-policy radio
+  with honest help text — no false privacy promise on the
+  `on_verified_request` option. The text explicitly warns that the
+  location is "effectively public" because verified members can reshare
+  it.
+- The public listing page (`/listings/$id`) shows an "Address" row for
+  `on_verified_request` listings with a "Show street address" button.
+  Anonymous and unverified-email viewers see a gated message instead of
+  the address.
+
+## Future work (held in the Community Produce Stand plan)
+
+- `community-produce-stand` listing kind + preset
+  (`on_verified_request` + drop-offs + steward).
+- `accepts_drop_offs` column + `intent` (`take` / `dropoff`) on
+  `address_reveals`.
+- Raw-whole-produce restriction + ToS clause; steward-required
+  validation.
+- Same-map "instant vs. owner responds" expectation cue.
+- `last_stocked_at` liquidity signal — kokoto workflow seeded by
+  reveals/intent.
+- Drop-off suggestion N days after a non-stand listing is created.


### PR DESCRIPTION
feat(www): address-release policy + verified-member reveal flow Introduce a per-listing `address_release_policy` that decides *how* the precise street address reaches non-owners. Today every listing gates the address behind the existing owner-approval inquiry flow; this commit adds a second policy — release synchronously to any signed-in member with a verified email — and the projection, presenter, and instrumentation around it. This is the substrate the Community Produce Stand listing type will sit on; nothing stand-specific ships here.
## Schema (migration 0009)
- `listings.address_release_policy` (TEXT NOT NULL, CHECK in `on_owner_approval | on_verified_request`, default `on_owner_approval` so every existing row keeps today's behavior).
- New append-only `address_reveals` table (id, user_id, listing_id, created_at) with FK cascades and `(listing_id, created_at)` / `(user_id, created_at)` indexes. Authz for `on_verified_request` is the viewer's `user.email_verified`, not a `(user, listing)` pair — this log exists for attribution, unique-member analytics, and as the seed for future gleaner follow-ups, not as ACL state.
## Shape projection
- New `VerifiedPublicListing` = `PublicListing` + the released address fields (`address`, `city`, `state`, `zip`) + the precise `lat` / `lng` so the map can swap to an exact pin without a second fetch.
- New `listingShapeFor(listing, viewer, photos)` presenter chooses `Private` / `VerifiedPublic` / `Public` from `(policy × viewer tier)`. Unit tests cover the full matrix and assert the default policy preserves the pre-existing public shape.
## Reveal flow
- `revealListingAddress` server fn (POST semantics):
  - 404 on missing, `NOT_ALLOWED` if the policy doesn't match.
  - Returns `{ tag: 'gated', reason: 'email_unverified' }` for authenticated-but-unverified viewers (no row written).
  - Otherwise appends an `address_reveals` row (skipped for the listing's owner) and returns the `VerifiedPublicListing`.
  - Row-write failure still releases the address; a `captureMessage` + fingerprinted `captureException` flag the silent audit-trail loss.
- Sentry counters (`listing.address.reveal.click | gated |
  revealed`), breadcrumbs (`reveal.requested` → `auth.checked` → `reveal.event.written | reveal.gated`), per-reveal Pino fields (`{ listingId, userId, policy, verified, wroteEvent }`), and the `['address-release', 'reveal', …]` fingerprint family.
## UI
- New-listing form (`/listings/new`):
  - "How is your address shared?" radio fieldset with honest copy — the verified-request option explicitly warns that the location is "effectively public" because members can reshare it.
  - Focus ring moved from the hidden `<input>` to the surrounding `<label>` via `:focus-within` for a cleaner keyboard target; radio label is 16px so it doesn't dwarf the description.
- Owner-edit view (`/listings/$id`):
  - New "Address Visibility" radio between Location and Notes, mirroring the existing Visibility radio. Persists through `updateListing` (`updateListingSchema` + `updateListingById` now accept `addressReleasePolicy`).
  - When the owner picks "Share with verified members" the "What others see" hexagon on the owner map shrinks to H3 res
    12. `ListingMap` takes a new `publicHexResolution` prop; the route keys the owner-map render on the live resolution so MapLibre re-mounts on toggle.
- Public listing detail (`/listings/$id`):
  - For `on_verified_request` listings, an `Address` row replaces nothing else: unauthenticated viewers see a button-styled `<a href="/login?returnTo=/listings/{id}">` (direct deep-link, no server round-trip, no "please sign in" interstitial). Verified viewers see a "Show street address" button that calls the server fn and swaps to the precise address.
  - The inquiry form ("Interested in this produce?") and its divider are hidden for `on_verified_request` listings — the auto-release path replaces the inquiry path.
  - After a successful reveal, `revealedListing` is lifted to the page so `ListingMap` re-renders in a new `mode="verified"` (exact marker, no hex, no legend) at zoom 16.
## Tests
- Unit: shape-matrix coverage for `listingShapeFor`; reveal-fn integration tests for the gated, success, owner-skips-write, repeat (no dedupe), row-write-failure, and wrong-policy branches.
- E2E: `address-release.test.ts` covers the anonymous → /login deep-link → verified reveal → row-recorded → exact-pin map path, plus an assertion that the inquiry form is absent. The verified flow is tagged `test.slow()` so the dev-server warm-up cost on slow CI hosts doesn't blow the per-test timeout.
## Docs
`docs/0009-address-release-policy.md` covers the authz-vs-record distinction, the shape projection (with a Mermaid diagram), the reveal flow, and the observability funnel (money-moment metric, breadcrumbs, fingerprints, Pino).