### PR TITLE
feat(kokoto): add manual dispatch mode to end E2E SQLite lock contention

### DIFF
--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -44,6 +44,10 @@ export default defineConfig({
 			EMAIL_FROM: 'Test <test@example.com>',
 			EMAIL_PROVIDER: 'silent',
 			HMAC_SECRET: 'test-secret-for-e2e-minimum-32-characters',
+			// Drive kokoto on demand instead of via a 1s background poll so its
+			// writes do not contend with the test fixture's connection for the
+			// shared SQLite write lock. See tests/e2e/helpers/test-db.ts.
+			KOKOTO_DISPATCH: 'manual',
 			NODE_ENV: 'test',
 			PORT: '5174',
 			STORAGE_PROVIDER: 'local',

--- a/apps/www/src/lib/env.server.ts
+++ b/apps/www/src/lib/env.server.ts
@@ -83,6 +83,13 @@ const outputSchema = z
 			.string()
 			.regex(/^.+\s<[^@]+@[^>]+>$/, 'Must be in "Display Name <email>" format'),
 		HMAC_SECRET: z.string().min(32),
+		/**
+		 * Kokoto dispatch strategy. `'auto'` (default) runs the background poll
+		 * loop; `'manual'` performs no writes while idle and drives work on
+		 * demand — set in E2E so the dispatcher does not contend with the test
+		 * fixture's connection for the shared SQLite write lock.
+		 */
+		KOKOTO_DISPATCH: z.enum(['auto', 'manual']).prefault('auto'),
 		/** When true, apply journal migrations once when the server process starts. */
 		RUN_MIGRATIONS_ON_BOOT: z.stringbool().prefault('false'),
 		NODE_ENV: z.string().prefault('development'),

--- a/apps/www/src/lib/kokoto.server.ts
+++ b/apps/www/src/lib/kokoto.server.ts
@@ -5,6 +5,7 @@ import {
 	type DurableRuntime,
 } from '@pickmyfruit/kokoto/runtime.server'
 import { libsqlClient } from '@/data/db.server'
+import { serverEnv } from '@/lib/env.server'
 import { logger } from '@/lib/logger.server'
 import { Sentry } from '@/lib/sentry'
 import { submitInquiryWorkflow } from '@/workflows/submit-inquiry.workflow.server'
@@ -65,6 +66,7 @@ export function getRuntime(): DurableRuntime {
 			telemetry: buildTelemetry(),
 			pollMs: 1000,
 			globalConcurrency: 16,
+			dispatch: serverEnv.KOKOTO_DISPATCH,
 		})
 	}
 	return runtimeInstance

--- a/apps/www/tests/e2e/global-setup.ts
+++ b/apps/www/tests/e2e/global-setup.ts
@@ -1,7 +1,76 @@
 import { chromium, type FullConfig } from '@playwright/test'
