### PR TITLE
Fix high-leverage issues from repository review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ A site for gardeners to share surplus produce with their community.
 - Use idiomatic Solid JS, TanStack Router, TypeScript, SQLite.
 - Use context7
 - When handling exceptions, import Sentry from `@/lib/sentry` and use `Sentry.captureException`. Do not separately log errors — `src/lib/sentry.ts` is the designated exception handler and manages console output itself. (Exception: `sentry.ts` itself uses `console.error` because it runs on both client and server and cannot depend on Pino.)
-- For server-side informational/debug logging, import `logger` from `@/lib/logger.server` (Pino). Always pass structured data as the first argument: `logger.info(fields, msg)`, `logger.debug(fields, msg)`, `logger.warn(fields, msg)`. Use `logger.error(fields, msg)` only in CLI scripts (e.g. `seed.ts`) where Sentry is not initialized — in all other server code, use `Sentry.captureException` for errors. Do **not** use `console.log` or `console.error` in application code. (Exception: test infrastructure files such as `vitest-global-setup.ts` may use `console.log`.)
+- For server-side informational/debug logging, import `logger` from `@/lib/logger.server` (Pino). Always pass structured data as the first argument: `logger.info(fields, msg)`, `logger.debug(fields, msg)`, `logger.warn(fields, msg)`. Use `logger.error(fields, msg)` only in CLI scripts (e.g. `seed.server.ts`) where Sentry is not initialized — in all other server code, use `Sentry.captureException` for errors. Do **not** use `console.log` or `console.error` in application code. (Exception: test infrastructure files such as `vitest-global-setup.ts` may use `console.log`.)
 
 ### Solid JS
 
@@ -167,4 +167,3 @@ The only service is the **Solid JS web application** in `apps/www`. It uses an e
 - **Magic link auth in dev**: `EMAIL_PROVIDER=console` (default) logs the magic link token to the Vite dev server stdout. Look for the Pino log line with `token:` to extract it for manual testing.
 - **E2E test server**: Playwright starts its own Vite dev server on port 5174 with test-specific env vars (`reuseExistingServer: false`). The port-5173 dev server does not interfere.
 - **pnpm build script warnings**: `pnpm install` may show "Ignored build scripts" for `esbuild`, `sharp`, `@parcel/watcher`, `@sentry/cli`. The platform-specific binaries are still installed correctly via optional dependencies; these warnings are safe to ignore.
-- **`pnpm db:seed` script reference**: The `package.json` `db:seed` script references `src/data/seed.ts` but the actual file is `src/data/seed.server.ts`. The seed script will fail; this is a known discrepancy in the repo.

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -26,7 +26,7 @@
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
 		"db:push": "drizzle-kit push",
-		"db:seed": "vite-node src/data/seed.ts",
+		"db:seed": "vite-node src/data/seed.server.ts",
 		"deploy": "fly deploy",
 		"deploy:setup": "fly launch --no-deploy",
 		"logs": "fly logs",

--- a/apps/www/src/api/listings.ts
+++ b/apps/www/src/api/listings.ts
@@ -49,9 +49,17 @@ export const getMyLastAddress = createServerFn({ method: 'GET' })
 		return getUserLastAddress(session.user.id)
 	})
 
+const availableListingsLimitSchema = z
+	.number()
+	.int()
+	.positive()
+	.max(50)
+	.default(3)
+
+/** Fetches the most recently created available listings. */
 export const getAvailableListings = createServerFn({ method: 'GET' })
 	.middleware([errorMiddleware])
