### PR TITLE
Add CSRF protection middleware for server functions

### DIFF
--- a/apps/www/src/start.ts
+++ b/apps/www/src/start.ts
@@ -1,13 +1,23 @@
-import { createIsomorphicFn, createStart } from '@tanstack/solid-start'
+import {
+	createCsrfMiddleware,
+	createIsomorphicFn,
+	createStart,
+} from '@tanstack/solid-start'
 import { bootReadyMiddleware } from '@/middleware/boot-ready'
 import { mediaPreconnectMiddleware } from '@/middleware/media-preconnect'
 import { securityHeadersMiddleware } from '@/middleware/security-headers'
 import { tlsMiddleware } from '@/middleware/tls'
 
+/** Rejects cross-site requests to server functions, which are same-origin RPC endpoints. */
+const csrfMiddleware = createCsrfMiddleware({
+	filter: (ctx) => ctx.handlerType === 'serverFn',
+})
+
 export const startInstance = createStart(() => ({
 	requestMiddleware: [
 		bootReadyMiddleware, // await server-boot migrations before handlers run
 		tlsMiddleware, // May short-circuit with a redirect
+		csrfMiddleware, // Rejects cross-site server-function requests before they run
 		securityHeadersMiddleware, // Applies to all non-redirect responses
 		mediaPreconnectMiddleware, // HTML only — Link preconnect to media CDN (Tigris)
 	],


### PR DESCRIPTION
## Summary

Adds CSRF (Cross-Site Request Forgery) protection to the application by implementing a middleware that rejects cross-site requests to server functions, which serve as same-origin RPC endpoints.

## Changes

- Import `createCsrfMiddleware` from `@tanstack/solid-start`
- Create a `csrfMiddleware` instance configured to filter and protect server function handlers
- Add the CSRF middleware to the request middleware chain, positioned after TLS middleware but before security headers middleware to ensure protection runs early in the request lifecycle

## Implementation Details

The CSRF middleware is configured with a filter that targets only `serverFn` handler types, ensuring that legitimate server function calls from the same origin are allowed while cross-site requests are rejected. This protects the application's RPC endpoints from unauthorized cross-origin requests while maintaining normal application functionality.

https://claude.ai/code/session_01FgG9GmXuBeRDNWttyTxQAE