### PR TITLE
Fix PICKMYFRUIT-1V: replace toSorted for Apple Mail / legacy WebKit

### DIFF
--- a/apps/www/.oxlintrc.json
+++ b/apps/www/.oxlintrc.json
@@ -10,6 +10,23 @@
 	"jsPlugins": ["./oxlint-plugins/no-server-static-import.js"],
 	"rules": {
 		"local/no-server-static-import": "error",
+
+		// ES2023 array copy methods are missing in some runtimes (e.g. Apple Mail WebKit).
+		"eslint/no-restricted-properties": [
+			"error",
+			{
+				"property": "toSorted",
+				"message": "Use .sort() on a fresh array (e.g. after .map()) or [...arr].sort() — toSorted is unavailable in some browsers."
+			},
+			{
+				"property": "toReversed",
+				"message": "Use [...arr].reverse() or arr.slice().reverse() — toReversed is unavailable in some browsers."
+			},
+			{
+				"property": "toSpliced",
+				"message": "Use .slice().splice() or spread — toSpliced is unavailable in some browsers."
+			}
+		],
 		// Solid JS doesn't use React, so React-specific rules don't apply
 		"react/react-in-jsx-scope": "off",
 
@@ -137,6 +154,12 @@
 			"files": ["src/components/ListingForm.tsx"],
 			"rules": {
 				"import/max-dependencies": ["warn", { "max": 15 }]
+			}
+		},
+		{
+			"files": ["tests/produce-types-legacy.test.ts"],
+			"rules": {
+				"eslint/no-restricted-properties": "off"
 			}
 		},
 		{

--- a/apps/www/src/lib/produce-types.ts
+++ b/apps/www/src/lib/produce-types.ts
@@ -39,7 +39,7 @@ function parseCsv(raw: string): ProduceType[] {
 				namePluralSentenceCase,
 			}
 		})
-		.toSorted((a, b) =>
+		.sort((a, b) =>
 			a.nameSingularTitleCase.localeCompare(b.nameSingularTitleCase)
 		)
 }

--- a/apps/www/tests/produce-types-legacy.test.ts
+++ b/apps/www/tests/produce-types-legacy.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest'
+
+describe('produceTypes legacy browser compatibility', () => {
+	it('loads and sorts alphabetically when Array.prototype.toSorted is unavailable', async () => {
+		expect.hasAssertions()
+
+		// @ts-expect-error simulate runtimes without ES2023 Array.prototype.toSorted
+		delete Array.prototype.toSorted
+		vi.resetModules()
+
+		const { produceTypes } = await import('../src/lib/produce-types')
+
+		expect(produceTypes.length).toBeGreaterThan(0)
+
+		const names = produceTypes.map((t) => t.nameSingularTitleCase)
+		const sorted = [...names].sort((a, b) => a.localeCompare(b))
+		expect(names).toStrictEqual(sorted)
+	})
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [PICKMYFRUIT-1V](https://confident-technology.sentry.io/issues/PICKMYFRUIT-1V): `TypeError: undefined is not a function` when loading the homepage in Apple Mail's embedded WebKit browser.

## Root cause

`produce-types.ts` used `Array.prototype.toSorted()` (ES2023) to sort the produce catalog at module load. Apple Mail 605.x does not implement `toSorted`, so the client bundle crashed before the page could render.

## Fix

- Replace `.toSorted()` with `.sort()` on the array returned by `.map()`.
- Add `eslint/no-restricted-properties` for `toSorted`, `toReversed`, and `toSpliced` to prevent recurrence.
- Exempt `produce-types-legacy.test.ts` (it deliberately deletes `toSorted` to simulate the broken runtime).

## TDD

1. Added `produce-types-legacy.test.ts` that deletes `Array.prototype.toSorted` and dynamically imports the module — reproduces the production error before the fix.
2. Confirmed the test failed with `toSorted is not a function`.
3. Applied the fix; all tests pass.

## Verification

- [x] New regression test passes
- [x] Existing `produce-types.test.ts` suite passes
- [x] `bash bin/after-turn.sh` passes (format, lint, typecheck, unit tests)

Fixes PICKMYFRUIT-1V
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81665e1f-9fdc-48f3-88ae-c977fbffa65c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81665e1f-9fdc-48f3-88ae-c977fbffa65c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

