### PR TITLE
Ignore Meta in-app browser WKWebView bridge errors in Sentry

### DIFF
--- a/apps/www/src/lib/sentry.ts
+++ b/apps/www/src/lib/sentry.ts
@@ -96,6 +96,16 @@ export function redactGeoSpan(span: SpanJSON): SpanJSON {
 	return span
 }
 
+// Meta's in-app browsers (Instagram, Facebook) inject their own instrumentation
+// script into every page loaded in their iOS WKWebView. That script talks to the
+// native app through `window.webkit.messageHandlers`, and it throws
+// `undefined is not an object (evaluating 'window.webkit.messageHandlers…')`
+// when the bridge isn't present. The error is caught by our global onerror
+// handler and attributed to the host document, but it is third-party code we
+// neither ship nor control (this app has no native WKWebView bridge), so it is
+// pure noise. See Sentry PICKMYFRUIT-23/24/25.
+export const IGNORED_ERROR_PATTERNS = [/window\.webkit\.messageHandlers/]
+
 const isServer = typeof window === 'undefined'
 const environment = isServer ? 'server' : 'client'
 
@@ -154,6 +164,7 @@ if (clientEnv.sentryDsn) {
 		release: clientEnv.sentryRelease,
 		sampleRate: clientEnv.sentrySampleRate,
 		tracesSampleRate: clientEnv.sentryTracesSampleRate,
+		ignoreErrors: IGNORED_ERROR_PATTERNS,
 		beforeBreadcrumb(breadcrumb) {
 			// Strip the internal shared secret from any breadcrumb that may have
 			// captured request headers (fetch, http, console). Defense-in-depth on

--- a/apps/www/tests/sentry-redaction.test.ts
+++ b/apps/www/tests/sentry-redaction.test.ts
@@ -12,8 +12,34 @@ vi.mock('../src/lib/env', () => ({
 	},
 }))
 
-const { redactGeoServiceUrl, redactGeoBreadcrumb, redactGeoSpan } =
-	await import('../src/lib/sentry')
+const {
+	redactGeoServiceUrl,
+	redactGeoBreadcrumb,
+	redactGeoSpan,
+	IGNORED_ERROR_PATTERNS,
+} = await import('../src/lib/sentry')
+
+/** Mirrors how Sentry's `ignoreErrors` matches an event: any pattern hits. */
+function isIgnored(message: string): boolean {
+	return IGNORED_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+describe('IGNORED_ERROR_PATTERNS', () => {
+	it.each([
+		"TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers')",
+		"TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers[e].postMessage')",
+	])('ignores Meta in-app browser bridge error: %s', (message) => {
+		expect(isIgnored(message)).toBe(true)
+	})
+
+	it.each([
+		'TypeError: Cannot read properties of undefined (reading id)',
+		"ReferenceError: Can't find variable: fetch",
+		'Error: Failed to load listing',
+	])('does not ignore genuine application error: %s', (message) => {
+		expect(isIgnored(message)).toBe(false)
+	})
+})
 
 describe('redactGeoServiceUrl', () => {
 	it.each([


### PR DESCRIPTION
## Summary

Sentry issues **PICKMYFRUIT-23**, **-24**, and **-25** are the same underlying problem, and it is **not a bug in our app** — it is noise from Meta's in-app browsers.

All three events share this signature:

- Error: `TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers…')`
- Browser: **Instagram** (in-app browser), every occurrence
- OS/device: iOS on iPhone
- Mechanism: `auto.browser.global_handlers.onerror` (unhandled), **0 users impacted**
- Stack functions: `sendDataToNative`, `sendPageHideMessage`

### Root cause

Instagram and Facebook inject their own instrumentation script into every page loaded in their iOS in-app browser (a `WKWebView`). That script talks to the native app via `window.webkit.messageHandlers` and throws when the native bridge isn't present. Our global `onerror` handler catches it, and because the injected script has no source URL the browser attributes it to the host document (`pickmyfruit.com/:1`), which is why the Sentry frames misleadingly show our server-rendered `<head>` HTML.

It is third-party code we neither ship nor control — this app has no native WKWebView bridge (a grep for `webkit`/`messageHandlers`/`sendDataToNative` finds only CSS vendor prefixes). So the events are pure noise.

## Changes

- **`apps/www/src/lib/sentry.ts`** — add an `ignoreErrors` pattern (`/window\.webkit\.messageHandlers/`) to the client `init()` so these are dropped at ingest, with a comment documenting the origin and referencing the Sentry issues.
- **`apps/www/tests/sentry-redaction.test.ts`** — unit tests confirming the pattern matches the known Instagram messages and, importantly, does **not** swallow genuine application errors.

## Testing

- `bash bin/after-turn.sh` (format, lint, typecheck, unit tests) — passes.
- E2E suite run via the pre-push hook — passes (one flaky inline-edit test failed once, then passed on isolated re-run; unrelated to this change).

Fixes PICKMYFRUIT-23
Fixes PICKMYFRUIT-24
Fixes PICKMYFRUIT-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBRp78WKZnufWgEwUBuPEF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBRp78WKZnufWgEwUBuPEF)_