### PR TITLE
Recover from stale asset 404s after deploys by reloading once

### DIFF
--- a/apps/www/src/lib/stale-asset-recovery.ts
+++ b/apps/www/src/lib/stale-asset-recovery.ts
@@ -1,0 +1,68 @@
+import { Sentry } from '@/lib/sentry'
+
+/**
+ * Structural shape of Vite's `vite:preloadError` event, kept minimal so unit
+ * tests can fire plain objects instead of constructing real DOM events.
+ */
+export interface ChunkPreloadErrorEvent {
+	payload: Error
+	preventDefault(): void
+}
+
+/** Injectable dependencies for `createPreloadErrorHandler`. */
+export interface StaleAssetRecoveryDeps {
+	storage: Pick<Storage, 'getItem' | 'setItem'>
+	reload(): void
+	now(): number
+}
+
+/** sessionStorage key holding the timestamp of the last recovery reload. */
+export const RELOAD_MARKER_KEY = 'pmf:stale-asset-reload-at'
+
+/**
+ * Two chunk-load failures within this window mean the reload did not fix the
+ * problem — the 404 is not deploy staleness — so the second failure is allowed
+ * to propagate instead of reloading forever.
+ */
+export const RELOAD_LOOP_WINDOW_MS = 30_000
+
+/** Builds the `vite:preloadError` handler with injected dependencies. */
+export function createPreloadErrorHandler(deps: StaleAssetRecoveryDeps) {
+	return (event: ChunkPreloadErrorEvent): void => {
+		const lastReloadAt = Number(deps.storage.getItem(RELOAD_MARKER_KEY)) || 0
+		if (deps.now() - lastReloadAt < RELOAD_LOOP_WINDOW_MS) {
+			Sentry.captureException(event.payload, {
+				tags: { staleAssetRecovery: 'reload-loop' },
+			})
+			return
+		}
+		deps.storage.setItem(RELOAD_MARKER_KEY, String(deps.now()))
+		Sentry.captureMessage('Reloading after stale asset chunk load failure', {
+			level: 'warning',
+			tags: { staleAssetRecovery: 'reload' },
+		})
+		event.preventDefault()
+		deps.reload()
+	}
+}
+
+let installed = false
+
+/**
+ * Recovers from hashed asset chunks 404ing after a deploy by reloading the
+ * page, which completes the in-flight navigation on the new build. Reloads at
+ * most once per `RELOAD_LOOP_WINDOW_MS`; repeat failures propagate to the
+ * router error boundary. See docs/0014-stale-asset-recovery.md.
+ */
+export function installStaleAssetRecovery(): void {
+	if (installed) return
+	installed = true
+	window.addEventListener(
+		'vite:preloadError',
+		createPreloadErrorHandler({
+			storage: window.sessionStorage,
+			reload: () => window.location.reload(),
+			now: Date.now,
+		})
+	)
+}

--- a/apps/www/src/router.tsx
+++ b/apps/www/src/router.tsx
@@ -1,6 +1,7 @@
 import { createRouter } from '@tanstack/solid-router'
 import { tanstackRouterBrowserTracingIntegration } from '@sentry/solid/tanstackrouter'
 import { Sentry } from '@/lib/sentry'
