### PR TITLE
Add geolocation-based location bias for address suggestions

### DIFF
--- a/apps/www/src/components/AddressAutosuggest.tsx
+++ b/apps/www/src/components/AddressAutosuggest.tsx
@@ -1,9 +1,22 @@
-import { createSignal, createUniqueId, For, onCleanup, Show } from 'solid-js'
+import {
+	createSignal,
+	createUniqueId,
+	For,
+	onCleanup,
+	onMount,
+	Show,
+} from 'solid-js'
 import {
 	fetchAddressSuggestions,
+	fetchReverseGeocodedAddress,
 	SuggestionsUnavailableError,
 	type AddressSuggestion,
 } from '@/lib/address-suggestions'
+import {
+	NAPA_CITY_HALL,
+	requestCurrentLocation,
+	type LocationBias,
+} from '@/lib/geolocation'
 import { Sentry } from '@/lib/sentry'
 import '@/components/AddressAutosuggest.css'
 
@@ -31,6 +44,11 @@ export interface AddressAutosuggestProps {
  * the structured address and its coordinates via `onSelect`. Degrades to a
  * status message (never an error wall) when the suggestion service fails —
  * the manual-entry fallback rendered by the parent stays available.
+ *
+ * On mount it asks for the user's position (the browser shows its permission
+ * prompt) to bias suggestion ranking; when granted and the field is empty,
+ * the position is also reverse-geocoded to prepopulate the address.
+ * See docs/0012-geolocation-location-bias.md.
  */
 export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 	const inputId = createUniqueId()
@@ -45,6 +63,49 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 	const [open, setOpen] = createSignal(false)
 	const [activeIndex, setActiveIndex] = createSignal(-1)
 	const [status, setStatus] = createSignal<SuggestStatus>('idle')
+	// Until (and unless) the user grants access to their position, searches
+	// are biased toward the launch city so a typed-before-answering query
+	// still gets deterministic ranking.
+	const [bias, setBias] = createSignal<LocationBias>(NAPA_CITY_HALL)
+
+	// Once the user has typed or picked anything, the field is theirs — the
+	// reverse-geocoded prepopulation must never overwrite it.
+	let userInteracted = false
+	const prepopulateAbort = new AbortController()
+	onCleanup(() => prepopulateAbort.abort())
+
+	onMount(() => void initLocationBias())
+
+	async function initLocationBias() {
+		const position = await requestCurrentLocation()
+		if (!position) return
+		setBias(position)
+		await prepopulateFrom(position)
+	}
+
+	// Fills the empty field with the address at the user's position, applied
+	// exactly like a picked suggestion. Best-effort: any failure is silent,
+	// and the user's own input always wins.
+	async function prepopulateFrom(position: LocationBias) {
+		if (userInteracted || query() !== '' || props.defaultSelection) return
+		let suggestion: AddressSuggestion | null
+		try {
+			suggestion = await fetchReverseGeocodedAddress(position, {
+				signal: prepopulateAbort.signal,
+			})
+		} catch (err) {
+			if (err instanceof DOMException && err.name === 'AbortError') return
+			if (!(err instanceof SuggestionsUnavailableError)) {
+				Sentry.captureException(err)
+			}
+			return
+		}
+		if (!suggestion) return
+		// Re-check: the user may have started typing while the request ran.
+		if (userInteracted || query() !== '') return
+		setQuery(suggestion.label)
+		props.onSelect(suggestion)
+	}
 
 	const hasErrors = () => (props.errors?.length ?? 0) > 0
 
@@ -108,6 +169,7 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 		try {
 			const results = await fetchAddressSuggestions(value, {
 				signal: controller.signal,
+				bias: bias(),
 			})
 			if (seq !== requestSeq) return
 			setSuggestions(results)
@@ -127,6 +189,7 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 	}
 
 	function handleInput(event: InputEvent) {
+		userInteracted = true
 		const value = (event.currentTarget as HTMLInputElement).value
 		setQuery(value)
 		// Any edit invalidates a previous selection — the text no longer
@@ -144,6 +207,7 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 	}
 
 	function select(suggestion: AddressSuggestion) {
+		userInteracted = true
 		cancelPending()
 		setQuery(suggestion.label)
 		setSuggestions([])

--- a/apps/www/src/components/AddressAutosuggest.tsx
+++ b/apps/www/src/components/AddressAutosuggest.tsx
@@ -26,14 +26,26 @@ export const SUGGEST_DEBOUNCE_MS = 300
 /** Queries shorter than this are too ambiguous to be worth a request. */
 const MIN_QUERY_LENGTH = 3
 
-type SuggestStatus = 'idle' | 'loading' | 'empty' | 'error'
+type SuggestStatus = 'idle' | 'loading' | 'empty' | 'error' | 'prepopulated'
 
 export interface AddressAutosuggestProps {
+	/**
+	 * When false, the position-based prepopulation is suppressed — e.g. the
+	 * user already touched the address during a previous mount of this
+	 * component, so the field is theirs even though this instance is fresh.
+	 */
+	allowPrepopulate?: boolean
 	/** Pre-selected suggestion (e.g. rebuilt from the user's last listing). */
 	defaultSelection?: AddressSuggestion | null
 	disabled?: boolean
 	errors?: string[]
 	hint?: string
+	/**
+	 * Fires once, on the user's first focus/edit/pick — never for the
+	 * prepopulation. Lets the parent remember that the field belongs to the
+	 * user across remounts (see `allowPrepopulate`).
+	 */
+	onInteract?: () => void
 	/** Fires with the chosen suggestion, or null when the text is edited. */
 	onSelect: (selection: AddressSuggestion | null) => void
 }
@@ -68,11 +80,17 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 	// still gets deterministic ranking.
 	const [bias, setBias] = createSignal<LocationBias>(NAPA_CITY_HALL)
 
-	// Once the user has typed or picked anything, the field is theirs — the
-	// reverse-geocoded prepopulation must never overwrite it.
+	// Once the user has focused, typed, or picked anything, the field is
+	// theirs — the reverse-geocoded prepopulation must never overwrite it.
 	let userInteracted = false
 	const prepopulateAbort = new AbortController()
 	onCleanup(() => prepopulateAbort.abort())
+
+	function markInteracted() {
+		if (userInteracted) return
+		userInteracted = true
+		props.onInteract?.()
+	}
 
 	onMount(() => void initLocationBias())
 
@@ -87,6 +105,7 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 	// exactly like a picked suggestion. Best-effort: any failure is silent,
 	// and the user's own input always wins.
 	async function prepopulateFrom(position: LocationBias) {
+		if (props.allowPrepopulate === false) return
 		if (userInteracted || query() !== '' || props.defaultSelection) return
 		let suggestion: AddressSuggestion | null
 		try {
@@ -101,9 +120,12 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 			return
 		}
 		if (!suggestion) return
-		// Re-check: the user may have started typing while the request ran.
+		// Re-check: the user may have claimed the field while the request ran.
 		if (userInteracted || query() !== '') return
 		setQuery(suggestion.label)
+		// Announce the change — both for screen readers (the value changed
+		// without any user action) and as a visible nudge to verify the guess.
+		setStatus('prepopulated')
 		props.onSelect(suggestion)
 	}
 
@@ -122,6 +144,8 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 				return 'No matching addresses. Check the spelling, or enter the address manually below.'
 			case 'error':
 				return 'Suggestions are unavailable right now. Enter the address manually below.'
+			case 'prepopulated':
+				return 'Filled in from your current location. Edit if different.'
 			default:
 				return ''
 		}
@@ -189,9 +213,11 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 	}
 
 	function handleInput(event: InputEvent) {
-		userInteracted = true
+		markInteracted()
 		const value = (event.currentTarget as HTMLInputElement).value
 		setQuery(value)
+		// The prepopulation notice describes a value the user just replaced.
+		if (status() === 'prepopulated') setStatus('idle')
 		// Any edit invalidates a previous selection — the text no longer
 		// matches the suggestion's coordinates.
 		props.onSelect(null)
@@ -207,7 +233,7 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 	}
 
 	function select(suggestion: AddressSuggestion) {
-		userInteracted = true
+		markInteracted()
 		cancelPending()
 		setQuery(suggestion.label)
 		setSuggestions([])
@@ -276,6 +302,9 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 				disabled={props.disabled}
 				id={inputId}
 				onBlur={handleBlur}
+				// Focusing claims the field: a prepopulation landing under the
+				// user's caret would corrupt what they're about to type.
+				onFocus={markInteracted}
 				onInput={handleInput}
 				onKeyDown={handleKeyDown}
 				placeholder="Start typing your address…"

--- a/apps/www/src/components/AddressAutosuggest.tsx
+++ b/apps/www/src/components/AddressAutosuggest.tsx
@@ -341,6 +341,11 @@ export default function AddressAutosuggest(props: AddressAutosuggestProps) {
 			    changes for screen readers to announce it. */}
 			<p class="address-autosuggest__status" id={statusId} role="status">
 				{statusMessage()}
+				{/* A value change on an unfocused input is never announced, so
+				    speak the filled-in address; sighted users already see it. */}
+				<Show when={status() === 'prepopulated'}>
+					<span class="sr-only"> The address is {query()}.</span>
+				</Show>
 			</p>
 			<Show when={props.hint}>
 				<div class="form-field__hint" id={hintId}>

--- a/apps/www/src/components/ListingForm.tsx
+++ b/apps/www/src/components/ListingForm.tsx
@@ -56,6 +56,10 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 	const [addressSelectionError, setAddressSelectionError] = createSignal<
 		string | null
 	>(null)
+	// Once the user touches the address, it stays theirs: the autosuggest
+	// remounts when manual entry is toggled, and a fresh mount would otherwise
+	// re-prepopulate a field the user deliberately cleared.
+	const [addressInteracted, setAddressInteracted] = createSignal(false)
 
 	// Manual entry starts from the picked suggestion when there is one (the
 	// user is likely correcting it), else from the last listing's address.
@@ -493,6 +497,7 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 						}
 					>
 						<AddressAutosuggest
