### PR TITLE
Mock OpenFreeMap tile requests in E2E tests

### DIFF
--- a/apps/www/tests/e2e/helpers/fixtures.ts
+++ b/apps/www/tests/e2e/helpers/fixtures.ts
@@ -1,4 +1,4 @@
-import { test as nominatimBase } from './nominatim-mock'
+import { test as tileBase } from './tile-mock'
 import {
 	type TestUser,
 	type TestListing,
@@ -12,7 +12,7 @@ type TestFixtures = {
 	testListing: TestListing
 }
 
-export const test = nominatimBase.extend<TestFixtures>({
+export const test = tileBase.extend<TestFixtures>({
 	// Auto-fixture: clears cookies before every test
 	context: async ({ context }, playwrightUse) => {
 		await context.clearCookies()

--- a/apps/www/tests/e2e/helpers/tile-mock.ts
+++ b/apps/www/tests/e2e/helpers/tile-mock.ts
@@ -1,0 +1,55 @@
+import { test as nominatimBase } from './nominatim-mock'
+
+/**
+ * Minimal valid MapLibre style with no sources or layers, so the map fires its
+ * `load` event without fetching vector tiles, sprites, or glyphs. The app adds
+ * its own GeoJSON sources and fill/line layers after load, none of which need
+ * those external assets.
+ */
+const EMPTY_STYLE = {
+	version: 8,
+	sources: {},
+	layers: [],
+}
+
+export type TileMockFixture = {
+	/** Number of intercepted OpenFreeMap requests served by the mock. */
+	callCount: number
+}
+
+/**
+ * Fixture that intercepts all OpenFreeMap requests at the network boundary,
+ * keeping the E2E suite deterministic by never hitting the real tile service.
+ */
+export const test = nominatimBase.extend<{ tileMock: TileMockFixture }>({
+	tileMock: [
+		async ({ context }, use) => {
+			const fixture: TileMockFixture = { callCount: 0 }
+
+			await context.route('**/tiles.openfreemap.org/**', async (route) => {
+				fixture.callCount++
+
+				const pathname = new URL(route.request().url()).pathname
+
+				// Style requests get a minimal valid style; everything else
+				// (tiles, sprites, glyphs) is served as an empty body so no
+				// request escapes to the network.
+				if (pathname.includes('/styles/')) {
+					await route.fulfill({
+						status: 200,
+						contentType: 'application/json',
+						body: JSON.stringify(EMPTY_STYLE),
+					})
+					return
+				}
+
+				await route.fulfill({ status: 204, body: '' })
+			})
+
+			await use(fixture)
+		},
+		{ auto: true },
+	],
+})
+
+export { expect } from '@playwright/test'


### PR DESCRIPTION
## Summary

Adds network mocking for OpenFreeMap tile service requests in E2E tests to keep the test suite deterministic and avoid external dependencies.

## Changes

- **New file: `tile-mock.ts`** — Creates a Playwright fixture that intercepts all OpenFreeMap requests at the network boundary
  - Style requests receive a minimal valid MapLibre style with no sources or layers, allowing the map to fire its `load` event without fetching external assets
  - All other requests (tiles, sprites, glyphs) are served with empty 204 responses to prevent network escapes
  - Tracks call count for test assertions
  - Extends the existing `nominatim-mock` fixture to compose multiple mocks

- **Updated: `fixtures.ts`** — Changes the base fixture from `nominatimBase` to `tileBase` so all E2E tests inherit both Nominatim and tile mocking

## Implementation Details

The mock uses Playwright's `context.route()` API to intercept requests matching `**/tiles.openfreemap.org/**`. Style requests are identified by checking if the pathname includes `/styles/` and receive a valid JSON response; all other requests get empty 204 responses. This approach keeps tests deterministic while allowing the app to add its own GeoJSON sources and layers after the map loads.

https://claude.ai/code/session_016sM5kVsVqHLhFnTek1dsq4