+import { installStaleAssetRecovery } from '@/lib/stale-asset-recovery'
 import { routeTree } from './routeTree.gen'
 
 export function getRouter() {
@@ -13,6 +14,7 @@ export function getRouter() {
 	// TanStack Router-aware version so navigation spans use route patterns.
 	if (!import.meta.env.SSR) {
 		Sentry.addIntegration(tanstackRouterBrowserTracingIntegration(router))
+		installStaleAssetRecovery()
 	}
 
 	return router

--- a/apps/www/tests/stale-asset-recovery.test.ts
+++ b/apps/www/tests/stale-asset-recovery.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+	RELOAD_LOOP_WINDOW_MS,
+	RELOAD_MARKER_KEY,
+	createPreloadErrorHandler,
+	installStaleAssetRecovery,
+	type StaleAssetRecoveryDeps,
+} from '../src/lib/stale-asset-recovery'
+import { Sentry } from '../src/lib/sentry'
+
+vi.mock('../src/lib/sentry', () => ({
+	Sentry: {
+		captureException: vi.fn(),
+		captureMessage: vi.fn(),
+	},
+}))
+
+const NOW = 1_750_000_000_000
+
+function fakeStorage(initial: Record<string, string> = {}) {
+	const map = new Map(Object.entries(initial))
+	return {
+		getItem: (key: string) => map.get(key) ?? null,
+		setItem: (key: string, value: string) => void map.set(key, value),
+		map,
+	}
+}
+
+function fireChunkLoadError(deps: StaleAssetRecoveryDeps) {
+	const event = {
+		payload: new Error('Failed to fetch'),
+		preventDefault: vi.fn(),
+	}
+	createPreloadErrorHandler(deps)(event)
+	return event
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+describe('createPreloadErrorHandler', () => {
+	it('reloads the page and records the reload time on the first failure', () => {
+		const storage = fakeStorage()
+		const reload = vi.fn()
+
+		const event = fireChunkLoadError({ storage, reload, now: () => NOW })
+
+		expect(reload).toHaveBeenCalledOnce()
+		expect(event.preventDefault).toHaveBeenCalledOnce()
+		expect(storage.map.get(RELOAD_MARKER_KEY)).toBe(String(NOW))
+		expect(Sentry.captureMessage).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({ level: 'warning' })
+		)
+	})
+
+	it('lets the error propagate instead of reloading again within the loop window', () => {
+		const storage = fakeStorage({
+			[RELOAD_MARKER_KEY]: String(NOW - RELOAD_LOOP_WINDOW_MS + 1),
+		})
+		const reload = vi.fn()
+
+		const event = fireChunkLoadError({ storage, reload, now: () => NOW })
+
+		expect(reload).not.toHaveBeenCalled()
+		expect(event.preventDefault).not.toHaveBeenCalled()
+		expect(Sentry.captureException).toHaveBeenCalledWith(
+			event.payload,
+			expect.objectContaining({
+				tags: { staleAssetRecovery: 'reload-loop' },
+			})
+		)
+	})
+
+	it('reloads again once the loop window has passed', () => {
+		const storage = fakeStorage({
+			[RELOAD_MARKER_KEY]: String(NOW - RELOAD_LOOP_WINDOW_MS),
+		})
+		const reload = vi.fn()
+
+		fireChunkLoadError({ storage, reload, now: () => NOW })
+
+		expect(reload).toHaveBeenCalledOnce()
+	})
+
+	it.each(['', 'garbage', 'NaN'])(
+		'treats an unparseable reload marker (%j) as no previous reload',
+		(marker) => {
+			const storage = fakeStorage({ [RELOAD_MARKER_KEY]: marker })
+			const reload = vi.fn()
+
+			fireChunkLoadError({ storage, reload, now: () => NOW })
+
+			expect(reload).toHaveBeenCalledOnce()
+		}
+	)
+})
+
+describe('installStaleAssetRecovery', () => {
+	it('registers the vite:preloadError listener only once', () => {
+		const addEventListener = vi.spyOn(window, 'addEventListener')
+
+		installStaleAssetRecovery()
+		installStaleAssetRecovery()
+
+		const preloadErrorRegistrations = addEventListener.mock.calls.filter(
+			([type]) => type === 'vite:preloadError'
+		)
+		expect(preloadErrorRegistrations).toHaveLength(1)
+	})
+})

--- a/docs/0014-stale-asset-recovery.md
+++ b/docs/0014-stale-asset-recovery.md
@@ -1,0 +1,87 @@
+# 0014 — Stale-asset recovery after deploys
+
+## Problem
+
+Vite emits content-hashed client chunks into `.output/public/assets/`, and
+those files exist only inside the Docker image of the currently running Fly
+machine. Deploys use `strategy = 'immediate'`, so the moment a new release
+lands, every old hashed file is gone. A browser that loaded the previous
+release keeps navigating client-side; TanStack Router lazy-loads each
+destination route with a dynamic `import()` of a chunk whose hashed filename
+no longer exists. The fetch 404s, the import throws ("Failed to fetch
+dynamically imported module"), and the navigation breaks.
+
+Two properties of our setup shape the fix:
+
+- The router does not set `defaultPreload`, so chunks are fetched at
+  navigation time, not on hover. A chunk-load failure therefore almost always
+  happens when the user has already chosen to leave the current page, which
+  makes a full-page load an acceptable recovery: it costs no more state than
+  the navigation itself.
+- TanStack Router commits the new URL to history before it loads the
+  destination's chunk. Reloading after a failure therefore lands on the
+  _intended destination_, served by the new build — the user's navigation
+  completes instead of bouncing back.
+
+## Plan
+
+1. Add `src/lib/stale-asset-recovery.ts` exporting
+   `installStaleAssetRecovery()`. It listens for Vite's built-in
+   [`vite:preloadError`](https://vite.dev/guide/build#load-error-handling)
+   window event, which fires exactly when a Vite-emitted chunk (or one of its
+   CSS/JS dependencies) fails to load.
+2. On failure, record a reload marker (timestamp) in `sessionStorage`, call
+   `event.preventDefault()` so the underlying error is not rethrown, and
+   `window.location.reload()`.
+3. Loop guard: if another failure occurs within 30 seconds of the marker, do
+   **not** reload. Let the error propagate to the router's error boundary
+   (`RootError` in `__root.tsx`), which offers "Try again". One reload fixes
+   deploy staleness; a second immediate failure means the 404 has some other
+   cause and reloading would spin forever.
+4. Telemetry, so the deferred work below is a decision we make from numbers:
+   - `Sentry.captureMessage(…, { level: 'warning' })` with tag
+     `staleAssetRecovery: 'reload'` just before reloading. The SDK's fetch
+     transport uses `keepalive`, so the event usually survives the unload;
+     occasional loss is acceptable.
+   - `Sentry.captureException` with tag `staleAssetRecovery: 'reload-loop'`
+     when the loop guard trips.
+5. Install the listener from `getRouter()` in `src/router.tsx`, inside the
+   existing client-only (`!import.meta.env.SSR`) block.
+6. Testing: unit-test the handler with injected `storage`/`reload`/`now`
+   dependencies. An E2E test is impractical (it would require serving two
+   different builds mid-test); production telemetry from step 4 is the
+   real-world verification.
+
+## Future work
+
+### Version-skew detection once assets become durable
+
+We may later serve old hashed assets from a durable store (e.g. a Tigris
+fallback for `/assets/*` misses) so old clients stop hitting 404s at all. That
+change silently defeats this doc's mechanism: chunks always load, so
+`vite:preloadError` never fires, and old clients keep running old code
+indefinitely — worsening client↔server contract skew. Before or alongside a
+durable asset fallback, ship explicit version-skew detection:
+
+1. Every build already has a unique identifier: the git SHA baked in as
+   `SENTRY_RELEASE` / `VITE_SENTRY_RELEASE` (see `apps/www/Dockerfile`). Add a
+   Nitro middleware that sets an `X-PMF-Build: <sha>` header on document and
+   server-function responses.
+2. On the client, record the most recent server build id seen (server-function
+   client middleware or a fetch wrapper) and compare it to the client's own
+   baked-in `clientEnv.sentryRelease`.
+3. On mismatch, set a module-level `versionSkew` flag. Do not interrupt the
+   user — in-progress work (e.g. a half-filled listing form) is preserved.
+4. Watch for transition intent instead: in the root route's `beforeLoad`
+   (which runs on every client-side navigation before the destination chunk is
+   requested), when the flag is set and this is not the initial mount, call
+   `window.location.assign(location.href)` and return a never-resolving
+   promise. The user's next navigation becomes a full-page load onto the new
+   build, with zero extra disruption.
+5. Keep the `vite:preloadError` handler as a backstop. Skew detection no-ops
+   when either side lacks a build id (local dev without `SENTRY_RELEASE`).
+
+Signals it's time to pick this up: shipping the Tigris asset fallback;
+Sentry showing frequent `staleAssetRecovery` events per deploy; or shipping
+backwards-incompatible server-function changes often enough that we want old
+clients upgraded before they hit an error.


### PR DESCRIPTION
Hashed chunks exist only in the running machine's image, so a deploy
strands old clients: their next navigation dynamic-imports a chunk that
no longer exists and the navigation breaks. Listen for Vite's
vite:preloadError and reload the page — the router has already committed
the destination URL, so the reload completes the user's navigation on
the new build. A sessionStorage marker limits recovery to one reload per
30s window; repeat failures propagate to the router error boundary.
Sentry tags (staleAssetRecovery: reload | reload-loop) provide the
per-deploy signal for the deferred work in docs/0014.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HuaLUMaJUEhuXRf81QxRmE