-	.inputValidator((limit: number = 3) => limit)
+	.inputValidator((limit?: number) => availableListingsLimitSchema.parse(limit))
 	.handler(async ({ data: limit }) => {
 		const { getAvailableListings: query } = await import('@/data/queries.server')
 		return query(limit)

--- a/apps/www/src/components/ListingCard.tsx
+++ b/apps/www/src/components/ListingCard.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@tanstack/solid-router'
 import { Apple } from 'lucide-solid'
 import { Show } from 'solid-js'
-import { getStatusVariant } from '@/lib/listing-status'
+import { getStatusLabel, getStatusVariant } from '@/lib/listing-status'
 import { formatListingLocation } from '@/lib/format-location'
 import { PRODUCE_STAND_SLUG } from '@/lib/produce-types'
 import DropOffIndicator from '@/components/DropOffIndicator'
@@ -68,7 +68,7 @@ export default function ListingCard(props: { listing: ListingCardData }) {
 						<span
 							class={`listing-card-status listing-card-status--${getStatusVariant(status())}`}
 						>
-							{status()}
+							{getStatusLabel(status())}
 						</span>
 					)}
 				</Show>

--- a/apps/www/src/lib/listing-status.ts
+++ b/apps/www/src/lib/listing-status.ts
@@ -45,6 +45,13 @@ export function getStatusVariant(status: string): StatusVariant {
 	return statusVariantMap[status as ListingStatusValue] ?? 'private'
 }
 
+/** Maps a listing status string to its user-facing label. */
+export function getStatusLabel(status: string): string {
+	return (
+		VISIBILITY_OPTIONS.find((option) => option.value === status)?.label ?? status
+	)
+}
+
 /** The two address-release policies, with the same shape as VISIBILITY_OPTIONS. */
 export const ADDRESS_RELEASE_OPTIONS = [
 	{

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -82,8 +82,8 @@ function HomePage() {
 								</div>
 								<div class="step">
 									<div class="step-number">2</div>
-									<h3>We match you with neighbors</h3>
-									<p>You get notified</p>
+									<h3>Neighbors find your listing</h3>
+									<p>You get an email when someone wants to pick</p>
 								</div>
 								<div class="step">
 									<div class="step-number">3</div>

--- a/apps/www/src/routes/listings.$id.tsx
+++ b/apps/www/src/routes/listings.$id.tsx
@@ -17,6 +17,7 @@ import { ListingDetailField } from '@/components/ListingDetailField'
 import {
 	ADDRESS_RELEASE_OPTIONS,
 	addressReleaseSemanticColor,
+	getStatusLabel,
 	getStatusVariant,
 	VISIBILITY_OPTIONS,
 	statusSemanticColor,
@@ -1023,7 +1024,7 @@ function ListingDetailPage() {
 								<header class="listing-detail-header">
 									<h1>{displayTitle()}</h1>
 									<span class={`badge badge--${getStatusVariant(l().status)}`}>
-										{l().status}
+										{getStatusLabel(l().status)}
 									</span>
 								</header>
 							</Show>

--- a/apps/www/src/routes/privacy.tsx
+++ b/apps/www/src/routes/privacy.tsx
@@ -15,7 +15,7 @@ function PrivacyPage() {
 			<main id="main-content">
 				<div class="container privacy-policy">
 					<h1>Privacy Policy</h1>
-					<p class="effective-date">Effective date: March 7, 2026</p>
+					<p class="effective-date">Effective date: June 12, 2026</p>
 
 					<p>
 						Pick My Fruit ("we", "us", or "our") operates pickmyfruit.com. This policy
@@ -56,11 +56,22 @@ function PrivacyPage() {
 							</strong>
 						</p>
 						<p>
-							Your precise address is shared with another user only if you explicitly
-							choose to share it — for example, when you agree to a pick-up and decide
-							to reveal your door-step location. We will always ask for your permission
-							before disclosing anything more specific than your approximate area.
+							When and how your precise address is shared depends on the sharing
+							setting you choose for each listing:
 						</p>
+						<ul>
+							<li>
+								<strong>Approve each request</strong> (the default) — your address is
+								shared with a requester only after you approve their request.
+							</li>
+							<li>
+								<strong>Share with verified members</strong> — any signed-in member with
+								a verified email address can view the address without asking you first.
+								Choose this only if you are comfortable treating the location as
+								effectively public. We keep a record of each time the address is viewed
+								this way.
+							</li>
+						</ul>
 					</section>
 
 					<section>

--- a/apps/www/src/server-boot.server.ts
+++ b/apps/www/src/server-boot.server.ts
@@ -35,5 +35,13 @@ export const migrationsReady = runMigrations().then(async () => {
 		registerShutdown()
 	} catch (err) {
 		Sentry.captureException(err)
+		// Rethrow so bootReadyMiddleware fails every request (including the Fly
+		// health check) with a 503 instead of serving traffic with a dead
+		// workflow runtime that would enqueue inquiries nobody processes.
+		throw err
 	}
 })
+
+// Pre-attach a handler so a boot failure before the first request doesn't
+// crash the process as an unhandled rejection; awaiters still see the error.
+void migrationsReady.catch(() => {})

--- a/apps/www/tests/e2e/listing-detail.test.ts
+++ b/apps/www/tests/e2e/listing-detail.test.ts
@@ -24,7 +24,9 @@ test.describe('Listing Detail Page', () => {
 		).toBeVisible()
 
 		// Verify status badge
-		await expect(page.locator('.badge')).toHaveText(testListing.status)
+		await expect(page.locator('.badge')).toHaveText(testListing.status, {
+			ignoreCase: true,
+		})
 	})
 
 	test('shows not-found for non-existent listing', async ({ page }) => {

--- a/docs/0003-inquiry-system.md
+++ b/docs/0003-inquiry-system.md
@@ -85,7 +85,7 @@ CREATE INDEX inquiry_gleaner_id_idx ON inquiries(gleaner_id);
 | File | Changes |
 |------|---------|
 | `src/data/schema.ts` | Add `inquiries` table, add `deletedAt` to plants, export types |
-| `src/data/queries.ts` | Add inquiry queries, update status filter to `active`, add soft delete check |
+| `src/data/queries.server.ts` | Add inquiry queries, update status filter to `active`, add soft delete check |
 | `src/lib/validation.ts` | Add `inquiryFormSchema`, `updateListingStatusSchema` |
 | `src/routes/garden/mine.tsx` | Add status toggle button, update status badge classes |
 | `src/routes/garden/mine.css` | Add styles for new status values and toggle button |
@@ -94,7 +94,7 @@ CREATE INDEX inquiry_gleaner_id_idx ON inquiries(gleaner_id);
 
 ---
 
-## Query Functions (`src/data/queries.ts`)
+## Query Functions (`src/data/queries.server.ts`)
 
 ### New Functions
 
@@ -484,7 +484,7 @@ Make plant cards clickable:
 ### Phase 1: Database Layer (atomic - deploy together)
 1. Update `src/data/schema.ts` - add inquiries table, add deletedAt to plants
 2. Create migration `drizzle/0003_add_inquiries.sql`
-3. Update `src/data/queries.ts` - all query changes (status filter, soft delete, new functions)
+3. Update `src/data/queries.server.ts` - all query changes (status filter, soft delete, new functions)
 4. Run migration, then deploy code
 
 ### Phase 2: Utilities

--- a/fly.toml
+++ b/fly.toml
@@ -34,7 +34,9 @@ primary_region = 'sjc'
   force_https = false # handled in @/middleware/tls
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  # Keep one machine awake so kokoto retry timers fire without waiting for
+  # inbound traffic — a stopped machine would stall queued email retries.
+  min_machines_running = 1
   processes = ['app']
 
   # HTTP request timeouts.


### PR DESCRIPTION
- server-boot: rethrow kokoto startup failures so bootReadyMiddleware (and the Fly health check) fail loudly instead of serving traffic with a dead workflow runtime that would silently drop inquiries
- fly.toml: keep one machine running so kokoto retry timers fire without waiting for inbound traffic to wake the app
- api/listings: clamp getAvailableListings limit (int, positive, ≤50) to match getNearbyListings instead of passing it through unvalidated
- package.json: fix db:seed to point at seed.server.ts; drop the now-stale known-issue note from AGENTS.md and fix seed/queries file references in AGENTS.md and docs/0003
- listing-status: add getStatusLabel and use it for the listing detail badge and ListingCard status chip instead of raw DB enum values
- home page: replace "We match you with neighbors" with copy that describes the actual browse-and-inquire flow
- privacy policy: describe both address-release policies instead of promising per-request permission that on_verified_request doesn't ask for; bump effective date