+							allowPrepopulate={!addressInteracted()}
 							defaultSelection={selectedAddress()}
 							disabled={isSubmitting()}
 							errors={
@@ -501,6 +506,7 @@ export default function ListingForm(props: { defaultAddress?: AddressFields }) {
 									: fieldErrors().properties?.address?.errors
 							}
 							hint="Others will see your neighborhood, but not your exact address."
+							onInteract={() => setAddressInteracted(true)}
 							onSelect={setSelectedAddress}
 						/>
 						<button

--- a/apps/www/src/lib/address-suggestions.ts
+++ b/apps/www/src/lib/address-suggestions.ts
@@ -210,7 +210,8 @@ export async function fetchAddressSuggestions(
 ): Promise<AddressSuggestion[]> {
 	// Unlike geocoding.ts this runs per keystroke, so only the length is
 	// breadcrumbed — never the partial address itself (nor the bias point,
-	// which may be the user's position).
+	// which may be the user's position). The SDK's own fetch breadcrumbs and
+	// spans are scrubbed of these URLs' query strings in sentry.ts.
 	Sentry.addBreadcrumb({
 		category: 'address-suggestions',
 		level: 'info',

--- a/apps/www/src/lib/address-suggestions.ts
+++ b/apps/www/src/lib/address-suggestions.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import type { AddressFields } from '@/data/schema.server'
 import { countryName } from '@/lib/format-location'
+import type { LocationBias } from '@/lib/geolocation'
 import { Sentry } from '@/lib/sentry'
 
 /** A structured address suggestion with its coordinates. */
@@ -34,6 +35,8 @@ export class SuggestionsUnavailableError extends Error {
 // Like Nominatim in geocoding.ts, requests come directly from the browser.
 // @see docs/0011-international-address-entry.md
 const SUGGEST_URL = 'https://photon.komoot.io/api/?limit=5&lang=en'
+// @see docs/0012-geolocation-location-bias.md
+const REVERSE_URL = 'https://photon.komoot.io/reverse?limit=1&lang=en'
 
 const photonFeatureSchema = z.object({
 	geometry: z.object({
@@ -129,7 +132,69 @@ export function addressFieldsToSuggestion(
 }
 
 /**
- * Fetch address suggestions for a partial query from Photon.
+ * Fetches a Photon endpoint and maps its features to suggestions, skipping
+ * any feature that lacks the parts a listing needs.
+ *
+ * @throws {SuggestionsUnavailableError} on network, HTTP, or response-shape
+ * failures
+ * @throws {DOMException} `AbortError` is re-thrown untouched so callers can
+ * silently drop stale in-flight requests
+ */
+async function fetchPhotonSuggestions(
+	url: URL,
+	signal?: AbortSignal
+): Promise<AddressSuggestion[]> {
+	let response: Response
+	try {
+		response = await fetch(url.toString(), { signal })
+	} catch (err) {
+		if (err instanceof DOMException && err.name === 'AbortError') throw err
+		throw new SuggestionsUnavailableError(
+			err instanceof Error ? err.message : 'Network error fetching suggestions'
+		)
+	}
+
+	if (!response.ok) {
+		Sentry.captureMessage('suggestions.request_failed', {
+			level: 'warning',
+			extra: { status: response.status },
+		})
+		throw new SuggestionsUnavailableError(
+			`Suggestion request failed: ${response.status}`
+		)
+	}
+
+	let json: unknown
+	try {
+		json = await response.json()
+	} catch {
+		throw new SuggestionsUnavailableError(
+			'Suggestion response was not valid JSON'
+		)
+	}
+
+	const parsed = photonResponseSchema.safeParse(json)
+	if (!parsed.success) {
+		const err = new SuggestionsUnavailableError(
+			'Suggestion response did not match expected shape'
+		)
+		Sentry.captureException(err)
+		throw err
+	}
+
+	const suggestions: AddressSuggestion[] = []
+	for (const raw of parsed.data.features) {
+		const feature = photonFeatureSchema.safeParse(raw)
+		if (!feature.success) continue
+		const suggestion = toSuggestion(feature.data)
+		if (suggestion) suggestions.push(suggestion)
+	}
+	return suggestions
+}
+
+/**
+ * Fetch address suggestions for a partial query from Photon, optionally
+ * re-ranked toward a bias point (the results are biased, never filtered).
  *
  * Features that cannot be mapped to a usable suggestion are skipped, so the
  * result may be shorter than Photon's response (or empty).
@@ -141,10 +206,11 @@ export function addressFieldsToSuggestion(
  */
 export async function fetchAddressSuggestions(
 	query: string,
-	options: { signal?: AbortSignal } = {}
+	options: { signal?: AbortSignal; bias?: LocationBias } = {}
 ): Promise<AddressSuggestion[]> {
 	// Unlike geocoding.ts this runs per keystroke, so only the length is
-	// breadcrumbed — never the partial address itself.
+	// breadcrumbed — never the partial address itself (nor the bias point,
+	// which may be the user's position).
 	Sentry.addBreadcrumb({
 		category: 'address-suggestions',
 		level: 'info',
@@ -156,53 +222,36 @@ export async function fetchAddressSuggestions(
 		async () => {
 			const url = new URL(SUGGEST_URL)
 			url.searchParams.append('q', query)
-
-			let response: Response
-			try {
-				response = await fetch(url.toString(), { signal: options.signal })
-			} catch (err) {
-				if (err instanceof DOMException && err.name === 'AbortError') throw err
-				throw new SuggestionsUnavailableError(
-					err instanceof Error ? err.message : 'Network error fetching suggestions'
-				)
+			if (options.bias) {
+				url.searchParams.append('lat', String(options.bias.lat))
+				url.searchParams.append('lon', String(options.bias.lng))
 			}
+			return fetchPhotonSuggestions(url, options.signal)
+		}
+	)
+}
 
-			if (!response.ok) {
-				Sentry.captureMessage('suggestions.request_failed', {
-					level: 'warning',
-					extra: { status: response.status },
-				})
-				throw new SuggestionsUnavailableError(
-					`Suggestion request failed: ${response.status}`
-				)
-			}
-
-			let json: unknown
-			try {
-				json = await response.json()
-			} catch {
-				throw new SuggestionsUnavailableError(
-					'Suggestion response was not valid JSON'
-				)
-			}
-
-			const parsed = photonResponseSchema.safeParse(json)
-			if (!parsed.success) {
-				const err = new SuggestionsUnavailableError(
-					'Suggestion response did not match expected shape'
-				)
-				Sentry.captureException(err)
-				throw err
-			}
-
-			const suggestions: AddressSuggestion[] = []
-			for (const raw of parsed.data.features) {
-				const feature = photonFeatureSchema.safeParse(raw)
-				if (!feature.success) continue
-				const suggestion = toSuggestion(feature.data)
-				if (suggestion) suggestions.push(suggestion)
-			}
-			return suggestions
+/**
+ * Reverse-geocodes a position into a suggestion via Photon, or null when
+ * Photon returns nothing usable for a listing address.
+ *
+ * @throws {SuggestionsUnavailableError} on network, HTTP, or response-shape
+ * failures
+ * @throws {DOMException} `AbortError` is re-thrown untouched so callers can
+ * silently drop stale in-flight requests
+ */
+export async function fetchReverseGeocodedAddress(
+	location: LocationBias,
+	options: { signal?: AbortSignal } = {}
+): Promise<AddressSuggestion | null> {
+	return Sentry.startSpan(
+		{ name: 'suggestions.photon.reverse', op: 'http.client' },
+		async () => {
+			const url = new URL(REVERSE_URL)
+			url.searchParams.append('lat', String(location.lat))
+			url.searchParams.append('lon', String(location.lng))
+			const suggestions = await fetchPhotonSuggestions(url, options.signal)
+			return suggestions[0] ?? null
 		}
 	)
 }

--- a/apps/www/src/lib/geocoding.ts
+++ b/apps/www/src/lib/geocoding.ts
@@ -88,10 +88,12 @@ export async function geocodeAddress(
 ): Promise<GeocodingResult> {
 	const query = buildQuery(input)
 
+	// Only the length: the query is the user's full street address, which
+	// must not ride along on Sentry events (see redaction in sentry.ts).
 	Sentry.addBreadcrumb({
 		category: 'geocoding',
 		level: 'info',
-		data: { query },
+		data: { queryLength: query.length },
 	})
 
 	return Sentry.startSpan(

--- a/apps/www/src/lib/geolocation.ts
+++ b/apps/www/src/lib/geolocation.ts
@@ -1,0 +1,41 @@
+/** A point used to bias location-aware lookups. */
+export interface LocationBias {
+	lat: number
+	lng: number
+}
+
+/** Napa City Hall — the bias fallback when the user's position is unknown. */
+export const NAPA_CITY_HALL: LocationBias = {
+	lat: 38.2967151,
+	lng: -122.292037,
+}
+
+/**
+ * Asks the browser for the user's current position, resolving null on any
+ * non-success outcome (denied, unavailable, timed out, API missing). Denial
+ * is a normal answer, not an exception — nothing is reported or logged.
+ *
+ * A cached fix up to five minutes old at coarse accuracy is accepted: the
+ * position only biases address lookups, which never need GPS precision.
+ */
+export function requestCurrentLocation(): Promise<LocationBias | null> {
+	return new Promise((resolve) => {
+		if (typeof navigator === 'undefined' || !navigator.geolocation) {
+			resolve(null)
+			return
+		}
+		navigator.geolocation.getCurrentPosition(
+			(position) =>
+				resolve({
+					lat: position.coords.latitude,
+					lng: position.coords.longitude,
+				}),
+			() => resolve(null),
+			{
+				enableHighAccuracy: false,
+				maximumAge: 5 * 60_000,
+				timeout: 10_000,
+			}
+		)
+	})
+}

--- a/apps/www/src/lib/sentry.ts
+++ b/apps/www/src/lib/sentry.ts
@@ -68,7 +68,10 @@ export function redactGeoBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb {
 export function redactGeoSpan(span: SpanJSON): SpanJSON {
 	let touchesGeoService = false
 	if (span.data) {
-		for (const key of ['http.url', 'url.full'] as const) {
+		// Browser fetch spans carry the full URL in `url` and `http.url`
+		// (see @sentry/core's getFetchSpanAttributes); server-side HTTP
+		// instrumentation uses `url.full`.
+		for (const key of ['url', 'http.url', 'url.full'] as const) {
 			const value = span.data[key]
 			if (typeof value !== 'string') continue
 			const redacted = redactGeoServiceUrl(value)
@@ -77,8 +80,12 @@ export function redactGeoSpan(span: SpanJSON): SpanJSON {
 				touchesGeoService = true
 			}
 		}
-		// The raw query string would undo the URL redaction.
-		if (touchesGeoService) delete span.data['http.query']
+		// The standalone query/fragment attributes would undo the redaction.
+		if (touchesGeoService) {
+			delete span.data['http.query']
+			delete span.data['url.query']
+			delete span.data['http.fragment']
+		}
 	}
 	if (typeof span.description === 'string') {
 		span.description = span.description.replace(

--- a/apps/www/src/lib/sentry.ts
+++ b/apps/www/src/lib/sentry.ts
@@ -11,9 +11,83 @@ import {
 	startSpan,
 	withScope,
 } from '@sentry/solidstart'
-import type { CaptureContext, SeverityLevel } from '@sentry/solidstart'
+import type {
+	Breadcrumb,
+	CaptureContext,
+	SeverityLevel,
+} from '@sentry/solidstart'
 import { clientEnv } from './env'
 import isNetworkError from 'is-network-error'
+
+// The serialized span shape `beforeSendSpan` receives; the SDK does not
+// re-export its `SpanJSON` type, so derive it from the option's signature.
+type SpanJSON = Parameters<
+	NonNullable<NonNullable<Parameters<typeof init>[0]>['beforeSendSpan']>
+>[0]
+
+// Query strings on these hosts carry user-typed addresses or the user's raw
+// coordinates (geocoding, suggestions, reverse geocoding). They must never
+// reach Sentry, where they would ride along on error events and traces.
+const GEO_SERVICE_HOSTS = new Set([
+	'photon.komoot.io',
+	'nominatim.openstreetmap.org',
+])
+
+/**
+ * Strips the query string from geocoding-service URLs; all other strings are
+ * returned untouched.
+ */
+export function redactGeoServiceUrl(url: string): string {
+	try {
+		const parsed = new URL(url)
+		if (GEO_SERVICE_HOSTS.has(parsed.hostname)) {
+			return parsed.origin + parsed.pathname
+		}
+	} catch {
+		// Relative URL or not a URL at all — nothing to redact.
+	}
+	return url
+}
+
+/**
+ * Redacts geocoding-service URLs in a breadcrumb. The SDK's default fetch
+ * instrumentation records every request's full URL in `data.url`.
+ */
+export function redactGeoBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb {
+	if (typeof breadcrumb.data?.url === 'string') {
+		breadcrumb.data.url = redactGeoServiceUrl(breadcrumb.data.url)
+	}
+	return breadcrumb
+}
+
+/**
+ * Redacts geocoding-service URLs in a span. Browser tracing's fetch
+ * instrumentation stores the full URL in the span name/description and in
+ * the `http.url`/`url.full`/`http.query` attributes.
+ */
+export function redactGeoSpan(span: SpanJSON): SpanJSON {
+	let touchesGeoService = false
+	if (span.data) {
+		for (const key of ['http.url', 'url.full'] as const) {
+			const value = span.data[key]
+			if (typeof value !== 'string') continue
+			const redacted = redactGeoServiceUrl(value)
+			if (redacted !== value) {
+				span.data[key] = redacted
+				touchesGeoService = true
+			}
+		}
+		// The raw query string would undo the URL redaction.
+		if (touchesGeoService) delete span.data['http.query']
+	}
+	if (typeof span.description === 'string') {
+		span.description = span.description.replace(
+			/https?:\/\/\S+/g,
+			(url: string) => redactGeoServiceUrl(url)
+		)
+	}
+	return span
+}
 
 const isServer = typeof window === 'undefined'
 const environment = isServer ? 'server' : 'client'
@@ -88,8 +162,9 @@ if (clientEnv.sentryDsn) {
 					}
 				}
 			}
-			return breadcrumb
+			return redactGeoBreadcrumb(breadcrumb)
 		},
+		beforeSendSpan: redactGeoSpan,
 		beforeSend(event, hint) {
 			const err = hint.originalException
 			if (isControlFlow(err)) return null

--- a/apps/www/src/middleware/security-headers.ts
+++ b/apps/www/src/middleware/security-headers.ts
@@ -52,9 +52,11 @@ export function applySecurityHeaders(
 	headers.set('X-Frame-Options', 'DENY')
 	headers.set('X-Content-Type-Options', 'nosniff')
 	headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
+	// geolocation=(self): the New Listing form asks for the user's position
+	// to bias address suggestions (docs/0012-geolocation-location-bias.md).
 	headers.set(
 		'Permissions-Policy',
-		['camera=()', 'microphone=()', 'geolocation=()', 'payment=()'].join(', ')
+		['camera=()', 'microphone=()', 'geolocation=(self)', 'payment=()'].join(', ')
 	)
 }
 

--- a/apps/www/tests/AddressAutosuggest.test.tsx
+++ b/apps/www/tests/AddressAutosuggest.test.tsx
@@ -26,15 +26,31 @@ vi.mock('../src/lib/env', () => ({
 vi.mock('../src/lib/address-suggestions', async (importOriginal) => {
 	const actual =
 		await importOriginal<typeof import('../src/lib/address-suggestions')>()
-	return { ...actual, fetchAddressSuggestions: vi.fn() }
+	return {
+		...actual,
+		fetchAddressSuggestions: vi.fn(),
+		fetchReverseGeocodedAddress: vi.fn(),
+	}
 })
 
-const { fetchAddressSuggestions, SuggestionsUnavailableError } =
-	await import('../src/lib/address-suggestions')
+vi.mock('../src/lib/geolocation', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../src/lib/geolocation')>()
+	return { ...actual, requestCurrentLocation: vi.fn() }
+})
+
+const {
+	fetchAddressSuggestions,
+	fetchReverseGeocodedAddress,
+	SuggestionsUnavailableError,
+} = await import('../src/lib/address-suggestions')
+const { NAPA_CITY_HALL, requestCurrentLocation } =
+	await import('../src/lib/geolocation')
 const { default: AddressAutosuggest, SUGGEST_DEBOUNCE_MS } =
 	await import('../src/components/AddressAutosuggest')
 
 const mockFetchSuggestions = vi.mocked(fetchAddressSuggestions)
+const mockFetchReverse = vi.mocked(fetchReverseGeocodedAddress)
+const mockRequestLocation = vi.mocked(requestCurrentLocation)
 
 const PARIS: AddressSuggestion = {
 	label: '12 Rue de la Paix, Paris, Île-de-France, 75002, France',
@@ -86,6 +102,11 @@ async function typeAndSettle(input: HTMLInputElement, value: string) {
 beforeEach(() => {
 	vi.useFakeTimers()
 	mockFetchSuggestions.mockReset()
+	mockFetchReverse.mockReset()
+	mockFetchReverse.mockResolvedValue(null)
+	mockRequestLocation.mockReset()
+	// Most tests don't care about geolocation — behave as if unavailable.
+	mockRequestLocation.mockResolvedValue(null)
 })
 
 afterEach(() => {
@@ -233,6 +254,152 @@ describe('AddressAutosuggest — pending work is cancelled', () => {
 
 		expect(input.value).toBe(PARIS.label)
 		expect(queryByRole('listbox')).not.toBeInTheDocument()
+	})
+})
+
+const GRANTED_POSITION = { lat: 38.291859, lng: -122.458036 }
+
+const REVERSE_SUGGESTION: AddressSuggestion = {
+	label: '1600 Reverse Road, Sonoma, California, 95476, United States',
+	address: '1600 Reverse Road',
+	city: 'Sonoma',
+	state: 'California',
+	postcode: '95476',
+	countryCode: 'US',
+	lat: GRANTED_POSITION.lat,
+	lng: GRANTED_POSITION.lng,
+}
+
+describe('AddressAutosuggest — location bias', () => {
+	it('passes the granted position as the suggest bias', async () => {
+		mockRequestLocation.mockResolvedValue(GRANTED_POSITION)
+		mockFetchSuggestions.mockResolvedValue([NAPA])
+		const { input } = renderAutosuggest()
+		// Let the position promise resolve before typing.
+		await vi.advanceTimersByTimeAsync(0)
+
+		await typeAndSettle(input, 'school')
+
+		expect(mockFetchSuggestions).toHaveBeenCalledWith(
+			'school',
+			expect.objectContaining({ bias: GRANTED_POSITION })
+		)
+	})
+
+	it('falls back to the Napa City Hall bias when the position is unavailable', async () => {
+		mockRequestLocation.mockResolvedValue(null)
+		mockFetchSuggestions.mockResolvedValue([NAPA])
+		const { input } = renderAutosuggest()
+		await vi.advanceTimersByTimeAsync(0)
+
+		await typeAndSettle(input, 'school')
+
+		expect(mockFetchSuggestions).toHaveBeenCalledWith(
+			'school',
+			expect.objectContaining({ bias: NAPA_CITY_HALL })
+		)
+	})
+
+	it('uses the fallback bias while the position request is still pending', async () => {
+		// A user can type before answering the permission prompt.
+		mockRequestLocation.mockReturnValue(new Promise(() => {}))
+		mockFetchSuggestions.mockResolvedValue([NAPA])
+		const { input } = renderAutosuggest()
+
+		await typeAndSettle(input, 'school')
+
+		expect(mockFetchSuggestions).toHaveBeenCalledWith(
+			'school',
+			expect.objectContaining({ bias: NAPA_CITY_HALL })
+		)
+	})
+})
+
+describe('AddressAutosuggest — prepopulation from the granted position', () => {
+	it('prepopulates the empty field from the reverse geocode and reports the selection', async () => {
+		mockRequestLocation.mockResolvedValue(GRANTED_POSITION)
+		mockFetchReverse.mockResolvedValue(REVERSE_SUGGESTION)
+		const { input, onSelect } = renderAutosuggest()
+
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(mockFetchReverse).toHaveBeenCalledWith(
+			GRANTED_POSITION,
+			expect.anything()
+		)
+		expect(input.value).toBe(REVERSE_SUGGESTION.label)
+		expect(onSelect).toHaveBeenCalledWith(REVERSE_SUGGESTION)
+	})
+
+	it('skips the reverse geocode when a pre-filled selection exists', async () => {
+		mockRequestLocation.mockResolvedValue(GRANTED_POSITION)
+		mockFetchReverse.mockResolvedValue(REVERSE_SUGGESTION)
+		const { input } = renderAutosuggest({ defaultSelection: NAPA })
+
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(mockFetchReverse).not.toHaveBeenCalled()
+		expect(input.value).toBe(NAPA.label)
+	})
+
+	it('skips the reverse geocode when the position is unavailable', async () => {
+		mockRequestLocation.mockResolvedValue(null)
+		renderAutosuggest()
+
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(mockFetchReverse).not.toHaveBeenCalled()
+	})
+
+	it('does not clobber text typed while the reverse geocode is in flight', async () => {
+		mockRequestLocation.mockResolvedValue(GRANTED_POSITION)
+		let resolveReverse!: (s: AddressSuggestion | null) => void
+		mockFetchReverse.mockReturnValue(
+			new Promise((r) => {
+				resolveReverse = r
+			})
+		)
+		mockFetchSuggestions.mockResolvedValue([NAPA])
+		const { input, onSelect } = renderAutosuggest()
+		// Position resolves; the reverse geocode is now in flight.
+		await vi.advanceTimersByTimeAsync(0)
+
+		fireEvent.input(input, { target: { value: 'my own query' } })
+		resolveReverse(REVERSE_SUGGESTION)
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(input.value).toBe('my own query')
+		expect(onSelect).not.toHaveBeenCalledWith(REVERSE_SUGGESTION)
+	})
+
+	it('does not clobber text typed before the position resolves', async () => {
+		let resolvePosition!: (p: { lat: number; lng: number } | null) => void
+		mockRequestLocation.mockReturnValue(
+			new Promise((r) => {
+				resolvePosition = r
+			})
+		)
+		mockFetchReverse.mockResolvedValue(REVERSE_SUGGESTION)
+		mockFetchSuggestions.mockResolvedValue([NAPA])
+		const { input, onSelect } = renderAutosuggest()
+
+		fireEvent.input(input, { target: { value: 'my own query' } })
+		resolvePosition(GRANTED_POSITION)
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(input.value).toBe('my own query')
+		expect(onSelect).not.toHaveBeenCalledWith(REVERSE_SUGGESTION)
+	})
+
+	it('stays silent when the reverse geocode fails', async () => {
+		mockRequestLocation.mockResolvedValue(GRANTED_POSITION)
+		mockFetchReverse.mockRejectedValue(new SuggestionsUnavailableError('boom'))
+		const { input, queryByText } = renderAutosuggest()
+
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(input.value).toBe('')
+		expect(queryByText(/unavailable/i)).not.toBeInTheDocument()
 	})
 })
 

--- a/apps/www/tests/AddressAutosuggest.test.tsx
+++ b/apps/www/tests/AddressAutosuggest.test.tsx
@@ -405,6 +405,9 @@ describe('AddressAutosuggest — prepopulation from the granted position', () =>
 		expect(getByRole('status')).toHaveTextContent(
 			/filled in from your current location/i
 		)
+		// A value change on an unfocused input is not announced, so the live
+		// region must speak the filled-in address itself.
+		expect(getByRole('status')).toHaveTextContent('1600 Reverse Road')
 	})
 
 	it('clears the prepopulation notice once the user edits the field', async () => {
@@ -452,6 +455,15 @@ describe('AddressAutosuggest — prepopulation from the granted position', () =>
 
 		await typeAndSettle(input, 'school')
 		await typeAndSettle(input, 'school street')
+
+		expect(onInteract).toHaveBeenCalledTimes(1)
+	})
+
+	it('reports focus via onInteract so the claim survives remounts', async () => {
+		const onInteract = vi.fn()
+		const { input } = renderAutosuggest({ onInteract })
+
+		fireEvent.focus(input)
 
 		expect(onInteract).toHaveBeenCalledTimes(1)
 	})

--- a/apps/www/tests/AddressAutosuggest.test.tsx
+++ b/apps/www/tests/AddressAutosuggest.test.tsx
@@ -78,6 +78,8 @@ function renderAutosuggest(
 	props: {
 		onSelect?: (s: AddressSuggestion | null) => void
 		defaultSelection?: AddressSuggestion
+		allowPrepopulate?: boolean
+		onInteract?: () => void
 	} = {}
 ) {
 	const onSelect = props.onSelect ?? vi.fn()
@@ -85,6 +87,8 @@ function renderAutosuggest(
 		<AddressAutosuggest
 			onSelect={onSelect}
 			defaultSelection={props.defaultSelection}
+			allowPrepopulate={props.allowPrepopulate}
+			onInteract={props.onInteract}
 		/>
 	))
 	const input = utils.getByLabelText('Address', {
@@ -389,6 +393,78 @@ describe('AddressAutosuggest — prepopulation from the granted position', () =>
 
 		expect(input.value).toBe('my own query')
 		expect(onSelect).not.toHaveBeenCalledWith(REVERSE_SUGGESTION)
+	})
+
+	it('announces the prepopulation through the status live region', async () => {
+		mockRequestLocation.mockResolvedValue(GRANTED_POSITION)
+		mockFetchReverse.mockResolvedValue(REVERSE_SUGGESTION)
+		const { getByRole } = renderAutosuggest()
+
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(getByRole('status')).toHaveTextContent(
+			/filled in from your current location/i
+		)
+	})
+
+	it('clears the prepopulation notice once the user edits the field', async () => {
+		mockRequestLocation.mockResolvedValue(GRANTED_POSITION)
+		mockFetchReverse.mockResolvedValue(REVERSE_SUGGESTION)
+		mockFetchSuggestions.mockResolvedValue([NAPA])
+		const { input, getByRole } = renderAutosuggest()
+		await vi.advanceTimersByTimeAsync(0)
+
+		fireEvent.input(input, { target: { value: 'something else' } })
+
+		expect(getByRole('status')).not.toHaveTextContent(/current location/i)
+	})
+
+	it('skips prepopulation when the input is focused before the position resolves', async () => {
+		mockRequestLocation.mockResolvedValue(GRANTED_POSITION)
+		mockFetchReverse.mockResolvedValue(REVERSE_SUGGESTION)
+		const { input, onSelect } = renderAutosuggest()
+
+		// The user clicked into the field intending to type — it's theirs now,
+		// even though they haven't typed yet.
+		fireEvent.focus(input)
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(input.value).toBe('')
+		expect(onSelect).not.toHaveBeenCalled()
+	})
+
+	it('skips prepopulation when the parent disallows it', async () => {
+		mockRequestLocation.mockResolvedValue(GRANTED_POSITION)
+		mockFetchReverse.mockResolvedValue(REVERSE_SUGGESTION)
+		const { input, onSelect } = renderAutosuggest({ allowPrepopulate: false })
+
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(mockFetchReverse).not.toHaveBeenCalled()
+		expect(input.value).toBe('')
+		expect(onSelect).not.toHaveBeenCalled()
+	})
+
+	it('reports the first user interaction via onInteract', async () => {
+		const onInteract = vi.fn()
+		mockFetchSuggestions.mockResolvedValue([NAPA])
+		const { input } = renderAutosuggest({ onInteract })
+
+		await typeAndSettle(input, 'school')
+		await typeAndSettle(input, 'school street')
+
+		expect(onInteract).toHaveBeenCalledTimes(1)
+	})
+
+	it('does not report the prepopulation itself as an interaction', async () => {
+		const onInteract = vi.fn()
+		mockRequestLocation.mockResolvedValue(GRANTED_POSITION)
+		mockFetchReverse.mockResolvedValue(REVERSE_SUGGESTION)
+		renderAutosuggest({ onInteract })
+
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(onInteract).not.toHaveBeenCalled()
 	})
 
 	it('stays silent when the reverse geocode fails', async () => {

--- a/apps/www/tests/address-suggestions.test.ts
+++ b/apps/www/tests/address-suggestions.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
 	addressFieldsToSuggestion,
 	fetchAddressSuggestions,
+	fetchReverseGeocodedAddress,
 	SuggestionsUnavailableError,
 } from '../src/lib/address-suggestions'
 
@@ -115,6 +116,119 @@ describe('fetchAddressSuggestions — happy path', () => {
 		mockFetch(makePhotonResponse([]))
 
 		await expect(fetchAddressSuggestions('road to nowhere')).resolves.toEqual([])
+	})
+})
+
+describe('fetchAddressSuggestions — location bias', () => {
+	it('sends the bias as lat/lon parameters', async () => {
+		const spy = mockFetch(makePhotonResponse([]))
+
+		await fetchAddressSuggestions('school st', {
+			bias: { lat: 38.2967151, lng: -122.292037 },
+		})
+
+		const url = new URL(spy.mock.calls[0][0] as string)
+		expect(url.searchParams.get('lat')).toBe('38.2967151')
+		expect(url.searchParams.get('lon')).toBe('-122.292037')
+	})
+
+	it('sends no lat/lon parameters when no bias is given', async () => {
+		const spy = mockFetch(makePhotonResponse([]))
+
+		await fetchAddressSuggestions('school st')
+
+		const url = new URL(spy.mock.calls[0][0] as string)
+		expect(url.searchParams.get('lat')).toBeNull()
+		expect(url.searchParams.get('lon')).toBeNull()
+	})
+})
+
+describe('fetchReverseGeocodedAddress', () => {
+	const SONOMA = { lat: 38.291859, lng: -122.458036 }
+
+	it('requests the reverse endpoint with the position', async () => {
+		const spy = mockFetch(makePhotonResponse([makeFeature(PARIS_PROPERTIES)]))
+
+		await fetchReverseGeocodedAddress(SONOMA)
+
+		const url = new URL(spy.mock.calls[0][0] as string)
+		expect(url.hostname).toBe('photon.komoot.io')
+		expect(url.pathname).toBe('/reverse')
+		expect(url.searchParams.get('lat')).toBe('38.291859')
+		expect(url.searchParams.get('lon')).toBe('-122.458036')
+		expect(url.searchParams.get('limit')).toBe('1')
+		expect(url.searchParams.get('lang')).toBe('en')
+	})
+
+	it('maps the feature to a suggestion', async () => {
+		mockFetch(makePhotonResponse([makeFeature(PARIS_PROPERTIES)]))
+
+		const suggestion = await fetchReverseGeocodedAddress(SONOMA)
+
+		expect(suggestion).toEqual({
+			label: '12 Rue de la Paix, Paris, Île-de-France, 75002, France',
+			address: '12 Rue de la Paix',
+			city: 'Paris',
+			state: 'Île-de-France',
+			postcode: '75002',
+			countryCode: 'FR',
+			lat: 48.8693,
+			lng: 2.3312,
+		})
+	})
+
+	it('resolves null when Photon has no result', async () => {
+		mockFetch(makePhotonResponse([]))
+
+		await expect(fetchReverseGeocodedAddress(SONOMA)).resolves.toBeNull()
+	})
+
+	it('resolves null when the feature is unusable for a listing', async () => {
+		// No street line or name — cannot prepopulate an address from it.
+		mockFetch(
+			makePhotonResponse([
+				makeFeature({ city: 'Paris', country: 'France', countrycode: 'FR' }),
+			])
+		)
+
+		await expect(fetchReverseGeocodedAddress(SONOMA)).resolves.toBeNull()
+	})
+
+	it('throws SuggestionsUnavailableError on non-2xx responses', async () => {
+		mockFetch('Bad Gateway', 502)
+
+		await expect(fetchReverseGeocodedAddress(SONOMA)).rejects.toThrow(
+			SuggestionsUnavailableError
+		)
+	})
+
+	it('throws SuggestionsUnavailableError on fetch rejection', async () => {
+		vi
+			.spyOn(globalThis, 'fetch')
+			.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+		await expect(fetchReverseGeocodedAddress(SONOMA)).rejects.toThrow(
+			SuggestionsUnavailableError
+		)
+	})
+
+	it('throws SuggestionsUnavailableError when the shape is unexpected', async () => {
+		mockFetch(JSON.stringify({ results: [] }))
+
+		await expect(fetchReverseGeocodedAddress(SONOMA)).rejects.toThrow(
+			SuggestionsUnavailableError
+		)
+	})
+
+	it('lets aborts propagate untouched', async () => {
+		const abortError = new DOMException('Aborted', 'AbortError')
+		vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(abortError)
+
+		await expect(
+			fetchReverseGeocodedAddress(SONOMA, {
+				signal: new AbortController().signal,
+			})
+		).rejects.toBe(abortError)
 	})
 })
 

--- a/apps/www/tests/e2e/helpers/photon-mock.ts
+++ b/apps/www/tests/e2e/helpers/photon-mock.ts
@@ -57,8 +57,27 @@ function napaFeature(query: string): PhotonFeature {
 	}
 }
 
+/** A reverse-geocode result clearly distinguishable from search results. */
+function reverseFeature(lat: number, lng: number): PhotonFeature {
+	return {
+		type: 'Feature',
+		geometry: { type: 'Point', coordinates: [lng, lat] },
+		properties: {
+			housenumber: '1600',
+			street: 'Reverse Road',
+			city: 'Sonoma',
+			postcode: '95476',
+			state: 'California',
+			country: 'United States',
+			countrycode: 'US',
+			osm_key: 'building',
+			osm_value: 'yes',
+		},
+	}
+}
+
 export type PhotonMockFixture = {
-	/** Number of intercepted Photon requests served by the mock. */
+	/** Number of intercepted Photon search requests served by the mock. */
 	callCount: number
 	/** The most recent `q` parameter the mock saw. */
 	lastQuery: string | null
@@ -68,30 +87,70 @@ export type PhotonMockFixture = {
 	 * assertion.
 	 */
 	resultFor: (query: string) => { lat: number; lng: number } | undefined
+	/**
+	 * The `lat`/`lon` location-bias parameters a search request carried, or
+	 * null when it carried none. Keyed by query for the same race-free reason
+	 * as `resultFor`.
+	 */
+	biasFor: (query: string) => { lat: number; lng: number } | null | undefined
+	/** Number of intercepted Photon reverse-geocode requests. */
+	reverseCallCount: number
+	/** The `lat`/`lon` of the most recent reverse-geocode request. */
+	lastReverse: { lat: number; lng: number } | null
+}
+
+/** Reads the `lat`/`lon` pair from a Photon URL, or null when absent. */
+function readLatLng(url: URL): { lat: number; lng: number } | null {
+	const lat = url.searchParams.get('lat')
+	const lng = url.searchParams.get('lon')
+	if (lat === null || lng === null) return null
+	return { lat: Number(lat), lng: Number(lng) }
 }
 
 /**
  * Fixture that intercepts all Photon (address autosuggest) requests at the
- * network boundary. Queries containing "paris" get a French address,
+ * network boundary. Search queries containing "paris" get a French address,
  * "nowhere" gets an empty result set, and anything else gets a deterministic
- * Napa address.
+ * Napa address. Reverse-geocode requests echo the requested coordinates back
+ * as "1600 Reverse Road, Sonoma".
  */
 export const test = tileBase.extend<{ photonMock: PhotonMockFixture }>({
 	photonMock: [
 		async ({ context }, use) => {
 			const servedResults = new Map<string, { lat: number; lng: number }>()
+			const servedBiases = new Map<string, { lat: number; lng: number } | null>()
 			const fixture: PhotonMockFixture = {
 				callCount: 0,
 				lastQuery: null,
 				resultFor: (query) => servedResults.get(query),
+				biasFor: (query) => servedBiases.get(query),
+				reverseCallCount: 0,
+				lastReverse: null,
 			}
 
 			await context.route('**/photon.komoot.io/**', async (route) => {
 				const url = new URL(route.request().url())
+
+				if (url.pathname.startsWith('/reverse')) {
+					fixture.reverseCallCount++
+					const position = readLatLng(url)
+					fixture.lastReverse = position
+					await route.fulfill({
+						status: 200,
+						contentType: 'application/json',
+						body: JSON.stringify({
+							type: 'FeatureCollection',
+							features: position ? [reverseFeature(position.lat, position.lng)] : [],
+						}),
+					})
+					return
+				}
+
 				const q = url.searchParams.get('q') ?? ''
 
 				fixture.callCount++
 				fixture.lastQuery = q
+				servedBiases.set(q, readLatLng(url))
 
 				let features: PhotonFeature[]
 				if (/nowhere/i.test(q)) {

--- a/apps/www/tests/e2e/location-bias.test.ts
+++ b/apps/www/tests/e2e/location-bias.test.ts
@@ -1,0 +1,139 @@
+import { test, expect } from './helpers/fixtures'
+import { createTestListing, getListingLocation } from './helpers/test-db'
+import { loginViaUI } from './helpers/login'
+
+/** Sonoma Plaza — a granted position clearly distinct from the Napa fallback. */
+const GRANTED_POSITION = { latitude: 38.291859, longitude: -122.458036 }
+
+/** The fallback bias when the user denies the geolocation request. */
+const NAPA_CITY_HALL = { lat: 38.2967151, lng: -122.292037 }
+
+test.describe('Address suggestions — geolocation granted', () => {
+	test.use({
+		geolocation: GRANTED_POSITION,
+		permissions: ['geolocation'],
+	})
+
+	test('prepopulates the address from the user’s position and submits with its coordinates', async ({
+		page,
+		testUser,
+		photonMock,
+		nominatimMock,
+	}) => {
+		await loginViaUI(page, testUser)
+		await page.goto('/listings/new')
+
+		// The granted position is reverse-geocoded into the address field.
+		const address = page.getByLabel('Address', { exact: true })
+		await expect(address).toHaveValue(/1600 Reverse Road/, { timeout: 10_000 })
+		await expect(address).toHaveValue(/Sonoma/)
+		expect(photonMock.reverseCallCount).toBe(1)
+		expect(photonMock.lastReverse!.lat).toBeCloseTo(GRANTED_POSITION.latitude, 5)
+		expect(photonMock.lastReverse!.lng).toBeCloseTo(GRANTED_POSITION.longitude, 5)
+
+		// The prepopulated address behaves like a picked suggestion: it already
+		// carries coordinates, so submitting needs no search and no geocoding.
+		await page.locator('.combobox__trigger').click()
+		await page.locator('.combobox__item').filter({ hasText: 'Avocado' }).click()
+		await page.getByLabel(/When to Pick/i).fill('July–September')
+		await page.getByRole('button', { name: 'Share my produce' }).click()
+
+		await expect(page).toHaveURL(/\/listings\/\d+/, { timeout: 10_000 })
+		expect(photonMock.callCount).toBe(0)
+		expect(nominatimMock.callCount).toBe(0)
+
+		const listingId = Number(page.url().match(/\/listings\/(\d+)/)![1])
+		const stored = await getListingLocation(listingId)
+		expect(stored).toBeDefined()
+		expect(stored!.lat).toBeCloseTo(GRANTED_POSITION.latitude, 5)
+		expect(stored!.lng).toBeCloseTo(GRANTED_POSITION.longitude, 5)
+		expect(stored!.city).toBe('Sonoma')
+	})
+
+	test('searches carry the user’s position as the location bias', async ({
+		page,
+		testUser,
+		photonMock,
+	}) => {
+		await loginViaUI(page, testUser)
+		await page.goto('/listings/new')
+
+		// Wait for prepopulation so the position has definitely resolved, then
+		// search for something else.
+		const address = page.getByLabel('Address', { exact: true })
+		await expect(address).toHaveValue(/1600 Reverse Road/, { timeout: 10_000 })
+		await address.fill('400 School St')
+		await page.getByRole('option', { name: /School Street/ }).click()
+
+		const bias = photonMock.biasFor('400 School St')
+		expect(bias).toBeDefined()
+		expect(bias!.lat).toBeCloseTo(GRANTED_POSITION.latitude, 5)
+		expect(bias!.lng).toBeCloseTo(GRANTED_POSITION.longitude, 5)
+	})
+
+	test('does not overwrite the pre-fill from the last listing', async ({
+		page,
+		testUser,
+		photonMock,
+	}) => {
+		await createTestListing(testUser.id, {
+			address: '456 Oak Avenue',
+			city: 'St. Helena',
+			state: 'CA',
+			zip: '94574',
+		})
+
+		await loginViaUI(page, testUser)
+		await page.goto('/listings/new')
+
+		const address = page.getByLabel('Address', { exact: true })
+		await expect(address).toHaveValue(/456 Oak Avenue/, { timeout: 10_000 })
+
+		// The produce-type selector renders client-side only, so its presence
+		// proves hydration finished and the address input's handlers are live.
+		await page.locator('.combobox__trigger').click()
+		await page.locator('.combobox__item').filter({ hasText: 'Avocado' }).click()
+
+		// Searching with the granted bias proves the position resolved — and
+		// the resolution path must have skipped the reverse geocode.
+		await address.fill('400 School St')
+		await page.getByRole('option', { name: /School Street/ }).click()
+		const bias = photonMock.biasFor('400 School St')
+		expect(bias!.lat).toBeCloseTo(GRANTED_POSITION.latitude, 5)
+		expect(photonMock.reverseCallCount).toBe(0)
+		await expect(address).toHaveValue(/400 School Street/)
+	})
+})
+
+test.describe('Address suggestions — geolocation denied', () => {
+	// Playwright denies geolocation unless the permission is granted, so the
+	// component’s error path runs immediately — no prompt is shown.
+	test.use({ permissions: [] })
+
+	test('falls back to the Napa City Hall bias and leaves the field empty', async ({
+		page,
+		testUser,
+		photonMock,
+	}) => {
+		await loginViaUI(page, testUser)
+		await page.goto('/listings/new')
+
+		// The produce-type selector renders client-side only, so its presence
+		// proves hydration finished and the address input's handlers are live.
+		await page.locator('.combobox__trigger').click()
+		await page.locator('.combobox__item').filter({ hasText: 'Avocado' }).click()
+
+		const address = page.getByLabel('Address', { exact: true })
+		await expect(address).toHaveValue('', { timeout: 10_000 })
+
+		await address.fill('400 School St')
+		await page.getByRole('option', { name: /School Street/ }).click()
+
+		const bias = photonMock.biasFor('400 School St')
+		expect(bias).toBeDefined()
+		expect(bias!.lat).toBeCloseTo(NAPA_CITY_HALL.lat, 5)
+		expect(bias!.lng).toBeCloseTo(NAPA_CITY_HALL.lng, 5)
+		expect(photonMock.reverseCallCount).toBe(0)
+		await expect(address).toHaveValue(/400 School Street/)
+	})
+})

--- a/apps/www/tests/e2e/location-bias.test.ts
+++ b/apps/www/tests/e2e/location-bias.test.ts
@@ -31,6 +31,11 @@ test.describe('Address suggestions — geolocation granted', () => {
 		expect(photonMock.lastReverse!.lat).toBeCloseTo(GRANTED_POSITION.latitude, 5)
 		expect(photonMock.lastReverse!.lng).toBeCloseTo(GRANTED_POSITION.longitude, 5)
 
+		// The guess is announced and visibly flagged for verification.
+		await expect(
+			page.getByText(/Filled in from your current location/i)
+		).toBeVisible()
+
 		// The prepopulated address behaves like a picked suggestion: it already
 		// carries coordinates, so submitting needs no search and no geocoding.
 		await page.locator('.combobox__trigger').click()
@@ -115,6 +120,23 @@ test.describe('Address suggestions — geolocation denied', () => {
 		testUser,
 		photonMock,
 	}) => {
+		// Surface the denial on `window` — otherwise "the field stays empty"
+		// could be asserted while the geolocation outcome is still pending,
+		// proving nothing.
+		await page.addInitScript(() => {
+			const geolocation = navigator.geolocation
+			const original = geolocation.getCurrentPosition.bind(geolocation)
+			geolocation.getCurrentPosition = (onSuccess, onError, options) =>
+				original(
+					onSuccess,
+					(error) => {
+						;(window as { __geolocationDenied?: boolean }).__geolocationDenied = true
+						onError?.(error)
+					},
+					options
+				)
+		})
+
 		await loginViaUI(page, testUser)
 		await page.goto('/listings/new')
 
@@ -123,8 +145,11 @@ test.describe('Address suggestions — geolocation denied', () => {
 		await page.locator('.combobox__trigger').click()
 		await page.locator('.combobox__item').filter({ hasText: 'Avocado' }).click()
 
+		await page.waitForFunction(
+			() => (window as { __geolocationDenied?: boolean }).__geolocationDenied
+		)
 		const address = page.getByLabel('Address', { exact: true })
-		await expect(address).toHaveValue('', { timeout: 10_000 })
+		await expect(address).toHaveValue('')
 
 		await address.fill('400 School St')
 		await page.getByRole('option', { name: /School Street/ }).click()

--- a/apps/www/tests/geolocation.test.ts
+++ b/apps/www/tests/geolocation.test.ts
@@ -8,7 +8,7 @@ const GEOLOCATION_ERROR_CODES = {
 	TIMEOUT: 3,
 } as const
 
-function stubGeolocation(getCurrentPosition: PositionCallback | unknown) {
+function stubGeolocation(getCurrentPosition: unknown) {
 	vi.stubGlobal('navigator', {
 		...globalThis.navigator,
 		geolocation: { getCurrentPosition },

--- a/apps/www/tests/geolocation.test.ts
+++ b/apps/www/tests/geolocation.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { NAPA_CITY_HALL, requestCurrentLocation } from '../src/lib/geolocation'
+
+/** Mirrors the numeric error codes of the GeolocationPositionError interface. */
+const GEOLOCATION_ERROR_CODES = {
+	PERMISSION_DENIED: 1,
+	POSITION_UNAVAILABLE: 2,
+	TIMEOUT: 3,
+} as const
+
+function stubGeolocation(getCurrentPosition: PositionCallback | unknown) {
+	vi.stubGlobal('navigator', {
+		...globalThis.navigator,
+		geolocation: { getCurrentPosition },
+	})
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+describe('NAPA_CITY_HALL', () => {
+	it('is the agreed fallback bias', () => {
+		expect(NAPA_CITY_HALL).toEqual({ lat: 38.2967151, lng: -122.292037 })
+	})
+})
+
+describe('requestCurrentLocation', () => {
+	it('resolves the position when the user grants access', async () => {
+		stubGeolocation((onSuccess: PositionCallback) => {
+			onSuccess({
+				coords: { latitude: 38.291859, longitude: -122.458036 },
+			} as GeolocationPosition)
+		})
+
+		await expect(requestCurrentLocation()).resolves.toEqual({
+			lat: 38.291859,
+			lng: -122.458036,
+		})
+	})
+
+	it.each(
+		Object.entries(GEOLOCATION_ERROR_CODES).map(([name, code]) => ({
+			name,
+			code,
+		}))
+	)('resolves null on $name', async ({ code }) => {
+		stubGeolocation(
+			(_onSuccess: PositionCallback, onError: PositionErrorCallback) => {
+				onError({ code, message: 'nope' } as GeolocationPositionError)
+			}
+		)
+
+		await expect(requestCurrentLocation()).resolves.toBeNull()
+	})
+
+	it('resolves null when the Geolocation API is missing', async () => {
+		vi.stubGlobal('navigator', {})
+
+		await expect(requestCurrentLocation()).resolves.toBeNull()
+	})
+
+	it('accepts a coarse cached fix instead of forcing a fresh GPS read', async () => {
+		let seenOptions: PositionOptions | undefined
+		stubGeolocation(
+			(
+				onSuccess: PositionCallback,
+				_onError: PositionErrorCallback,
+				options?: PositionOptions
+			) => {
+				seenOptions = options
+				onSuccess({
+					coords: { latitude: 1, longitude: 2 },
+				} as GeolocationPosition)
+			}
+		)
+
+		await requestCurrentLocation()
+
+		expect(seenOptions?.enableHighAccuracy).toBe(false)
+		expect(seenOptions?.maximumAge).toBeGreaterThan(0)
+		expect(seenOptions?.timeout).toBeGreaterThan(0)
+	})
+})

--- a/apps/www/tests/security-headers.server.test.ts
+++ b/apps/www/tests/security-headers.server.test.ts
@@ -41,6 +41,19 @@ describe('applySecurityHeaders', () => {
 		expect(csp).not.toContain('https://*.fly.storage.tigris.dev')
 	})
 
+	it('allows geolocation for our own origin only, keeping other features blocked', () => {
+		const headers = new Headers()
+		applySecurityHeaders(headers)
+
+		const policy = headers.get('Permissions-Policy')!
+		// (self), not (): the New Listing form asks for the user's position to
+		// bias address suggestions. Everything else stays denied.
+		expect(policy).toContain('geolocation=(self)')
+		expect(policy).toContain('camera=()')
+		expect(policy).toContain('microphone=()')
+		expect(policy).toContain('payment=()')
+	})
+
 	it('uses only the passed mediaOrigin in img-src, not the default bucket host', () => {
 		const headers = new Headers()
 		applySecurityHeaders(headers, ['https://media.pickmyfruit.com'])

--- a/apps/www/tests/sentry-redaction.test.ts
+++ b/apps/www/tests/sentry-redaction.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/lib/env', () => ({
+	clientEnv: {
+		sentryDsn: undefined,
+		sentryEnabled: false,
+		sentryEnvironment: 'test',
+		sentryRelease: undefined,
+		sentrySampleRate: 0,
+		sentryTracesSampleRate: 0,
+		mode: 'test',
+	},
+}))
+
+const { redactGeoServiceUrl, redactGeoBreadcrumb, redactGeoSpan } =
+	await import('../src/lib/sentry')
+
+describe('redactGeoServiceUrl', () => {
+	it.each([
+		{
+			label: 'Photon search query and bias coordinates',
+			url: 'https://photon.komoot.io/api/?q=400%20school&lat=38.29&lon=-122.45',
+			expected: 'https://photon.komoot.io/api/',
+		},
+		{
+			label: 'Photon reverse-geocode coordinates',
+			url: 'https://photon.komoot.io/reverse?lat=38.29&lon=-122.45&limit=1',
+			expected: 'https://photon.komoot.io/reverse',
+		},
+		{
+			label: 'Nominatim query',
+			url: 'https://nominatim.openstreetmap.org/search?q=123+Main+St&format=json',
+			expected: 'https://nominatim.openstreetmap.org/search',
+		},
+	])('strips the query string from $label', ({ url, expected }) => {
+		expect(redactGeoServiceUrl(url)).toBe(expected)
+	})
+
+	it.each([
+		{
+			label: 'other hosts',
+			url: 'https://example.com/api?token=abc',
+		},
+		{
+			label: 'relative URLs',
+			url: '/api/listings?created=true',
+		},
+		{
+			label: 'non-URL strings',
+			url: 'not a url',
+		},
+	])('leaves $label untouched', ({ url }) => {
+		expect(redactGeoServiceUrl(url)).toBe(url)
+	})
+})
+
+describe('redactGeoBreadcrumb', () => {
+	it('strips coordinates from fetch breadcrumb URLs', () => {
+		const breadcrumb = {
+			category: 'fetch',
+			data: {
+				method: 'GET',
+				url: 'https://photon.komoot.io/reverse?lat=38.29&lon=-122.45',
+				status_code: 200,
+			},
+		}
+
+		const redacted = redactGeoBreadcrumb(breadcrumb)
+
+		expect(redacted.data?.url).toBe('https://photon.komoot.io/reverse')
+		expect(redacted.data?.method).toBe('GET')
+	})
+
+	it('leaves other breadcrumbs untouched', () => {
+		const breadcrumb = {
+			category: 'fetch',
+			data: { method: 'POST', url: '/api/listings' },
+		}
+
+		expect(redactGeoBreadcrumb(breadcrumb).data?.url).toBe('/api/listings')
+	})
+
+	it('tolerates breadcrumbs without data', () => {
+		const breadcrumb = { category: 'console', message: 'hello' }
+
+		expect(redactGeoBreadcrumb(breadcrumb)).toBe(breadcrumb)
+	})
+})
+
+describe('redactGeoSpan', () => {
+	function makeSpan() {
+		return {
+			span_id: 'a',
+			trace_id: 'b',
+			start_timestamp: 0,
+			description:
+				'GET https://photon.komoot.io/api/?q=secret&lat=38.29&lon=-122.45',
+			data: {
+				'http.url': 'https://photon.komoot.io/api/?q=secret&lat=38.29&lon=-122.45',
+				'url.full': 'https://photon.komoot.io/api/?q=secret&lat=38.29&lon=-122.45',
+				'http.query': '?q=secret&lat=38.29&lon=-122.45',
+				'http.method': 'GET',
+			},
+		}
+	}
+
+	it('strips geocoding URLs and query attributes from http spans', () => {
+		const span = redactGeoSpan(makeSpan())
+
+		expect(span.description).toBe('GET https://photon.komoot.io/api/')
+		expect(span.data?.['http.url']).toBe('https://photon.komoot.io/api/')
+		expect(span.data?.['url.full']).toBe('https://photon.komoot.io/api/')
+		expect(span.data?.['http.query']).toBeUndefined()
+		expect(span.data?.['http.method']).toBe('GET')
+	})
+
+	it('leaves spans for other hosts untouched', () => {
+		const span = {
+			span_id: 'a',
+			trace_id: 'b',
+			start_timestamp: 0,
+			description: 'GET https://example.com/api?token=abc',
+			data: {
+				'http.url': 'https://example.com/api?token=abc',
+				'http.query': '?token=abc',
+			},
+		}
+
+		const redacted = redactGeoSpan(span)
+
+		expect(redacted.description).toBe('GET https://example.com/api?token=abc')
+		expect(redacted.data?.['http.url']).toBe('https://example.com/api?token=abc')
+		expect(redacted.data?.['http.query']).toBe('?token=abc')
+	})
+
+	it('tolerates spans without data or description', () => {
+		// The SDK types `data` as required, but be defensive at runtime.
+		const span = {
+			span_id: 'a',
+			trace_id: 'b',
+			start_timestamp: 0,
+		} as Parameters<typeof redactGeoSpan>[0]
+
+		expect(redactGeoSpan(span)).toBe(span)
+	})
+})

--- a/apps/www/tests/sentry-redaction.test.ts
+++ b/apps/www/tests/sentry-redaction.test.ts
@@ -88,7 +88,12 @@ describe('redactGeoBreadcrumb', () => {
 })
 
 describe('redactGeoSpan', () => {
+	// Mirrors what @sentry/core's getFetchSpanAttributes actually sets on
+	// browser fetch spans (`url`, `http.url`, `http.query`, `http.fragment`,
+	// `server.address`, `type`) plus the server-side shape (`url.full`,
+	// `url.query`) — not merely the keys the implementation happens to know.
 	function makeSpan() {
+		const fullUrl = 'https://photon.komoot.io/api/?q=secret&lat=38.29&lon=-122.45'
 		return {
 			span_id: 'a',
 			trace_id: 'b',
@@ -96,10 +101,15 @@ describe('redactGeoSpan', () => {
 			description:
 				'GET https://photon.komoot.io/api/?q=secret&lat=38.29&lon=-122.45',
 			data: {
-				'http.url': 'https://photon.komoot.io/api/?q=secret&lat=38.29&lon=-122.45',
-				'url.full': 'https://photon.komoot.io/api/?q=secret&lat=38.29&lon=-122.45',
+				url: fullUrl,
+				'http.url': fullUrl,
+				'url.full': fullUrl,
 				'http.query': '?q=secret&lat=38.29&lon=-122.45',
+				'url.query': 'q=secret&lat=38.29&lon=-122.45',
+				'http.fragment': 'frag',
+				'server.address': 'photon.komoot.io',
 				'http.method': 'GET',
+				type: 'fetch',
 			},
 		}
 	}
@@ -108,10 +118,14 @@ describe('redactGeoSpan', () => {
 		const span = redactGeoSpan(makeSpan())
 
 		expect(span.description).toBe('GET https://photon.komoot.io/api/')
+		expect(span.data?.url).toBe('https://photon.komoot.io/api/')
 		expect(span.data?.['http.url']).toBe('https://photon.komoot.io/api/')
 		expect(span.data?.['url.full']).toBe('https://photon.komoot.io/api/')
 		expect(span.data?.['http.query']).toBeUndefined()
+		expect(span.data?.['url.query']).toBeUndefined()
+		expect(span.data?.['http.fragment']).toBeUndefined()
 		expect(span.data?.['http.method']).toBe('GET')
+		expect(span.data?.['server.address']).toBe('photon.komoot.io')
 	})
 
 	it('leaves spans for other hosts untouched', () => {

--- a/docs/0012-geolocation-location-bias.md
+++ b/docs/0012-geolocation-location-bias.md
@@ -102,8 +102,11 @@ full addresses to Photon and Nominatim. On our side, the Sentry SDK's
 default fetch instrumentation would otherwise record every request URL
 (query string included) in breadcrumbs and tracing spans, so `sentry.ts`
 redacts the query string from Photon and Nominatim URLs in
-`beforeBreadcrumb` and `beforeSendSpan` — coordinates and typed addresses
-never reach Sentry.
+`beforeBreadcrumb` and `beforeSendSpan`, and the hand-written breadcrumbs in
+`geocoding.ts`/`address-suggestions.ts` record only the query length. The
+one remaining exception is deliberate: when Nominatim returns a malformed
+response, `geocoding.ts` attaches up to 1 KB of that raw response to the
+error report for diagnosis, and it can echo the queried address.
 
 ## Testing
 

--- a/docs/0012-geolocation-location-bias.md
+++ b/docs/0012-geolocation-location-bias.md
@@ -19,7 +19,9 @@ without excluding anything.
     City Hall (`38.2967151, -122.292037`), the project's launch city anchor.
   - **While the prompt is open** → the fallback bias is already in place, so
     a user who types before answering still gets deterministic (Napa-biased)
-    results rather than unbiased ones.
+    results rather than unbiased ones. (A prompt the user never answers
+    fires neither callback — the spec excludes decision time from
+    `timeout` — which simply leaves the fallback bias in place.)
 - Bias is passed as `lat`/`lon` on the suggest request. Photon's defaults for
   the optional tuning knobs (`zoom` 12, `location_bias_scale` 0.4) suit a
   city-scale bias, so they are not sent.
@@ -29,6 +31,13 @@ without excluding anything.
   result is applied exactly like a picked suggestion (label in the input,
   structured address + coordinates reported via `onSelect`). Any failure is
   silent — prepopulation is an optional nicety, never an error.
+  - Because the position is coarse (Wi-Fi/IP fixes can be hundreds of
+    meters off) and `/reverse` snaps to the _nearest_ known address, the
+    guess can be a neighbor's house. The component therefore announces the
+    fill through its status live region — "Filled in from your current
+    location. Edit if different." — which both nudges sighted users to
+    verify the guess and tells screen-reader users why a field they heard
+    as blank is now full.
 
 ### Where the logic lives
 
@@ -63,14 +72,20 @@ New module `src/lib/geolocation.ts` wraps the callback-style
 
 - **User types before the position resolves** → suggest requests fire with
   the fallback bias; later requests pick up the granted coordinates.
-- **User types (or picks) before the reverse geocode resolves** → the
-  prepopulation result is discarded; the user's text is never clobbered and
-  `onSelect` is not called with a stale selection. Guarded by re-checking
-  the "untouched" condition after each `await`.
+- **User focuses, types, or picks before the reverse geocode resolves** →
+  the prepopulation result is discarded; the user's text (or imminent
+  typing — focus alone claims the field) is never clobbered and `onSelect`
+  is not called with a stale selection. Guarded by re-checking the
+  "untouched" condition after each `await`.
 - **Pre-fill from the last listing** (`defaultSelection`) → prepopulation is
   skipped entirely; the reverse request is never made.
 - **Unmount** (e.g. switching to manual entry) → in-flight reverse geocode is
   aborted via the component's existing cleanup.
+- **Remount after interaction** → toggling manual entry and back remounts
+  the component with fresh internal state, which would re-prepopulate a
+  field the user deliberately cleared. `ListingForm` remembers the first
+  interaction (`onInteract`) and suppresses prepopulation on later mounts
+  (`allowPrepopulate={false}`).
 
 ## Security
 
@@ -83,8 +98,12 @@ our own origin may use it; embedded third-party content (none today,
 Privacy: when granted, the user's raw coordinates are sent to Photon
 (komoot's public instance) as bias parameters and once to `/reverse`. This
 matches the privacy posture accepted in doc 0011 — the browser already sends
-full addresses to Photon and Nominatim. Coordinates are not logged or
-breadcrumbed on our side.
+full addresses to Photon and Nominatim. On our side, the Sentry SDK's
+default fetch instrumentation would otherwise record every request URL
+(query string included) in breadcrumbs and tracing spans, so `sentry.ts`
+redacts the query string from Photon and Nominatim URLs in
+`beforeBreadcrumb` and `beforeSendSpan` — coordinates and typed addresses
+never reach Sentry.
 
 ## Testing
 

--- a/docs/0012-geolocation-location-bias.md
+++ b/docs/0012-geolocation-location-bias.md
@@ -1,0 +1,115 @@
+# 0012 — Geolocation-based location bias for address suggestions
+
+## Problem
+
+The New Listing form's address autosuggest (doc 0011) queries Photon with no
+location bias, so short queries rank results by global prominence: typing
+"400 school st" from Napa surfaces streets on other continents before the one
+around the corner. Photon supports a
+[location bias](https://github.com/komoot/photon/blob/master/docs/api-v1.md#location-bias)
+(`lat`/`lon` query parameters) that re-ranks results toward a focus point
+without excluding anything.
+
+## Approach
+
+- On mount, the autosuggest asks the browser for the user's position via the
+  Geolocation API (`navigator.geolocation.getCurrentPosition`).
+  - **Granted** → use the user's coordinates as the Photon bias.
+  - **Denied / unavailable / timed out / unsupported** → fall back to Napa
+    City Hall (`38.2967151, -122.292037`), the project's launch city anchor.
+  - **While the prompt is open** → the fallback bias is already in place, so
+    a user who types before answering still gets deterministic (Napa-biased)
+    results rather than unbiased ones.
+- Bias is passed as `lat`/`lon` on the suggest request. Photon's defaults for
+  the optional tuning knobs (`zoom` 12, `location_bias_scale` 0.4) suit a
+  city-scale bias, so they are not sent.
+- **Prepopulation (granted only)**: when the user grants access, the field is
+  still empty, and there is no pre-fill from a previous listing, the user's
+  coordinates are reverse-geocoded via Photon's `/reverse` endpoint and the
+  result is applied exactly like a picked suggestion (label in the input,
+  structured address + coordinates reported via `onSelect`). Any failure is
+  silent — prepopulation is an optional nicety, never an error.
+
+### Where the logic lives
+
+`AddressAutosuggest` owns the whole flow. Both consumers of the position —
+the suggest bias and the prepopulated selection — are concerns of that
+component, and its existing `onSelect` contract already propagates a
+selection (with coordinates) to `ListingForm`, so the form needs no changes.
+A side effect worth naming: the browser permission prompt appears when the
+autosuggest mounts (i.e. on opening the New Listing form), not on first
+keystroke. That is the requested behavior.
+
+New module `src/lib/geolocation.ts` wraps the callback-style
+`getCurrentPosition` in a promise:
+
+- `requestCurrentLocation(): Promise<LocationBias | null>` — `null` for
+  every non-success outcome (denied, unavailable, timeout, API missing).
+  Callers never see a rejection; denial is a normal outcome, not an
+  exception, so nothing is reported to Sentry.
+- `NAPA_CITY_HALL: LocationBias` — the shared fallback constant.
+
+`src/lib/address-suggestions.ts` gains:
+
+- an optional `bias` option on `fetchAddressSuggestions`, appended as
+  `lat`/`lon`;
+- `fetchReverseGeocodedAddress(location, { signal })` — `GET /reverse` with
+  `limit=1&lang=en`, mapped through the same feature→suggestion code path as
+  search results; resolves `null` when Photon returns nothing usable, throws
+  `SuggestionsUnavailableError` on transport/shape failures (the component
+  swallows it for prepopulation).
+
+### Races guarded in the component
+
+- **User types before the position resolves** → suggest requests fire with
+  the fallback bias; later requests pick up the granted coordinates.
+- **User types (or picks) before the reverse geocode resolves** → the
+  prepopulation result is discarded; the user's text is never clobbered and
+  `onSelect` is not called with a stale selection. Guarded by re-checking
+  the "untouched" condition after each `await`.
+- **Pre-fill from the last listing** (`defaultSelection`) → prepopulation is
+  skipped entirely; the reverse request is never made.
+- **Unmount** (e.g. switching to manual entry) → in-flight reverse geocode is
+  aborted via the component's existing cleanup.
+
+## Security
+
+`Permissions-Policy` currently sends `geolocation=()`, which hard-blocks the
+Geolocation API for the whole site. It becomes `geolocation=(self)` — only
+our own origin may use it; embedded third-party content (none today,
+`frame-src 'none'`) stays blocked. The CSP `connect-src` already allows
+`https://photon.komoot.io`, which covers `/reverse`.
+
+Privacy: when granted, the user's raw coordinates are sent to Photon
+(komoot's public instance) as bias parameters and once to `/reverse`. This
+matches the privacy posture accepted in doc 0011 — the browser already sends
+full addresses to Photon and Nominatim. Coordinates are not logged or
+breadcrumbed on our side.
+
+## Testing
+
+Double-loop TDD:
+
+- **Outer loop** (`tests/e2e/location-bias.test.ts`): the `photon-mock`
+  fixture additionally serves `/reverse` and records the bias parameters of
+  each search request. Playwright's `geolocation`/`permissions` context
+  options simulate grant and denial.
+  - granted → suggest requests carry the granted coordinates; the address
+    field is prepopulated from the reverse geocode and submits as a normal
+    selection.
+  - denied (Playwright's default) → suggest requests carry the Napa City
+    Hall coordinates; `/reverse` is never called; the field stays empty.
+- **Inner loops**: unit tests for `requestCurrentLocation` (success and each
+  failure mode), the `lat`/`lon` request parameters, `/reverse`
+  fetching/mapping/failures, the component's bias hand-off, prepopulation,
+  its guards, and the `Permissions-Policy` change.
+
+## Known simplifications
+
+- The position is requested with `enableHighAccuracy: false` and a cached
+  fix up to five minutes old is accepted — city-scale bias does not need GPS
+  precision, and a coarse cached answer is faster and cheaper on battery.
+- The home-page map keeps its own hard-coded Napa center; migrating it to
+  geolocation is out of scope here.
+- If the user grants the permission but later moves, the bias is whatever
+  was measured at mount. Fine for a form that lives for one listing.


### PR DESCRIPTION
Implements geolocation-based location bias for the address autosuggest component, improving suggestion relevance for users by biasing results toward their current location. When the user grants permission, their position is also used to prepopulate the address field via reverse geocoding.

## Changes

- **New module `src/lib/geolocation.ts`**: Wraps the callback-style Geolocation API in a promise-based interface. Provides `requestCurrentLocation()` which resolves to the user's position or `null` on any non-success outcome (denied, unavailable, timeout, API missing). Exports `NAPA_CITY_HALL` as the fallback bias when position is unavailable.

- **Enhanced `src/lib/address-suggestions.ts`**:
  - Added optional `bias` parameter to `fetchAddressSuggestions()` to pass location bias as `lat`/`lon` query parameters to Photon
  - New `fetchReverseGeocodedAddress()` function to reverse-geocode a position via Photon's `/reverse` endpoint, returning a suggestion or `null`
  - Extracted common Photon request logic into `fetchPhotonSuggestions()` helper

- **Updated `src/components/AddressAutosuggest.tsx`**:
  - Requests user's position on mount and uses it to bias all suggestion searches
  - Falls back to Napa City Hall bias while position request is pending or if denied
  - Implements prepopulation: when position is granted and field is empty, reverse-geocodes the position and fills the field with the result
  - Guards against race conditions: user interaction (focus, typing, picking) before position resolves prevents prepopulation from clobbering user input
  - Announces prepopulation through status live region for accessibility
  - New props: `allowPrepopulate` (to suppress prepopulation when field was previously touched) and `onInteract` (fires on first user interaction)

- **Updated `src/components/ListingForm.tsx`**: Tracks whether user has interacted with address field to control prepopulation across component remounts

- **Enhanced `src/lib/sentry.ts`**: Added redaction functions to strip sensitive query parameters from geocoding service URLs before they reach Sentry:
  - `redactGeoServiceUrl()`: removes query strings from Photon and Nominatim URLs
  - `redactGeoBreadcrumb()`: redacts fetch breadcrumb URLs
  - `redactGeoSpan()`: redacts HTTP span attributes and descriptions
  - Integrated into Sentry initialization via `beforeSendBreadcrumb` and `beforeSendSpan` hooks

- **Updated `src/middleware/security-headers.ts`**: Added `geolocation=(self)` to Permissions-Policy to allow geolocation requests only from the application's own origin

- **Comprehensive test coverage**:
  - Unit tests for `requestCurrentLocation()` covering success, all error codes, missing API, and options
  - Unit tests for `fetchReverseGeocodedAddress()` covering happy path, empty results, unusable features, errors, and abort handling
  - Unit tests for location bias in `fetchAddressSuggestions()`
  - Extensive component tests covering location bias application, prepopulation logic, race conditions, user interaction guards, and accessibility announcements
  - E2E tests verifying prepopulation, location bias in searches, pre-fill preservation, and fallback behavior when geolocation is denied
  - Unit tests for Sentry redaction functions

- **Documentation**: Added `docs/0012-geolocation-location-bias.md` explaining the approach, implementation details, and race condition guards

## Implementation Details

The component uses a fallback bias (Napa City Hall) immediately on mount, ensuring deterministic search results even while the geolocation permission prompt is open. Once the position resolves, it becomes the new bias for subsequent searches.

Prepopulation is carefully guarded against multiple race conditions: the component tracks whether the user has interacted with the field (via focus, input, or selection) and discards stale reverse-geocode results if interaction occurred before the result arrived. An `AbortController` ensures in-flight requests are cancelled on unmount.

Sensitive coordinates and user-typed addresses in

https://claude.ai/code/session_01UXSfcZxeZRhzQQG5tSHgeK