+import { createClient } from '@libsql/client'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const TEST_DB_PATH = resolve(__dirname, '../../data/test.db')
 
 /**
- * Runs after the webServer starts but before any test. Warms up three things:
+ * Fail loudly if the E2E server is NOT running kokoto in manual dispatch mode.
+ * The inquiry flow passes regardless of dispatch mode (handle.result() polls the
+ * DB either way), so without this guard the suite would stay green under the
+ * auto-mode 1s poll — silently reintroducing the SQLite write-lock contention
+ * this setup exists to avoid, now against a reduced 5s busy_timeout. We detect
+ * the mode by the executor heartbeat: auto mode advances it every poll; manual
+ * mode leaves it frozen while idle. Runs before the warmup enqueues any work.
+ */
+async function assertManualDispatch(): Promise<void> {
+	const client = createClient({ url: `file:${TEST_DB_PATH}` })
+	const sleep = (ms: number): Promise<void> =>
+		new Promise((resolve) => setTimeout(resolve, ms))
+	try {
+		const readHeartbeat = async (): Promise<number | null> => {
+			const res = await client.execute(
+				'SELECT MAX(heartbeat_at) AS hb FROM _dc_executor'
+			)
+			const hb = res.rows[0]?.hb
+			return hb == null ? null : Number(hb)
+		}
+
+		// kokoto records its executor row on the first SSR load; the webServer
+		// readiness probe already hit /login, so it should exist — retry briefly
+		// in case boot is still settling. Recursion (not a loop) keeps the
+		// sequential retries clear of the no-await-in-loop rule.
+		const waitForHeartbeat = async (attempts: number): Promise<number> => {
+			const hb = await readHeartbeat()
+			if (hb != null) {
+				return hb
+			}
+			if (attempts <= 0) {
+				throw new Error(
+					'[global-setup] kokoto recorded no executor row — the runtime did not boot'
+				)
+			}
+			await sleep(200)
+			return waitForHeartbeat(attempts - 1)
+		}
+
+		const before = await waitForHeartbeat(50)
+
+		// The app polls every 1s in auto mode, so 2s guarantees a tick would land
+		// and advance the heartbeat. Nothing is enqueued yet, so manual mode must
+		// leave it untouched.
+		await sleep(2000)
+		const after = await readHeartbeat()
+		if (after != null && after !== before) {
+			throw new Error(
+				`[global-setup] kokoto heartbeat advanced while idle (${before} → ${after}) — ` +
+					'the server is in AUTO dispatch mode. E2E requires KOKOTO_DISPATCH=manual ' +
+					'(set in playwright.config.ts) to avoid SQLite write-lock contention.'
+			)
+		}
+		console.log(
+			'[global-setup] confirmed kokoto manual dispatch (heartbeat idle)'
+		)
+	} finally {
+		client.close()
+	}
+}
+
+/**
+ * Runs after the webServer starts but before any test. First asserts the server
+ * is in manual kokoto dispatch (see {@link assertManualDispatch}), then warms up:
  * 1. Client bundles — browser visit to /login and /listings/new triggers Vite
  *    lazy compilation so the first real test doesn't exhaust its timeout.
  * 2. Auth SSR handler — clicking "Send sign-in link" in the browser exercises
@@ -11,6 +80,8 @@ import { chromium, type FullConfig } from '@playwright/test'
  */
 export default async function globalSetup(config: FullConfig) {
 	const baseURL = config.projects[0]?.use?.baseURL ?? 'http://localhost:5174'
+
+	await assertManualDispatch()
 
 	const browser = await chromium.launch()
 	try {

--- a/apps/www/tests/e2e/helpers/test-db.ts
+++ b/apps/www/tests/e2e/helpers/test-db.ts
@@ -37,11 +37,13 @@ const client = createClient({ url: TEST_DB_URL })
 // requires an exclusive lock, and without busy_timeout the PRAGMA fails
 // immediately with SQLITE_BUSY when the dev server is mid-write.
 //
-// 30s (vs. the 5s app default) gives the test fixture plenty of headroom
-// to outwait kokoto's dispatcher poll: every poll briefly acquires a write
-// lock via `BEGIN IMMEDIATE`, and on slow CI hardware those polls can
-// overlap with fixture writes often enough to exhaust a 5s budget.
-await client.execute('PRAGMA busy_timeout = 30000')
+// The E2E server runs kokoto in manual dispatch mode (KOKOTO_DISPATCH=manual
+// in playwright.config.ts), so the runtime performs no background writes while
+// idle — it only writes briefly while actually processing a workflow (e.g. an
+// inquiry submission). The 5s app-default budget is therefore ample for the
+// rare overlap; we no longer need the old 30s headroom that outwaited the 1s
+// dispatcher poll.
+await client.execute('PRAGMA busy_timeout = 5000')
 await client.execute('PRAGMA foreign_keys = ON')
 await client.execute('PRAGMA journal_mode = WAL')
 const db = drizzle(client)

--- a/packages/kokoto/src/runtime.server.ts
+++ b/packages/kokoto/src/runtime.server.ts
@@ -105,16 +105,21 @@ export class DurableRuntime {
 	private readonly globalConcurrency: number
 	private readonly executorId: string
 	private readonly inFlight = new Set<string>()
+	private readonly inFlightWorkers = new Set<Promise<void>>()
 	private readonly perQueueInFlight = new Map<string, number>()
 	private readonly wake = new EventEmitter()
+	private readonly autoDispatch: boolean
 	private dispatcherActive = false
 	private stopping = false
 	private startedAt: number | null = null
 	private currentDispatch: Promise<void> = Promise.resolve()
+	private draining: Promise<void> | undefined
+	private drainRequested = false
 
 	constructor(config: RuntimeConfig) {
 		this.client = config.client
 		this.telemetry = new Telemetry(config.telemetry)
+		this.autoDispatch = (config.dispatch ?? 'auto') === 'auto'
 		this.pollMs = Math.max(10, config.pollMs ?? DEFAULT_POLL_MS)
 		// leaseMs of 0 is legal (and used by the lease-expiry test): the row's
 		// expiry is set to `now`, which is already in the past by the time
@@ -125,6 +130,11 @@ export class DurableRuntime {
 			config.globalConcurrency ?? DEFAULT_GLOBAL_CONCURRENCY
 		)
 		this.executorId = config.executorId ?? uuidv7()
+		// `wake` listeners scale with concurrency: one per in-flight
+		// `handle.result()` waiter plus the dispatch loop. That legitimately
+		// exceeds Node's default cap of 10 under load, so disable the
+		// leak-detection warning rather than emit noise to stderr.
+		this.wake.setMaxListeners(0)
 	}
 
 	/** Unique id for this boot — recorded on every claimed row's `executor_id`. */
@@ -180,9 +190,16 @@ export class DurableRuntime {
 
 		this.startedAt = now
 		this.dispatcherActive = true
-		this.scheduleDispatchSoon()
+		// In manual mode the background timer never runs, so the runtime performs
+		// no writes while idle; work is driven on demand via drain() (which
+		// startWorkflow triggers automatically).
+		if (this.autoDispatch) this.scheduleDispatchSoon()
 		this.telemetry.info(
-			{ executorId: this.executorId, pollMs: this.pollMs },
+			{
+				executorId: this.executorId,
+				pollMs: this.pollMs,
+				dispatch: this.autoDispatch ? 'auto' : 'manual',
+			},
 			'kokoto.runtime.started'
 		)
 	}
@@ -197,7 +214,51 @@ export class DurableRuntime {
 		this.dispatcherActive = false
 		this.wake.emit('wake')
 		await this.currentDispatch
+		// A manual-mode drain may be mid-flight; let its in-flight workers settle.
+		if (this.draining) await this.draining.catch(() => {})
 		this.telemetry.info({ executorId: this.executorId }, 'kokoto.runtime.stopped')
+	}
+
+	/**
+	 * Run the dispatcher on demand until no ready work remains. This is the only
+	 * thing that advances workflows in `manual` dispatch mode; `startWorkflow`
+	 * calls it automatically, and tests can call it directly to await side
+	 * effects deterministically.
+	 *
+	 * Single-flight: concurrent callers share one in-progress drain, and a
+	 * workflow enqueued mid-drain is picked up before the drain resolves.
+	 * Resolves once a tick claims nothing and no worker is in flight; workflows
+	 * rescheduled for a future time (retry backoff) are not awaited — in manual
+	 * mode such a retry only fires when a later enqueue (or an explicit drain())
+	 * triggers another drain, so callers that need a backoff retry to run must
+	 * drive it themselves.
+	 */
+	async drain(): Promise<void> {
+		this.drainRequested = true
+		this.draining ??= this.runDrain().finally(() => {
+			this.draining = undefined
+			// If a drain() landed in the microtask gap between runDrain reading
+			// drainRequested === false and this finally clearing `draining`, the
+			// request would otherwise be lost (a fresh drain was suppressed by the
+			// still-set `draining`). Restart so the late enqueue is not stranded.
+			if (this.drainRequested) {
+				void this.drain().catch((err) => this.telemetry.captureException(err))
+			}
+		})
+		return this.draining
+	}
+
+	private async runDrain(): Promise<void> {
+		while (this.drainRequested) {
+			this.drainRequested = false
+			for (;;) {
+				await this.dispatchTick()
+				if (this.inFlightWorkers.size === 0) break
+				// Workers may free queue capacity or enqueue follow-on work, so
+				// loop and re-dispatch once the current batch settles.
+				await Promise.allSettled([...this.inFlightWorkers])
+			}
+		}
 	}
 
 	/**
@@ -254,7 +315,15 @@ export class DurableRuntime {
 			queue: queue ?? 'none',
 		})
 
-		if (this.dispatcherActive) this.wake.emit('wake')
+		if (this.dispatcherActive) {
+			if (this.autoDispatch) {
+				this.wake.emit('wake')
+			} else {
+				// Manual mode has no background loop, so drive the dispatcher now.
+				// Awaited results resolve via the worker's `wake` emit on finish.
+				void this.drain().catch((err) => this.telemetry.captureException(err))
+			}
+		}
 
 		return this.createHandle<Output>(effectiveId, def.name)
 	}
@@ -477,7 +546,7 @@ export class DurableRuntime {
 			queue: queueName ?? 'none',
 		})
 
-		void (async () => {
+		const workerPromise = (async () => {
 			try {
 				await runWorkflow(this.client, this.registry, this.telemetry, row)
 			} catch (err) {
@@ -493,6 +562,12 @@ export class DurableRuntime {
 				this.wake.emit('wake')
 			}
 		})()
+		// Tracked so drain() can await the current batch settling. The IIFE
+		// swallows its own errors, so this promise always resolves.
+		this.inFlightWorkers.add(workerPromise)
+		void workerPromise.finally(() => {
+			this.inFlightWorkers.delete(workerPromise)
+		})
 	}
 }
 

--- a/packages/kokoto/src/types.ts
+++ b/packages/kokoto/src/types.ts
@@ -218,6 +218,18 @@ export interface RuntimeConfig {
 	globalConcurrency?: number
 	/** Identifier for the host process; defaults to a UUIDv7. */
 	executorId?: string
+	/**
+	 * Dispatch strategy. Default `'auto'`.
+	 *
+	 * - `'auto'`: a background timer polls for work every `pollMs`, the normal
+	 *   production behavior.
+	 * - `'manual'`: no background timer runs, so the runtime performs no writes
+	 *   while idle. Enqueuing a workflow (or calling {@link DurableRuntime.drain})
+	 *   drives work to quiescence on demand. Intended for tests that share the
+	 *   SQLite file with another connection and cannot tolerate a continuous
+	 *   background write loop.
+	 */
+	dispatch?: 'auto' | 'manual'
 }
 
 /** Configuration for {@link DurableRuntime.start}. */

--- a/packages/kokoto/test/helpers.ts
+++ b/packages/kokoto/test/helpers.ts
@@ -92,6 +92,7 @@ export async function newRuntime(opts: {
 	pollMs?: number
 	leaseMs?: number
 	globalConcurrency?: number
+	dispatch?: 'auto' | 'manual'
 }): Promise<DurableRuntime> {
 	const runtime = createRuntime({
 		client: opts.client as never,
@@ -99,6 +100,7 @@ export async function newRuntime(opts: {
 		pollMs: opts.pollMs ?? 25,
 		leaseMs: opts.leaseMs ?? 5_000,
 		globalConcurrency: opts.globalConcurrency,
+		dispatch: opts.dispatch,
 	})
 	await runtime.createSchema()
 	return runtime

--- a/packages/kokoto/test/runtime.test.ts
+++ b/packages/kokoto/test/runtime.test.ts
@@ -446,3 +446,147 @@ describe('DurableRuntime — ctx.txStep (same-DB atomicity)', () => {
 		expect(appRows.rows).toEqual([{ note: 'second-try' }])
 	})
 })
+
+describe('DurableRuntime — manual dispatch', () => {
+	it('runs an awaited workflow on demand with no background poll', async () => {
+		const client = await newClient()
+		// A huge pollMs proves the background timer is NOT what advances work:
+		// manual mode never starts the timer, so completion comes from the
+		// drain that startWorkflow triggers — mirroring the inquiry request that
+		// awaits handle.result().
+		const runtime = await newRuntime({
+			client,
+			dispatch: 'manual',
+			pollMs: 60_000,
+		})
+		const echo = defineWorkflow('echo', async (_ctx, input: string) =>
+			input.toUpperCase()
+		)
+		await runtime.start({ workflows: [echo] })
+
+		const handle = await runtime.startWorkflow(echo, 'hello')
+		const result = await handle.result({ timeoutMs: 5_000, pollMs: 25 })
+
+		expect(result).toBe('HELLO')
+		expect(await handle.status()).toBe('success')
+		await runtime.stop()
+		client.close()
+	})
+
+	it('drain() advances an enqueued workflow and its side effect to completion', async () => {
+		const client = await newClient()
+		const runtime = await newRuntime({
+			client,
+			dispatch: 'manual',
+			pollMs: 60_000,
+		})
+		await client.execute(
+			`CREATE TABLE app_writes (id INTEGER PRIMARY KEY AUTOINCREMENT, note TEXT NOT NULL)`
+		)
+		const writer = defineWorkflow('writer', async (ctx) => {
+			return ctx.txStep('append', async (tx) => {
+				await tx.execute({
+					sql: `INSERT INTO app_writes (note) VALUES (?)`,
+					args: ['x'],
+				})
+				return null
+			})
+		})
+		await runtime.start({ workflows: [writer] })
+
+		const handle = await runtime.startWorkflow(writer, undefined)
+		// Awaiting drain() deterministically waits for the side effect, even
+		// though we never called handle.result().
+		await runtime.drain()
+
+		expect(await handle.status()).toBe('success')
+		const rows = await client.execute('SELECT note FROM app_writes')
+		expect(rows.rows).toEqual([{ note: 'x' }])
+		await runtime.stop()
+		client.close()
+	})
+
+	it('performs no writes while idle', async () => {
+		const client = await newClient()
+		const runtime = await newRuntime({ client, dispatch: 'manual', pollMs: 25 })
+		const noop = defineWorkflow('noop', async () => undefined)
+		await runtime.start({ workflows: [noop] })
+
+		// The executor heartbeat only advances inside a dispatch tick. With no
+		// enqueue and no background loop, it must stay frozen across many
+		// would-be poll intervals — this is the property that removes the
+		// write-lock contention with the E2E fixture connection.
+		const before = await client.execute('SELECT heartbeat_at FROM _dc_executor')
+		await sleep(150)
+		const after = await client.execute('SELECT heartbeat_at FROM _dc_executor')
+
+		expect(after.rows[0]?.heartbeat_at).toBe(before.rows[0]?.heartbeat_at)
+		await runtime.stop()
+		client.close()
+	})
+
+	it('drain() resolves with no work and coalesces concurrent callers', async () => {
+		const client = await newClient()
+		const runtime = await newRuntime({
+			client,
+			dispatch: 'manual',
+			pollMs: 60_000,
+		})
+		const noop = defineWorkflow('noop', async () => 'done')
+		await runtime.start({ workflows: [noop] })
+
+		// Nothing enqueued: drain is a clean no-op even when called concurrently.
+		await Promise.all([runtime.drain(), runtime.drain()])
+
+		// Still fully functional afterward.
+		const handle = await runtime.startWorkflow(noop, undefined)
+		expect(await handle.result({ timeoutMs: 5_000, pollMs: 25 })).toBe('done')
+		await runtime.stop()
+		client.close()
+	})
+
+	it('dispatches every workflow when many are enqueued back-to-back', async () => {
+		const client = await newClient()
+		const runtime = await newRuntime({
+			client,
+			dispatch: 'manual',
+			pollMs: 60_000,
+		})
+		const noop = defineWorkflow('noop', async (_ctx, n: number) => n)
+		await runtime.start({ workflows: [noop] })
+
+		// Each enqueue fires its own coalesced drain; none may be stranded by the
+		// single-flight guard (regression for the drain() lost-wakeup window).
+		const handles = await Promise.all(
+			Array.from({ length: 25 }, (_, i) => runtime.startWorkflow(noop, i))
+		)
+		const results = await Promise.all(
+			handles.map((h) => h.result({ timeoutMs: 10_000, pollMs: 25 }))
+		)
+
+		expect(results.sort((a, b) => a - b)).toEqual(
+			Array.from({ length: 25 }, (_, i) => i)
+		)
+		await runtime.stop()
+		client.close()
+	})
+})
+
+describe('DurableRuntime — auto dispatch (contrast)', () => {
+	it('advances the heartbeat in the background without any enqueue', async () => {
+		const client = await newClient()
+		const runtime = await newRuntime({ client, dispatch: 'auto', pollMs: 25 })
+		const noop = defineWorkflow('noop', async () => undefined)
+		await runtime.start({ workflows: [noop] })
+
+		const before = await client.execute('SELECT heartbeat_at FROM _dc_executor')
+		await sleep(150)
+		const after = await client.execute('SELECT heartbeat_at FROM _dc_executor')
+
+		expect(Number(after.rows[0]?.heartbeat_at)).toBeGreaterThan(
+			Number(before.rows[0]?.heartbeat_at)
+		)
+		await runtime.stop()
+		client.close()
+	})
+})


### PR DESCRIPTION
## Problem

The CI E2E job failed intermittently with `SQLITE_BUSY: database is locked` ([run 27440424374](https://github.com/jamesarosen/PickMyFruit/actions/runs/27440424374)). Four tests failed inside fixture setup/teardown (`createTestUser`/`cleanupTestUser`), not in their assertions — and none of the four even exercises a workflow.

## Root cause

kokoto's dispatcher self-schedules a `dispatchTick()` every second for the entire ~10-minute E2E run. Every tick writes (`touchExecutorHeartbeat` + a `claimPending` `UPDATE…RETURNING` per queue), so the app connection grabs the SQLite write lock ~5×/sec **even when idle**. The E2E fixture's second connection collides with that poll; the 30s `busy_timeout` headroom was exhausted under CI load. The failing tests never touch a workflow — they lost a race purely against the idle poll.

## Approach

Add a `dispatch: 'auto' | 'manual'` mode to the runtime — the mainstream "manual mode + drain" pattern (Oban `:manual`, Sidekiq fake-mode-with-drain; mirrored by absurd's `WorkBatch()`/`RunWorker()` split). It runs the **real** workflow code (unlike stubbing) while removing the idle poll.

- **`auto`** (default): unchanged background poll; production unaffected.
- **`manual`**: no background timer → zero writes while idle. Enqueuing triggers a coalesced `drain()` that runs ready work to quiescence and stops; a public `drain()` is exposed for tests.

**Why drain-on-enqueue rather than pause-then-drain:** the inquiry handler `await`s `handle.result()` and the row is written inside the workflow's txStep — a paused dispatcher would deadlock that request. Driving the drain from `startWorkflow` keeps awaited request-workflows resolving via the existing `wake` mechanism, with no app request-code change and no test-only endpoint.

## Changes

- **kokoto**: `RuntimeConfig.dispatch`; manual mode skips the poll loop, tracks in-flight worker promises, single-flight `drain()`; `startWorkflow` triggers a coalesced drain; `stop()` awaits any in-flight drain.
- **app**: `KOKOTO_DISPATCH` env (`auto` default) in `env.server.ts` → `createRuntime`; `playwright.config.ts` sets `manual`.
- **tests**: fixture `busy_timeout` 30s→5s (headroom no longer load-bearing); `global-setup` guard that fails the run if the server isn't in manual mode; kokoto unit tests for the manual path.

## Review

Three rounds of adversarial review, all addressed:

- **Round 1** — Fixed a lost-wakeup in the `drain()` single-flight guard (microtask-gap could strand just-enqueued work); fixed a `MaxListenersExceededWarning` on the `wake` emitter (latent in production too); documented the retry-backoff limitation.
- **Round 2** — The inquiry E2E passes regardless of dispatch mode, so the suite would have stayed green if `KOKOTO_DISPATCH=manual` silently stopped propagating. Added a `global-setup` guard that fails loudly in auto mode (detected via heartbeat-advancing-while-idle); **verified non-vacuous** by flipping the config to auto and confirming the run aborts.
- **Round 3** — GO, no issues; cleared the guard of false-positive flakiness and confirmed the `auto` production default is safe.
- **Deferred** (acceptable, manual mode is test-only): backoff retries and unawaited fire-and-forget workflows (e.g. resend-sync) are best-effort under manual dispatch — no E2E test asserts on them; production uses `auto`.

## Verification

kokoto unit suite green (53 tests); full E2E suite green across repeated runs with no `SQLITE_BUSY`, including the inquiry tests under the CSRF middleware now on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)