### PR TITLE
Reorder form fields: move Notes section to end

### DIFF
--- a/apps/www/src/components/ListingForm.tsx
+++ b/apps/www/src/components/ListingForm.tsx
@@ -341,17 +341,6 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 					</div>
 				</fieldset>
 
-				<fieldset>
-					<legend>Notes</legend>
-					<Textarea
-						errors={fieldErrors().properties?.notes?.errors}
-						label="Additional Details"
-						name="notes"
-						placeholder="e.g., Ring doorbell first. Take a few or take 'em all!"
-						rows={3}
-					/>
-				</fieldset>
-
 				<fieldset class="address-release-fieldset">
 					<legend>How is your address shared?</legend>
 					<label class="address-release-option">
@@ -387,6 +376,17 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 							</span>
 						</span>
 					</label>
+				</fieldset>
+
+				<fieldset>
+					<legend>Notes</legend>
+					<Textarea
+						errors={fieldErrors().properties?.notes?.errors}
+						label="Additional Details"
+						name="notes"
+						placeholder="e.g., Ring doorbell first. Take a few or take 'em all!"
+						rows={3}
+					/>
 				</fieldset>
 
 				<div class="form-actions">


### PR DESCRIPTION
## Summary
Reordered the ListingForm fields to improve the user experience by moving the Notes section to the end of the form, after the address sharing options.

## Changes
- Moved the "Notes" fieldset from its original position (after the main listing details) to the end of the form (before the submit button)
- The "How is your address shared?" section now appears before the Notes section
- No functional changes to the form logic or validation

## Rationale
This reordering puts the Address fields next to the How is Your Address Shared, increasing cohesion.

This reordering also places the optional Notes field at the end, allowing users to complete the required fields first and then add additional details if desired. This follows a common form pattern of progressing from essential information to supplementary details.

https://claude.ai/code/session_01M2gmY9Kbrs7nXhukpzP7EH