### PR TITLE
Add opt-in "Center" button to the home map

### DIFF
--- a/apps/www/src/components/ListingsMap.tsx
+++ b/apps/www/src/components/ListingsMap.tsx
@@ -3,6 +3,11 @@ import type { PublicListing } from '@/data/queries.server'
 import { cellToLatLng, cellToBoundary, cellToParent } from 'h3-js'
 import { H3_RESOLUTIONS, zoomToH3Resolution } from '@/lib/h3-resolutions'
 import { PRODUCE_STAND_SLUG } from '@/lib/produce-types'
+import type { LocationBias } from '@/lib/geolocation'
+import {
+	DEFAULT_MAP_ZOOM,
+	planListingsMapCamera,
+} from '@/lib/listings-map-camera'
 import { Sentry } from '@/lib/sentry'
 import MapLibreGL, {
 	MapLibreGLReadyArgs,
@@ -65,6 +70,11 @@ function h3ToPolygonCoordinates(h3Index: string): number[][] {
 
 interface Props {
 	listings: PublicListing[]
+	/**
+	 * The user's geolocated position, when known. The map centers here instead
+	 * of fitting the listing bounds; undefined/null keeps the default framing.
+	 */
+	center?: LocationBias | null
 	/** Called when a group marker is clicked. Null clears the filter. */
 	onGroupSelect?: (h3Index: string | null) => void
 	/** Currently selected H3 index, for highlighting. */
@@ -109,23 +119,43 @@ export default function ListingsMap(props: Props) {
 		}
 	}
 
+	/**
+	 * Mirrors the live camera onto `data-map-center` (`lng,lat`) and
+	 * `data-map-zoom` — non-secret observability the end-to-end tests assert
+	 * against.
+	 */
+	function reportCenter(container: HTMLDivElement) {
+		if (!map) return
+		const center = map.getCenter()
+		container.dataset.mapCenter = `${center.lng.toFixed(5)},${center.lat.toFixed(5)}`
+		container.dataset.mapZoom = map.getZoom().toFixed(2)
+	}
+
 	function setupMap({ container, maplibregl, onMapLoad }: MapLibreGLReadyArgs) {
 		maplibreglRef = maplibregl
 		const groups = groupByH3(props.listings)
-		const bounds = new maplibregl.LngLatBounds()
-		for (const group of groups) {
-			bounds.extend(group.center)
+		const camera = planListingsMapCamera(groups.length > 0, props.center)
+
+		let bounds: import('maplibre-gl').LngLatBounds | undefined
+		if (camera.kind === 'fit-groups') {
+			bounds = new maplibregl.LngLatBounds()
+			for (const group of groups) {
+				bounds.extend(group.center)
+			}
 		}
 
 		map = new maplibregl.Map({
 			container,
 			style: 'https://tiles.openfreemap.org/styles/liberty',
-			bounds: groups.length > 0 ? bounds : undefined,
-			center: groups.length === 0 ? [-122.2893688, 38.2966234] : undefined,
-			zoom: groups.length === 0 ? 13 : undefined,
+			bounds,
+			center: camera.kind === 'center' ? camera.center : undefined,
+			zoom: camera.kind === 'center' ? camera.zoom : undefined,
 			fitBoundsOptions: { padding: 60, maxZoom: 14 },
 			attributionControl: false,
 		})
+
+		reportCenter(container)
+		map.on('moveend', () => reportCenter(container))
 
 		map.addControl(
 			new maplibregl.AttributionControl({ compact: true }),
@@ -364,6 +394,22 @@ export default function ListingsMap(props: Props) {
 				updateHighlight()
 				updateRegion(props.selectedH3)
 			}
+		)
+	)
+
+	// A `center` arrives when the user clicks "Center"; fly there at a fixed
+	// neighborhood zoom. Deferred so it never fights the initial camera, which
+	// already reads `props.center` at setup. Centering is an explicit action, so
+	// the resulting zoom change re-framing the map (which the `zoomend` handler
+	// treats as a reset, clearing any `?area` selection) is acceptable.
+	createEffect(
+		on(
+			() => props.center,
+			(center) => {
+				if (!center || !map) return
+				map.flyTo({ center: [center.lng, center.lat], zoom: DEFAULT_MAP_ZOOM })
+			},
+			{ defer: true }
 		)
 	)
 

--- a/apps/www/src/lib/listings-map-camera.ts
+++ b/apps/www/src/lib/listings-map-camera.ts
@@ -1,0 +1,41 @@
+import { NAPA_CITY_HALL, type LocationBias } from '@/lib/geolocation'
+
+/** Zoom used when the map centers on a single point rather than fitting listings. */
+export const DEFAULT_MAP_ZOOM = 13
+
+/** Napa City Hall in MapLibre `[lng, lat]` order — the center fallback. */
+export const NAPA_CITY_HALL_LNGLAT: [lng: number, lat: number] = [
+	NAPA_CITY_HALL.lng,
+	NAPA_CITY_HALL.lat,
+]
+
+/** How the home map should frame itself on load. */
+export type ListingsMapCamera =
+	| { kind: 'center'; center: [lng: number, lat: number]; zoom: number }
+	| { kind: 'fit-groups' }
+
+/**
+ * Decides how the home map frames itself: centered on the user when their
+ * position is known, otherwise the existing behavior — fit the listing groups,
+ * or fall back to Napa City Hall when there are none.
+ */
+export function planListingsMapCamera(
+	hasGroups: boolean,
+	userCenter: LocationBias | null | undefined
+): ListingsMapCamera {
+	if (userCenter) {
+		return {
+			kind: 'center',
+			center: [userCenter.lng, userCenter.lat],
+			zoom: DEFAULT_MAP_ZOOM,
+		}
+	}
+	if (hasGroups) {
+		return { kind: 'fit-groups' }
+	}
+	return {
+		kind: 'center',
+		center: NAPA_CITY_HALL_LNGLAT,
+		zoom: DEFAULT_MAP_ZOOM,
+	}
+}

--- a/apps/www/src/routes/index.css
+++ b/apps/www/src/routes/index.css
@@ -110,6 +110,47 @@
 			text-align: center;
 		}
 
+		/* Title stays centered in the container; the Center button is pinned to
+		   the right edge without shifting it (absolute, out of flow). */
+		& .available-listings__header {
+			position: relative;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			margin-bottom: 40px;
+		}
+
+		& .available-listings__header h2 {
+			margin: 0;
+		}
+
+		& .available-listings__center {
+			position: absolute;
+			right: 0;
+			top: 50%;
+			transform: translateY(-50%);
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			width: 44px;
+			height: 44px;
+			color: var(--color-accent);
+			background: none;
+			border: 1px solid var(--color-accent);
+			border-radius: 8px;
+			cursor: pointer;
+			transition: background-color 0.15s;
+		}
+
+		& .available-listings__center:hover {
+			background: oklch(from var(--color-accent) l c h / 0.08);
+		}
+
+		& .available-listings__center:disabled {
+			opacity: 0.6;
+			cursor: default;
+		}
+
 		& .clear-filter {
 			display: block;
 			margin: 16px auto 0;

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -1,16 +1,19 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/solid-router'
-import { For, Show } from 'solid-js'
+import { createSignal, For, Show } from 'solid-js'
 import { z } from 'zod'
 import Layout from '@/components/Layout'
 import PageHeader from '@/components/PageHeader'
 import ListingsMap from '@/components/ListingsMap'
 import ListingCard from '@/components/ListingCard'
+import Locate from 'lucide-solid/icons/locate'
 import { getNearbyListings } from '@/api/listings'
 import { normalizeArea, listingMatchesArea } from '@/lib/h3-area'
+import {
+	NAPA_CITY_HALL,
+	requestCurrentLocation,
+	type LocationBias,
+} from '@/lib/geolocation'
 import '@/routes/index.css'
-
-// Napa City Hall — will be replaced with geolocation later
-const DEFAULT_CENTER = { lat: 38.2966234, lng: -122.2893688 }
 
 const homeSearchSchema = z.object({
 	area: z.string().optional(),
@@ -18,9 +21,12 @@ const homeSearchSchema = z.object({
 
 export const Route = createFileRoute('/')({
 	validateSearch: homeSearchSchema,
+	// The loader runs on the server and queries by the launch-city anchor; the
+	// map defaults to that framing and recenters only when the user clicks
+	// "Center" (below).
 	loader: () =>
 		getNearbyListings({
-			data: { lat: DEFAULT_CENTER.lat, lng: DEFAULT_CENTER.lng },
+			data: { lat: NAPA_CITY_HALL.lat, lng: NAPA_CITY_HALL.lng },
 		}),
 	component: HomePage,
 })
@@ -29,6 +35,25 @@ function HomePage() {
 	const listings = Route.useLoaderData()
 	const navigate = useNavigate()
 	const search = Route.useSearch()
+
+	// The map defaults to Napa. Centering on the user is opt-in via the "Center"
+	// button, which asks for their position on click; the map then pans there,
+	// keeping its zoom. Denial is silent (see requestCurrentLocation).
+	const [userLocation, setUserLocation] = createSignal<LocationBias | null>(null)
+	const [locating, setLocating] = createSignal(false)
+
+	async function centerOnMyLocation() {
+		if (locating()) return
+		setLocating(true)
+		try {
+			const position = await requestCurrentLocation()
+			// A fresh object each click re-triggers the map's recenter effect even
+			// when the coordinates are unchanged.
+			if (position) setUserLocation({ ...position })
+		} finally {
+			setLocating(false)
+		}
+	}
 
 	const selectedH3 = () => normalizeArea(search().area ?? null)
 
@@ -99,13 +124,28 @@ function HomePage() {
 
 					<section class="available-listings">
 						<div class="container">
-							<h2>Available Now</h2>
+							<div class="available-listings__header">
+								<h2>Available Now</h2>
+								<Show when={listings().length > 0}>
+									<button
+										type="button"
+										class="available-listings__center"
+										onClick={centerOnMyLocation}
+										disabled={locating()}
+										title="Center map on my location"
+										aria-label="Center map on my location"
+									>
+										<Locate aria-hidden="true" />
+									</button>
+								</Show>
+							</div>
 							<Show
 								when={listings().length > 0}
 								fallback={<p>No listings available right now.</p>}
 							>
 								<ListingsMap
 									listings={listings()}
+									center={userLocation()}
 									onGroupSelect={setSelectedH3}
 									selectedH3={selectedH3()}
 								/>

--- a/apps/www/tests/e2e/home-map-geolocation.test.ts
+++ b/apps/www/tests/e2e/home-map-geolocation.test.ts
@@ -1,0 +1,156 @@
+import { test, expect } from './helpers/fixtures'
+import type { Page } from '@playwright/test'
+import {
+	createTestListing,
+	createTestUser,
+	cleanupTestUser,
+} from './helpers/test-db'
+
+/** Sonoma Plaza — a granted position clearly west of the Napa fallback. */
+const SONOMA_PLAZA = { latitude: 38.291859, longitude: -122.458036 }
+
+/**
+ * Reads the live map center the component mirrors onto `data-map-center`.
+ * Returns null until the map has reported its center at least once.
+ */
+async function readMapCenter(
+	page: Page
+): Promise<{ lng: number; lat: number } | null> {
+	const value = await page
+		.locator('.listings-map')
+		.getAttribute('data-map-center')
+	if (!value) return null
+	const [lng, lat] = value.split(',').map(Number)
+	return { lng, lat }
+}
+
+function centerButton(page: Page) {
+	return page.getByRole('button', { name: 'Center map on my location' })
+}
+
+test.describe('Home map — defaults to Napa, centering is opt-in', () => {
+	test.use({ geolocation: SONOMA_PLAZA, permissions: ['geolocation'] })
+
+	test('does not ask for or use the position on load', async ({ page }) => {
+		test.slow()
+		const owner = await createTestUser()
+		// Default test listing sits in central Napa (38.3, -122.3).
+		await createTestListing(owner.id, { name: 'Napa lemons' })
+
+		try {
+			await page.goto('/')
+			await expect(page.locator('.listings-map')).toBeVisible({ timeout: 15_000 })
+
+			// Even with permission granted, the map frames the Napa listing — the
+			// page never requested the position, so it cannot have centered on it.
+			await expect
+				.poll(
+					async () => {
+						const center = await readMapCenter(page)
+						return center !== null && center.lng > -122.35
+					},
+					{ timeout: 15_000 }
+				)
+				.toBe(true)
+
+			// Give any stray async work a beat, then confirm it is still on Napa.
+			await page.waitForTimeout(1_000)
+			const center = await readMapCenter(page)
+			expect(Math.abs(center!.lng - SONOMA_PLAZA.longitude)).toBeGreaterThan(0.1)
+		} finally {
+			await cleanupTestUser(owner)
+		}
+	})
+
+	test('the Center button pans to the user’s position and zooms to 13', async ({
+		page,
+	}) => {
+		test.slow()
+		const owner = await createTestUser()
+		await createTestListing(owner.id, { name: 'Napa lemons' })
+
+		try {
+			await page.goto('/')
+			await expect(page.locator('.listings-map')).toBeVisible({ timeout: 15_000 })
+
+			// Wait for the default Napa framing and capture its fit-to-bounds zoom.
+			await expect
+				.poll(
+					async () => {
+						const center = await readMapCenter(page)
+						return center !== null && center.lng > -122.35
+					},
+					{ timeout: 15_000 }
+				)
+				.toBe(true)
+			const napaZoom = Number(
+				await page.locator('.listings-map').getAttribute('data-map-zoom')
+			)
+			// The default fit-to-bounds zoom is tighter than 13, so centering is an
+			// observable zoom change.
+			expect(napaZoom).toBeGreaterThan(13)
+
+			await centerButton(page).click()
+
+			// The map pans onto the granted position…
+			await expect
+				.poll(
+					async () => {
+						const center = await readMapCenter(page)
+						return (
+							center !== null &&
+							Math.abs(center.lng - SONOMA_PLAZA.longitude) < 0.02 &&
+							Math.abs(center.lat - SONOMA_PLAZA.latitude) < 0.02
+						)
+					},
+					{ timeout: 15_000 }
+				)
+				.toBe(true)
+
+			// …and zooms to 13.
+			const afterZoom = Number(
+				await page.locator('.listings-map').getAttribute('data-map-zoom')
+			)
+			expect(afterZoom).toBeCloseTo(13, 1)
+		} finally {
+			await cleanupTestUser(owner)
+		}
+	})
+})
+
+test.describe('Home map — Center button when geolocation is denied', () => {
+	test.use({ permissions: [] })
+
+	test('leaves the map on Napa when the position is denied', async ({
+		page,
+	}) => {
+		test.slow()
+		const owner = await createTestUser()
+		await createTestListing(owner.id, { name: 'Napa lemons' })
+
+		try {
+			await page.goto('/')
+			await expect(page.locator('.listings-map')).toBeVisible({ timeout: 15_000 })
+
+			await expect
+				.poll(
+					async () => {
+						const center = await readMapCenter(page)
+						return center !== null && center.lng > -122.35
+					},
+					{ timeout: 15_000 }
+				)
+				.toBe(true)
+
+			await centerButton(page).click()
+
+			// Denial is silent and leaves the map where it was — never near Sonoma.
+			await page.waitForTimeout(1_000)
+			const center = await readMapCenter(page)
+			expect(center!.lng).toBeGreaterThan(-122.35)
+			expect(Math.abs(center!.lng - SONOMA_PLAZA.longitude)).toBeGreaterThan(0.1)
+		} finally {
+			await cleanupTestUser(owner)
+		}
+	})
+})

--- a/apps/www/tests/listings-map-camera.test.ts
+++ b/apps/www/tests/listings-map-camera.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+	DEFAULT_MAP_ZOOM,
+	NAPA_CITY_HALL_LNGLAT,
+	planListingsMapCamera,
+} from '../src/lib/listings-map-camera'
+import { NAPA_CITY_HALL } from '../src/lib/geolocation'
+
+describe('planListingsMapCamera', () => {
+	it('centers on the user position when known, overriding listing groups', () => {
+		expect(
+			planListingsMapCamera(true, { lat: 38.291859, lng: -122.458036 })
+		).toEqual({
+			kind: 'center',
+			center: [-122.458036, 38.291859],
+			zoom: DEFAULT_MAP_ZOOM,
+		})
+	})
+
+	it('centers on the user position even when there are no groups', () => {
+		expect(planListingsMapCamera(false, { lat: 1, lng: 2 })).toEqual({
+			kind: 'center',
+			center: [2, 1],
+			zoom: DEFAULT_MAP_ZOOM,
+		})
+	})
+
+	it.each([null, undefined])(
+		'fits the listing groups when the position is %s',
+		(userCenter) => {
+			expect(planListingsMapCamera(true, userCenter)).toEqual({
+				kind: 'fit-groups',
+			})
+		}
+	)
+
+	it('falls back to Napa City Hall when the position is unknown and there are no groups', () => {
+		expect(planListingsMapCamera(false, null)).toEqual({
+			kind: 'center',
+			center: NAPA_CITY_HALL_LNGLAT,
+			zoom: DEFAULT_MAP_ZOOM,
+		})
+	})
+
+	it('derives the Napa fallback from the shared geolocation constant', () => {
+		expect(NAPA_CITY_HALL_LNGLAT).toEqual([
+			NAPA_CITY_HALL.lng,
+			NAPA_CITY_HALL.lat,
+		])
+	})
+})

--- a/docs/0012-geolocation-location-bias.md
+++ b/docs/0012-geolocation-location-bias.md
@@ -132,6 +132,6 @@ Double-loop TDD:
   fix up to five minutes old is accepted — city-scale bias does not need GPS
   precision, and a coarse cached answer is faster and cheaper on battery.
 - The home-page map keeps its own hard-coded Napa center; migrating it to
-  geolocation is out of scope here.
+  geolocation is out of scope here. (Done in doc 0013.)
 - If the user grants the permission but later moves, the bias is whatever
   was measured at mount. Fine for a form that lives for one listing.

--- a/docs/0013-home-map-geolocation.md
+++ b/docs/0013-home-map-geolocation.md
@@ -1,0 +1,100 @@
+# 0013 — Geolocation-centered home map
+
+## Problem
+
+The home page (`/`) shows an "Available Now" map of nearby listings. Its
+camera is fixed to Napa, the launch city: when listings exist it fits their
+bounds, and when there are none it centers on a hard-coded Napa City Hall
+point. A visitor browsing from another part of the Bay Area has no way to see
+"what's near me" — the map always frames Napa.
+
+Doc 0012 added geolocation to the New Listing form's address autosuggest but
+deliberately left the home map out of scope. This doc closes that gap.
+
+## Approach
+
+The map keeps its existing default framing: fit the bounds of the returned
+listing groups (the launch city, Napa), or fall back to a hard-coded Napa
+City Hall point when there are none. Nothing changes on load, and the page
+does **not** ask for the user's position on mount.
+
+Centering on the user is **opt-in**. An accent-colored "Center" button
+(Lucide `locate` icon) sits at the right edge of the "Available Now" header.
+Clicking it asks the browser for the user's position via the
+`requestCurrentLocation()` wrapper from 0012 (the browser shows its
+permission prompt only then):
+
+- **Granted** → the map flies to the user's coordinates and zooms to a fixed
+  neighborhood level (13).
+- **Denied / unavailable / timed out / unsupported** → nothing happens; the
+  map stays where it is. Denial is silent.
+
+The position flows to the map through the same `center` prop the initial
+camera reads; because the click happens after load, a deferred reactive
+effect (`flyTo`) performs the move. Because centering is an explicit action,
+the resulting zoom change re-frames the map — which the `zoomend` handler
+treats as a reset, clearing any `?area` selection. That is an accepted
+consequence of the user asking to recenter, not a background event.
+
+### Why prompting on click, not on mount
+
+An earlier iteration prompted on mount. That hit the most-trafficked, often-
+anonymous page with a permission dialog before any interaction, and a "Block"
+choice is sticky per-origin — it would also deny the New Listing form's
+later, more clearly-motivated request. Gating behind an explicit "Center"
+click keeps the prompt intentful, matching the posture doc 0012 took for the
+New Listing form.
+
+### Why centering, not re-querying
+
+The loader runs on the server and cannot know the client's position, so it
+continues to fetch the listings nearest Napa City Hall (the launch anchor).
+Centering is a presentation change — _where the map looks_ — not a change to
+_which listings are fetched_. A user far from Napa who clicks "Center" pans
+to their own neighborhood with the Napa markers off-screen; the listings grid
+below the map still shows the full set. That is the literal intent of the
+button, and it only happens on an explicit click. Re-querying by the client's
+position is a possible later step but is out of scope here.
+
+### Where the logic lives
+
+- `src/lib/listings-map-camera.ts` — a pure `planListingsMapCamera(hasGroups,
+userCenter)` that returns either a `center`/`zoom` camera or a
+  `fit-groups` instruction. This isolates the decision from MapLibre so it is
+  unit-testable without a map. It also exports `NAPA_CITY_HALL_LNGLAT`,
+  derived from the shared `NAPA_CITY_HALL` constant in `src/lib/geolocation.ts`
+  so the map and the autosuggest agree on one Napa anchor (the map previously
+  carried its own slightly different copy). The home map only ever supplies
+  `userCenter` after a click (via the deferred pan), so on load it always
+  takes the `fit-groups` / Napa-fallback path; the `center` branch keeps the
+  decision total and reusable.
+- `src/components/ListingsMap.tsx` — consumes the plan for the initial camera,
+  pans via a deferred effect when a `center` arrives after setup, and reflects
+  the live camera in `data-map-center` / `data-map-zoom` attributes so
+  end-to-end tests can assert it.
+- `src/routes/index.tsx` — renders the "Center" button, asks for the position
+  on click, and passes it to `ListingsMap` as `center`; the loader's Napa
+  query point uses the shared `NAPA_CITY_HALL` constant.
+
+## Testing
+
+Double-loop TDD:
+
+- **Outer loop** (`tests/e2e/home-map-geolocation.test.ts`): Playwright's
+  `geolocation`/`permissions` context options simulate grant and denial.
+  - granted, no click → the map stays on Napa (proves it never asked on load).
+  - granted, click "Center" → `data-map-center` settles on the granted
+    coordinates and `data-map-zoom` becomes 13.
+  - denied, click "Center" → the map stays on Napa, never near the granted
+    Sonoma point.
+- **Inner loop** (`tests/listings-map-camera.test.ts`): unit tests for
+  `planListingsMapCamera` — user position wins over groups, falls back to
+  fitting groups, then to Napa City Hall, and the fallback uses the shared
+  constant.
+
+## Known simplifications
+
+- The loader still queries by Napa City Hall; only the map's framing follows
+  the user. Client-side re-query by position is future work.
+- A clicked position is whatever was measured at click time; the map does not
+  follow the user if they move.


### PR DESCRIPTION
The home page "Available Now" map keeps its default Napa fit-to-bounds framing and no longer asks for the user's position on load. An accent-colored "Center" button (Lucide `locate` icon) in the section header requests the browser geolocation on click and flies the map to the user's position, zooming to 13. Denial is silent — the map stays put.

- `planListingsMapCamera` (pure, unit-tested without MapLibre) decides the initial camera: fit the listing groups, or fall back to Napa City Hall.
- The map, the loader's query point, and the address autosuggest now share one `NAPA_CITY_HALL` anchor (`NAPA_CITY_HALL_LNGLAT`) — the map previously carried its own ~250m-off copy.
- The live camera is mirrored onto `data-map-center` / `data-map-zoom` for end-to-end assertions.

The "Available Now" heading stays centered in the container; the button is pinned to the right edge out of flow (absolute), so it doesn't shift the title.

### Decisions & trade-offs (documented in `docs/0013-home-map-geolocation.md`)

- **Opt-in, not on mount.** Gating geolocation behind an explicit click avoids firing a permission dialog on the most-trafficked, often-anonymous page (a sticky per-origin "Block" would also deny the New Listing form's later request). Matches doc 0012's intentful-prompt posture.
- **Zoom to 13 on click.** Since centering is an explicit action, the resulting zoom change re-frames the map (which `zoomend` treats as a reset, clearing any `?area` selection) — an accepted, user-initiated consequence.
- **Presentation only, not re-query.** The loader still fetches the listings nearest Napa City Hall; clicking "Center" moves where the map looks, not which listings are fetched. Re-querying by client position is future work.

### Testing — double-loop TDD

- **Inner loop** (`tests/listings-map-camera.test.ts`): `planListingsMapCamera` — user position wins over groups, falls back to fit-groups, then Napa City Hall; fallback derives from the shared constant.
- **Outer loop** (`tests/e2e/home-map-geolocation.test.ts`): default framing stays on Napa (proves it never asks on load); clicking "Center" centers on the granted point and zooms to 13; denied click stays on Napa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvNv6qq66rzdBYrQmk1sg4