### PR TITLE
Fix badge layout in listing detail header

### DIFF
--- a/apps/www/src/routes/listing-show.css
+++ b/apps/www/src/routes/listing-show.css
@@ -21,7 +21,13 @@
 			display: flex;
 			justify-content: space-between;
 			align-items: flex-start;
+			gap: 4px;
 			margin-bottom: 0;
+		}
+
+		& .listing-detail-header .badge {
+			flex-shrink: 0;
+			white-space: nowrap;
 		}
 
 		& .listing-detail-header h1 {


### PR DESCRIPTION
## Summary
Improves the layout of badges in the listing detail header by preventing text wrapping and ensuring proper spacing between header elements.

## Changes
- Added `gap: 4px` to the header flex container for consistent spacing between title and badges
- Added new styles for `.listing-detail-header .badge` to prevent shrinking and text wrapping:
  - `flex-shrink: 0` ensures badges maintain their size
  - `white-space: nowrap` prevents badge text from wrapping to multiple lines

## Details
These changes ensure that badges display cleanly alongside the listing title without being compressed or having their text break across lines, improving the visual presentation of the listing detail header.

https://claude.ai/code/session_015v11LRkFU5pKR2A22MCF1H